### PR TITLE
fix(USA Kia): Refresh key for vehicles on expiry

### DIFF
--- a/hyundai_kia_connect_api/ApiImpl.py
+++ b/hyundai_kia_connect_api/ApiImpl.py
@@ -38,6 +38,10 @@ class ApiImpl:
         """Return all Vehicle instances for a given Token"""
         pass
 
+    def refresh_vehicles(self, token: Token, vehicles: list[Vehicle]) -> None:
+        """Refresh the vehicle data provided in get_vehicles. Required for Kia USA as key is session specific"""
+        pass
+
     def get_last_updated_at(self, value) -> dt.datetime:
         """Convert last updated value of vehicle into into datetime"""
         pass

--- a/hyundai_kia_connect_api/VehicleManager.py
+++ b/hyundai_kia_connect_api/VehicleManager.py
@@ -45,7 +45,9 @@ class VehicleManager:
     def initialize(self) -> None:
         self.token: Token = self.api.login(self.username, self.password)
         self.token.pin = self.pin
-        self.refresh_vehicles()
+        vehicles = self.api.get_vehicles(self.token)
+        for vehicle in vehicles:
+            self.vehicles[vehicle.id] = vehicle
         self.update_all_vehicles_with_cached_state()
         
     def get_vehicle(self, vehicle_id) -> Vehicle:
@@ -85,16 +87,9 @@ class VehicleManager:
         if self.token.valid_until <= dt.datetime.now(pytz.utc):
             _LOGGER.debug(f"{DOMAIN} - Refresh token expired")
             self.token = self.api.login(self.username, self.password)
-            self.refresh_vehicles()
+            self.api.refresh_vehicles(self.token, self.vehicles)
             return True
         return False
-
-    def refresh_vehicles(self) -> None:
-            vehicles = self.api.get_vehicles(self.token)
-            for vehicle in vehicles:
-                self.vehicles[vehicle.id] = vehicle
-
-
 
     def start_climate(self, vehicle_id: str, options: ClimateRequestOptions) -> str:
         return self.api.start_climate(self.token, self.get_vehicle(vehicle_id), options)


### PR DESCRIPTION
Kia USA has a vehicle specific one time use key.  This will update this in vehicle and also add new cars that may be found.  Other option may be make get_vehicles work this way, need to also add a delete.  Challenge with that is then get_vehicles will be called each token refresh including for APIs that don't need it. 