### PR TITLE
fix(US Kia): Correct temperature setting when starting climate

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoAPIUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoAPIUSA.py
@@ -493,6 +493,10 @@ class KiaUvoAPIUSA(ApiImpl):
         options: ClimateRequestOptions
     ) -> str:
         url = self.API_URL + "rems/start"
+        if set_temp < 62:
+            set_temp = "LOW"
+        elif set_temp > 82:
+            set_temp = "HIGH"
         body = {
             "remoteClimate": {
                 "airCtrl": options.climate,

--- a/hyundai_kia_connect_api/KiaUvoAPIUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoAPIUSA.py
@@ -493,10 +493,10 @@ class KiaUvoAPIUSA(ApiImpl):
         options: ClimateRequestOptions
     ) -> str:
         url = self.API_URL + "rems/start"
-        if set_temp < 62:
-            set_temp = "LOW"
-        elif set_temp > 82:
-            set_temp = "HIGH"
+        if options.set_temp < 62:
+            options.set_temp = "LOW"
+        elif options.set_temp > 82:
+            options.set_temp = "HIGH"
         body = {
             "remoteClimate": {
                 "airCtrl": options.climate,


### PR DESCRIPTION
In the US Kia vehicle and UVO app, the next step below 62 is "LOW" and the next step above 82 is "HIGH". So if you try to set the climate to an actual number lower than 62 or higher than 82, it causes an error that leads to the engine and the rear defroster coming on, but the AC does not. I don't know of an easy way to change the service call itself to accept numbers and also the words "LOW" and "HIGH", so adding the logic check to the API accounts for that and prevents the error.