### PR TITLE
Refactor Vehicle class

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
@@ -362,6 +362,7 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
                 VIN=entry["vin"],
                 model=entry["modelCode"],
                 registration_date=["enrollmentDate"],
+                api=self,
             )
             result.append(vehicle)
 

--- a/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
@@ -124,7 +124,7 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
         headers["accessToken"] = self.token.access_token
         headers["vin"] = vehicle.VIN
         headers["username"] = self.token.username
-        headers["blueLinkServicePin"] = token.pin
+        headers["blueLinkServicePin"] = self.token.pin
 
         _LOGGER.debug(f"{DOMAIN} - using API headers: {self.API_HEADERS}")
 
@@ -320,7 +320,7 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
         headers["accessToken"] = self.token.access_token
         headers["vehicleId"] = vehicle.id
         headers["username"] = self.token.username
-        headers["blueLinkServicePin"] = token.pin
+        headers["blueLinkServicePin"] = self.token.pin
         try:
             response = self.sessions.get(url, headers=headers)
             response_json = response.json()
@@ -346,7 +346,7 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
             )
 
     def get_vehicles(self):
-        url = self.API_URL + "enrollment/details/" + token.username
+        url = self.API_URL + "enrollment/details/" + self.token.username
         headers = self.API_HEADERS
         headers["accessToken"] = self.token.access_token
         headers["username"] = self.token.username
@@ -402,9 +402,9 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
         headers["registrationId"] = vehicle.id
         headers["APPCLOUD-VIN"] = vehicle.VIN
         headers["username"] = self.token.username
-        headers["blueLinkServicePin"] = token.pin
+        headers["blueLinkServicePin"] = self.token.pin
 
-        data = {"userName": token.username, "vin": vehicle.VIN}
+        data = {"userName": self.token.username, "vin": vehicle.VIN}
         response = self.sessions.post(url, headers=headers, json=data)
         # response_headers = response.headers
         # response = response.json()
@@ -428,7 +428,7 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
         headers["vin"] = vehicle.VIN
         headers["registrationId"] = vehicle.id
         headers["username"] = self.token.username
-        headers["blueLinkServicePin"] = token.pin
+        headers["blueLinkServicePin"] = self.token.pin
         _LOGGER.debug(f"{DOMAIN} - Start engine headers: {headers}")
 
         data = {
@@ -462,7 +462,7 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
         headers["vin"] = vehicle.VIN
         headers["registrationId"] = vehicle.id
         headers["username"] = self.token.username
-        headers["blueLinkServicePin"] = token.pin
+        headers["blueLinkServicePin"] = self.token.pin
 
         _LOGGER.debug(f"{DOMAIN} - Stop engine headers: {headers}")
 

--- a/hyundai_kia_connect_api/KiaUvoAPIUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoAPIUSA.py
@@ -386,7 +386,7 @@ class KiaUvoAPIUSA(ApiImpl):
             "vinKey": [vehicle.key],
         }
         response = self.post_request_with_logging_and_active_session(
-            token=token, url=url, json_body=body, vehicle=vehicle
+            token=self.token, url=url, json_body=body, vehicle=vehicle
         )
 
         response_body = response.json()
@@ -453,7 +453,7 @@ class KiaUvoAPIUSA(ApiImpl):
             "requestType": 0  # value of 1 would return cached results instead of forcing update
         }
         response = self.post_request_with_logging_and_active_session(
-            token=token, url=url, json_body=body, vehicle=vehicle
+            token=self.token, url=url, json_body=body, vehicle=vehicle
         )
         response_body = response.json()
         vehicle_status = response_body["payload"]["vehicleInfoList"][0][
@@ -464,7 +464,7 @@ class KiaUvoAPIUSA(ApiImpl):
         url = self.API_URL + "cmm/gts"
         body = {"xid": action_id}
         response = self.post_request_with_logging_and_active_session(
-            token=token, url=url, json_body=body, vehicle=vehicle
+            token=self.token, url=url, json_body=body, vehicle=vehicle
         )
         response_json = response.json()
         last_action_completed = all(
@@ -482,14 +482,13 @@ class KiaUvoAPIUSA(ApiImpl):
             _LOGGER.debug(f"Calling unlock")
 
         response = self.get_request_with_logging_and_active_session(
-            token=token, url=url, vehicle=vehicle
+            token=self.token, url=url, vehicle=vehicle
         )
 
         return response.headers["Xid"]
 
     def start_climate(
         self,
-        token: Token,
         vehicle: Vehicle,
         options: ClimateRequestOptions
     ) -> str:
@@ -518,14 +517,14 @@ class KiaUvoAPIUSA(ApiImpl):
             }
         }
         response = self.post_request_with_logging_and_active_session(
-            token=token, url=url, json_body=body, vehicle=vehicle
+            token=self.token, url=url, json_body=body, vehicle=vehicle
         )
         return response.headers["Xid"]
 
     def stop_climate(self, vehicle: Vehicle) -> str:
         url = self.API_URL + "rems/stop"
         response = self.get_request_with_logging_and_active_session(
-            token=token, url=url
+            token=self.token, url=url
         )
         return response.headers["Xid"]
 
@@ -533,14 +532,14 @@ class KiaUvoAPIUSA(ApiImpl):
         url = self.API_URL + "evc/charge"
         body = {"chargeRatio": 100}
         response = self.post_request_with_logging_and_active_session(
-            token=token, url=url, json_body=body
+            token=self.token, url=url, json_body=body
         )
         return response.headers["Xid"]
 
     def stop_charge(self, vehicle: Vehicle) -> str:
         url = self.API_URL + "evc/cancel"
         response = self.get_request_with_logging_and_active_session(
-            token=token, url=url, vehicle=vehicle
+            token=self.token, url=url, vehicle=vehicle
         )
         return response.headers["Xid"]
 
@@ -559,6 +558,6 @@ class KiaUvoAPIUSA(ApiImpl):
             ]
         }
         response = self.post_request_with_logging_and_active_session(
-            token=token, url=url, json_body=body, vechile=vehicle
+            token=self.token, url=url, json_body=body, vechile=vehicle
         )
         return response.headers["Xid"]

--- a/hyundai_kia_connect_api/KiaUvoAPIUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoAPIUSA.py
@@ -195,6 +195,7 @@ class KiaUvoAPIUSA(ApiImpl):
                 name=entry["nickName"],
                 model=entry["modelName"],
                 key=entry["vehicleKey"],
+                api=self,
             )
             result.append(vehicle)
         return result
@@ -218,6 +219,7 @@ class KiaUvoAPIUSA(ApiImpl):
                     name=entry["nickName"],
                     model=entry["modelName"],
                     key=entry["vehicleKey"],
+                    api=self,
                 )
                 vehicles.append(vehicle)
 

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -365,7 +365,7 @@ class KiaUvoApiCA(ApiImpl):
             headers["pAuth"] = self._get_pin_token(vehicle)
 
             response = requests.post(
-                url, headers=headers, data=json.dumps({"pin": token.pin})
+                url, headers=headers, data=json.dumps({"pin": self.token.pin})
             )
             response = response.json()
             _LOGGER.debug(f"{DOMAIN} - Get Vehicle Location {response}")
@@ -383,7 +383,7 @@ class KiaUvoApiCA(ApiImpl):
         headers["vehicleId"] = vehicle.id
 
         response = requests.post(
-            url, headers=headers, data=json.dumps({"pin": token.pin})
+            url, headers=headers, data=json.dumps({"pin": self.token.pin})
         )
         _LOGGER.debug(f"{DOMAIN} - Received Pin validation response {response.json()}")
         result = response.json()["result"]
@@ -404,7 +404,7 @@ class KiaUvoApiCA(ApiImpl):
         headers["pAuth"] = self._get_pin_token(vehicle)
 
         response = requests.post(
-            url, headers=headers, data=json.dumps({"pin": token.pin})
+            url, headers=headers, data=json.dumps({"pin": self.token.pin})
         )
         response_headers = response.headers
         response = response.json()
@@ -455,19 +455,19 @@ class KiaUvoApiCA(ApiImpl):
                         "hvacTempType": 1,
                     },
                 },
-                "pin": token.pin,
+                "pin": self.token.pin,
             }
         else:
               payload = {
-                "setting": {
-                    "airCtrl": int(options.climate),
-                    "defrost": options.defrost,
-                    "heating1": options.heating,
-                    "igniOnDuration": options.duration,
-                    "ims": 0,
-                    "airTemp": {"value": hex_set_temp, "unit": 0, "hvacTempType": 0},
-                },
-                "pin": token.pin,
+                  "setting": {
+                      "airCtrl": int(options.climate),
+                      "defrost": options.defrost,
+                      "heating1": options.heating,
+                      "igniOnDuration": options.duration,
+                      "ims": 0,
+                      "airTemp": {"value": hex_set_temp, "unit": 0, "hvacTempType": 0},
+                  },
+                  "pin": self.token.pin,
               }
         data = json.dumps(payload)
         _LOGGER.debug(f"{DOMAIN} - Planned start_climate payload {payload}")
@@ -490,7 +490,7 @@ class KiaUvoApiCA(ApiImpl):
         headers["pAuth"] = self._get_pin_token(vehicle)
 
         response = requests.post(
-            url, headers=headers, data=json.dumps({"pin": token.pin})
+            url, headers=headers, data=json.dumps({"pin": self.token.pin})
         )
         response_headers = response.headers
         response = response.json()
@@ -523,10 +523,10 @@ class KiaUvoApiCA(ApiImpl):
         headers["vehicleId"] = vehicle.id
         headers["pAuth"] = self._get_pin_token(vehicle)
         _LOGGER.debug(f"{DOMAIN} - Planned start_charge headers {headers}")
-        data = json.dumps({"pin": token.pin})
+        data = json.dumps({"pin": self.token.pin})
         _LOGGER.debug(f"{DOMAIN} - Planned start_charge payload {data}")
         response = requests.post(
-            url, headers=headers, data=json.dumps({"pin": token.pin})
+            url, headers=headers, data=json.dumps({"pin": self.token.pin})
         )
         response_headers = response.headers
         response = response.json()
@@ -542,7 +542,7 @@ class KiaUvoApiCA(ApiImpl):
         headers["pAuth"] = self._get_pin_token(vehicle)
 
         response = requests.post(
-            url, headers=headers, data=json.dumps({"pin": token.pin})
+            url, headers=headers, data=json.dumps({"pin": self.token.pin})
         )
         response_headers = response.headers
         response = response.json()
@@ -577,12 +577,12 @@ class KiaUvoApiCA(ApiImpl):
             "tsoc": [{
                 "plugType": 0,
                 "level": limits.dc,
-                },
+            },
                 {
                     "plugType": 1,
                     "level": limits.ac,
                 }],
-            "pin": token.pin,
+            "pin": self.token.pin,
         }
 
         response = requests.post(url, headers=headers, data=json.dumps(payload))

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -112,7 +112,8 @@ class KiaUvoApiCA(ApiImpl):
                 model=entry["modelName"],
                 year=int(entry["modelYear"]),
                 VIN=entry["vin"],
-                engine_type=entry_engine_type
+                engine_type=entry_engine_type,
+                api=self,
             )
             result.append(vehicle)
         return result

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -433,7 +433,7 @@ class KiaUvoApiEU(ApiImpl):
     def lock_action(self, vehicle: Vehicle, action: VEHICLE_LOCK_ACTION) -> None:
         url = self.SPA_API_URL + "vehicles/" + vehicle.id + "/control/door"
 
-        payload = {"action": action.value, "deviceId": token.device_id}
+        payload = {"action": action.value, "deviceId": self.token.device_id}
         _LOGGER.debug(f"{DOMAIN} - Lock Action Request: {payload}")
         response = requests.post(url, json=payload, headers=self._get_authenticated_headers()).json()
         _LOGGER.debug(f"{DOMAIN} - Lock Action Response: {response}")
@@ -497,7 +497,7 @@ class KiaUvoApiEU(ApiImpl):
     def start_charge(self, vehicle: Vehicle) -> None:
         url = self.SPA_API_URL + "vehicles/" + vehicle.id + "/control/charge"
 
-        payload = {"action": "start", "deviceId": token.device_id}
+        payload = {"action": "start", "deviceId": self.token.device_id}
         _LOGGER.debug(f"{DOMAIN} - Start Charge Action Request: {payload}")
         response = requests.post(url, json=payload, headers=self._get_authenticated_headers()).json()
         _LOGGER.debug(f"{DOMAIN} - Start Charge Action Response: {response}")
@@ -506,7 +506,7 @@ class KiaUvoApiEU(ApiImpl):
     def stop_charge(self, vehicle: Vehicle) -> None:
         url = self.SPA_API_URL + "vehicles/" + vehicle.id + "/control/charge"
 
-        payload = {"action": "stop", "deviceId": token.device_id}
+        payload = {"action": "stop", "deviceId": self.token.device_id}
         _LOGGER.debug(f"{DOMAIN} - Stop Charge Action Request {payload}")
         response = requests.post(url, json=payload, headers=self._get_authenticated_headers()).json()
         _LOGGER.debug(f"{DOMAIN} - Stop Charge Action Response: {response}")

--- a/hyundai_kia_connect_api/VehicleManager.py
+++ b/hyundai_kia_connect_api/VehicleManager.py
@@ -5,7 +5,8 @@ from dataclasses import dataclass
 
 import pytz
 
-from .ApiImpl import ApiImpl, ClimateRequestOptions, EvChargeLimits
+from .ApiImpl import ApiImpl
+from .Vehicle import Vehicle
 from .const import (
     BRAND_HYUNDAI,
     BRAND_KIA,
@@ -21,8 +22,7 @@ from .HyundaiBlueLinkAPIUSA import HyundaiBlueLinkAPIUSA
 from .KiaUvoApiCA import KiaUvoApiCA
 from .KiaUvoApiEU import KiaUvoApiEU
 from .KiaUvoAPIUSA import KiaUvoAPIUSA
-from .Vehicle import Vehicle
-from .Token import Token
+from .exceptions import VehicleNotFoundError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ class VehicleManager:
         self.brand: int = brand
         self.username: str = username
         self.password: str = password
-        self.geocode_api_enable: bool = geocode_api_enable   
+        self.geocode_api_enable: bool = geocode_api_enable
         self.geocode_api_use_email: bool = geocode_api_use_email
         self.pin: str = pin
 
@@ -41,85 +41,53 @@ class VehicleManager:
             self.region, self.brand
         )
 
-        self.token: Token = None
-        self.vehicles: dict = {}
+        self.vehicles: list[Vehicle] = []
 
     def initialize(self) -> None:
-        self.token: Token = self.api.login(self.username, self.password)
-        self.token.pin = self.pin
-        vehicles = self.api.get_vehicles(self.token)
+        self.api.login(self.username, self.password, self.pin)
+        vehicles = self.api.get_vehicles()
         for vehicle in vehicles:
-            self.vehicles[vehicle.id] = vehicle
+            self.vehicles.append(vehicle)
         self.update_all_vehicles_with_cached_state()
-        
+
     def get_vehicle(self, vehicle_id) -> Vehicle:
-        return self.vehicles[vehicle_id]
+        for v in self.vehicles:
+            if v.id == vehicle_id:
+                return v
+        raise VehicleNotFoundError("No vehicle found with this ID")
 
     def update_all_vehicles_with_cached_state(self) -> None:
-        for vehicle_id in self.vehicles.keys():
-            self.update_vehicle_with_cached_state(self.get_vehicle(vehicle_id))
+        for vehicle in self.vehicles:
+            vehicle.update_with_cached_state()
 
-    def update_vehicle_with_cached_state(self, vehicle: Vehicle) -> None:
-        self.api.update_vehicle_with_cached_state(self.token, vehicle)
-        if self.geocode_api_enable == True:
-            self.api.update_geocoded_location(self.token, vehicle, self.geocode_api_use_email)
 
     def check_and_force_update_vehicles(self, force_refresh_interval: int) -> None:
-        #Force refresh only if current data is older than the value bassed in seconds.  Otherwise runs a cached update. 
+        # Force refresh only if current data is older than the value bassed in seconds.  Otherwise runs a cached update.
         started_at_utc: dt = dt.datetime.now(pytz.utc)
-        for vehicle_id in self.vehicles.keys():
-            vehicle: Vehicle = self.get_vehicle(vehicle_id)
+        for vehicle in self.vehicles:
             _LOGGER.debug(
                 f"{DOMAIN} - Time differential in seconds: {(started_at_utc - vehicle.last_updated_at).total_seconds()}"
             )
             if (
                 started_at_utc - vehicle.last_updated_at
             ).total_seconds() > force_refresh_interval:
-                self.force_refresh_vehicle_state(vehicle)
-            else: 
-                self.update_vehicle_with_cached_state(vehicle)
+                vehicle.force_refresh_state()
+            else:
+                vehicle.update_with_cached_state()
 
     def force_refresh_all_vehicles_states(self) -> None:
-        for vehicle_id in self.vehicles.keys():
-            self.force_refresh_vehicle_state(self.get_vehicle(vehicle_id))
-
-    def force_refresh_vehicle_state(self, vehicle: Vehicle) -> None:
-        self.api.force_refresh_vehicle_state(self.token, vehicle)
+        for vehicle in self.vehicles:
+            vehicle.force_refresh_state()
 
     def check_and_refresh_token(self) -> bool:
-        if self.token is None:
+        if self.api.token is None:
             self.initialize()
-        if self.token.valid_until <= dt.datetime.now(pytz.utc):
+        if self.api.token.valid_until <= dt.datetime.now(pytz.utc):
             _LOGGER.debug(f"{DOMAIN} - Refresh token expired")
-            self.token: Token = self.api.login(self.username, self.password)
-            self.token.pin = self.pin
-            self.api.refresh_vehicles(self.token, self.vehicles)
+            self.api.refresh_vehicles(self.vehicles)
             return True
         return False
 
-    def start_climate(self, vehicle_id: str, options: ClimateRequestOptions) -> str:
-        return self.api.start_climate(self.token, self.get_vehicle(vehicle_id), options)
-            
-    def stop_climate(self, vehicle_id: str) -> str:
-        return self.api.stop_climate(self.token, self.get_vehicle(vehicle_id))
-
-    def lock(self, vehicle_id: str) -> str:
-        return self.api.lock_action(self.token, self.get_vehicle(vehicle_id), VEHICLE_LOCK_ACTION.LOCK)
-    
-    def unlock(self, vehicle_id: str) -> str:
-        return self.api.lock_action(self.token, self.get_vehicle(vehicle_id), VEHICLE_LOCK_ACTION.UNLOCK)
-
-    def start_charge(self, vehicle_id: str) -> str:
-        return self.api.start_charge(self.token, self.get_vehicle(vehicle_id))
-
-    def stop_charge(self, vehicle_id: str) -> str:
-        return self.api.stop_charge(self.token, self.get_vehicle(vehicle_id))
-
-    def set_charge_limits(self, vehicle_id: str, limits: EvChargeLimits) -> str:
-        return self.api.set_charge_limits(self.token, self.get_vehicle(vehicle_id), limits)
-
-    def check_action_status(self, vehicle_id: str, action_id: str):
-        return self.api.check_action_status(self.token, self.get_vehicle(vehicle_id), action_id)
 
     @staticmethod
     def get_implementation_by_region_brand(region: int, brand: int) -> ApiImpl:

--- a/hyundai_kia_connect_api/__init__.py
+++ b/hyundai_kia_connect_api/__init__.py
@@ -1,11 +1,12 @@
 """Top-level package for Hyundai / Kia Connect."""
 
-from .ApiImpl import ApiImpl, ClimateRequestOptions
-from .HyundaiBlueLinkAPIUSA import HyundaiBlueLinkAPIUSA
-from .KiaUvoApiCA import KiaUvoApiCA
-from .KiaUvoApiEU import KiaUvoApiEU
-from .KiaUvoAPIUSA import KiaUvoAPIUSA
+# TODO: check what to do with these imports. Leaving them may cause recursive import issues
+# from .ApiImpl import ApiImpl, ClimateRequestOptions
+# from .HyundaiBlueLinkAPIUSA import HyundaiBlueLinkAPIUSA
+# from .KiaUvoApiCA import KiaUvoApiCA
+# from .KiaUvoApiEU import KiaUvoApiEU
+# from .KiaUvoAPIUSA import KiaUvoAPIUSA
 
-from .Token import Token
-from .Vehicle import Vehicle, EvChargeLimits
-from .VehicleManager import VehicleManager
+# from .Token import Token
+# from .Vehicle import Vehicle, EvChargeLimits
+# from .VehicleManager import VehicleManager

--- a/hyundai_kia_connect_api/exceptions.py
+++ b/hyundai_kia_connect_api/exceptions.py
@@ -46,3 +46,10 @@ class InvalidAPIResponseError(APIError):
     Raised upon receipt of an invalid API response.
     """
     pass
+
+
+class VehicleNotFoundError(HyundaiKiaException):
+    """
+    Raised when looking up an ID that does not exist / is not associated to the current account.
+    """
+    pass

--- a/tests/ca_login_test.py
+++ b/tests/ca_login_test.py
@@ -16,4 +16,4 @@ def test_CA_login():
         geocode_api_enable=True,
     )
     vm.check_and_refresh_token()
-    assert len(vm.vehicles.keys()) > 0
+    assert len(vm.vehicles) > 0

--- a/tests/eu_login_test.py
+++ b/tests/eu_login_test.py
@@ -11,4 +11,4 @@ def test_EU_login():
         region=1, brand=1, username=username, password=password, pin=pin
     )
     vm.check_and_refresh_token()
-    assert len(vm.vehicles.keys()) > 0
+    assert len(vm.vehicles) > 0


### PR DESCRIPTION
Intro
====

This is a pretty extensive refactor but it's simpler than it looks.

The main purpose is to move "business" methods (functions) to the Vehicle class. IMO, a class/object should represent a real-world object whenever possible, and class methods should represent the actions on the real-world object.

Example
======

 if I want to start charging, here's how we do it currently:

```
vehicle = vehicle_manager.get_vehicle("xxx")
vehicle_manager.start_charge(vehicle.id)
```

and here's how we would do it with this PR:

```
vehicle = vehicle_manager.get_vehicle("xxx")
vehicle.start_charge()
```

lower-layer functions and properties updates are still handled by `ApiImpl` and subclasses.

Changes
======

- move vehicle-specific "business" methods (start_climate, lock, unlock, ...) to the Vehicle class whenever possible
- move Token to ApiImpl (it's the only class that needs it, makes more sense to have it there) and remove Token argument from methods
- VehicleManager: use a list of Vehicle objects rather than a list of dicts
- factorize get_last_updated_at (it's pretty much the same between all API implems)
- update unit tests

Attention points
============

- still having some recursive import issues (between ApiImpl, VehicleManager and Vehicle I believe) -- it works as is, but it's not the cleanest
- this PR changes the library's interface, so any apps/libs using it (including kia_uvo) will need updating

TODO
====
- update documentation
