### PR TITLE
fix(EU): Get Driving for unsupported cars

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -24,6 +24,7 @@ from .const import (
     SEAT_STATUS,
     VEHICLE_LOCK_ACTION,
     CHARGE_PORT_ACTION,
+    ENGINE_TYPES,
 )
 
 from .exceptions import *
@@ -191,6 +192,16 @@ class KiaUvoApiEU(ApiImpl):
         _check_response_for_errors(response)
         result = []
         for entry in response["resMsg"]["vehicles"]:
+            entry_engine_type = None
+            if(entry["type"] == "GN"):
+                entry_engine_type = ENGINE_TYPES.ICE
+            elif(entry["type"] == "EV"):
+                entry_engine_type = ENGINE_TYPES.EV
+            elif(entry["type"] == "PHEV"): 
+                entry_engine_type = ENGINE_TYPES.PHEV
+            elif(entry["type"] == HV"): 
+                #This isn't correct. I also don't know if EV and PHEV codes are for type. I posted to discord on bluelinky to see if anyone knows.  HV would be hyrbid but I don't have a type for that right now. 
+                entry_engine_type = ENGINE_TYPES.EV
             vehicle: Vehicle = Vehicle(
                 id=entry["vehicleId"],
                 name=entry["nickname"],
@@ -220,25 +231,40 @@ class KiaUvoApiEU(ApiImpl):
     def update_vehicle_with_cached_state(self, token: Token, vehicle: Vehicle) -> None:
         state = self._get_cached_vehicle_state(token, vehicle)
         self._update_vehicle_properties(vehicle, state)
-
-        try:
-            state = self._get_driving_info(token, vehicle)
-        except Exception as e:
-            # we don't know if all car types (ex: ICE cars) provide this information.
-            # we also don't know what the API returns if the info is unavailable.
-            # so, catch any exception and move on.
-            _LOGGER.exception("""Failed to parse driving info. Possible reasons:
-                                - incompatible vehicle (ICE)
-                                - new API format
-                                - API outage
-                        """, exc_info=e)
-        else:
-            self._update_vehicle_drive_info(vehicle, state)
+        
+        if vehicle.engine_type == ENGINE_TYPES.EV:
+            try:
+                state = self._get_driving_info(token, vehicle)
+            except Exception as e:
+                # we don't know if all car types (ex: ICE cars) provide this information.
+                # we also don't know what the API returns if the info is unavailable.
+                # so, catch any exception and move on.
+                _LOGGER.exception("""Failed to parse driving info. Possible reasons:
+                                    - incompatible vehicle (ICE)
+                                    - new API format
+                                    - API outage
+                            """, exc_info=e)
+            else:
+                self._update_vehicle_drive_info(vehicle, state)
 
     def force_refresh_vehicle_state(self, token: Token, vehicle: Vehicle) -> None:
         state = self._get_forced_vehicle_state(token, vehicle)
         state["vehicleLocation"] = self._get_location(token, vehicle)
         self._update_vehicle_properties(vehicle, state)
+        if vehicle.engine_type == ENGINE_TYPES.EV:
+            try:
+                state = self._get_driving_info(token, vehicle)
+            except Exception as e:
+                # we don't know if all car types (ex: ICE cars) provide this information.
+                # we also don't know what the API returns if the info is unavailable.
+                # so, catch any exception and move on.
+                _LOGGER.exception("""Failed to parse driving info. Possible reasons:
+                                    - incompatible vehicle (ICE)
+                                    - new API format
+                                    - API outage
+                            """, exc_info=e)
+            else:
+                self._update_vehicle_drive_info(vehicle, state)
 
     def _update_vehicle_properties(self, vehicle: Vehicle, state: dict) -> None:
         if get_child_value(state, "vehicleStatus.time"):

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -199,7 +199,7 @@ class KiaUvoApiEU(ApiImpl):
                 entry_engine_type = ENGINE_TYPES.EV
             elif(entry["type"] == "PHEV"): 
                 entry_engine_type = ENGINE_TYPES.PHEV
-            elif(entry["type"] == HV"): 
+            elif(entry["type"] == "HV"): 
                 #This isn't correct. I also don't know if EV and PHEV codes are for type. I posted to discord on bluelinky to see if anyone knows.  HV would be hyrbid but I don't have a type for that right now. 
                 entry_engine_type = ENGINE_TYPES.EV
             vehicle: Vehicle = Vehicle(

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -227,8 +227,8 @@ class KiaUvoApiEU(ApiImpl):
             # we don't know if all car types (ex: ICE cars) provide this information.
             # we also don't know what the API returns if the info is unavailable.
             # so, catch any exception and move on.
-            _LOGGER.exception("""Failed to parse driving info. Possible reasons:
-                                - incompatible vehicle (ICE?)
+            _LOGGER.warning("""Failed to parse driving info. Possible reasons:
+                                - incompatible vehicle (ICE)
                                 - new API format
                                 - API outage
                         """, exc_info=e)

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -208,6 +208,7 @@ class KiaUvoApiEU(ApiImpl):
                 model=entry["vehicleName"],
                 registration_date=entry["regDate"],
                 VIN=entry["vin"],
+                engine_type=entry_engine_type,
             )
             result.append(vehicle)
         return result

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -227,7 +227,7 @@ class KiaUvoApiEU(ApiImpl):
             # we don't know if all car types (ex: ICE cars) provide this information.
             # we also don't know what the API returns if the info is unavailable.
             # so, catch any exception and move on.
-            _LOGGER.warning("""Failed to parse driving info. Possible reasons:
+            _LOGGER.exception("""Failed to parse driving info. Possible reasons:
                                 - incompatible vehicle (ICE)
                                 - new API format
                                 - API outage

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -200,8 +200,7 @@ class KiaUvoApiEU(ApiImpl):
             elif(entry["type"] == "PHEV"): 
                 entry_engine_type = ENGINE_TYPES.PHEV
             elif(entry["type"] == "HV"): 
-                #This isn't correct. I also don't know if EV and PHEV codes are for type. I posted to discord on bluelinky to see if anyone knows.  HV would be hyrbid but I don't have a type for that right now. 
-                entry_engine_type = ENGINE_TYPES.EV
+                entry_engine_type = ENGINE_TYPES.HEV
             vehicle: Vehicle = Vehicle(
                 id=entry["vehicleId"],
                 name=entry["nickname"],
@@ -252,15 +251,15 @@ class KiaUvoApiEU(ApiImpl):
         state = self._get_forced_vehicle_state(token, vehicle)
         state["vehicleLocation"] = self._get_location(token, vehicle)
         self._update_vehicle_properties(vehicle, state)
+        #Only call for driving info on cars we know have a chance of supporting it.   Could be expanded if other types do support it. 
         if vehicle.engine_type == ENGINE_TYPES.EV:
             try:
                 state = self._get_driving_info(token, vehicle)
             except Exception as e:
-                # we don't know if all car types (ex: ICE cars) provide this information.
+                # we don't know if all car types provide this information.
                 # we also don't know what the API returns if the info is unavailable.
                 # so, catch any exception and move on.
                 _LOGGER.exception("""Failed to parse driving info. Possible reasons:
-                                    - incompatible vehicle (ICE)
                                     - new API format
                                     - API outage
                             """, exc_info=e)
@@ -616,6 +615,7 @@ class KiaUvoApiEU(ApiImpl):
 
             return drivingInfo
         else:
+            _LOGGER.debug(f"{DOMAIN} - Driving info didn't return valid data. This may be normal if the car doesn't support it.")
             return None
 
     def set_charge_limits(self, token: Token, vehicle: Vehicle, ac: int, dc: int)-> str:

--- a/hyundai_kia_connect_api/const.py
+++ b/hyundai_kia_connect_api/const.py
@@ -44,6 +44,7 @@ class ENGINE_TYPES(Enum):
     ICE = "ICE"
     EV = "EV"
     PHEV = "PHEV"
+    HEV = "HEV"
 
 
 class VEHICLE_LOCK_ACTION(Enum):


### PR DESCRIPTION
Let me know thoughts on this.   Essentially we are going to throw this on many cars so will have many reports of issues where this is normal for cars that don't offer it.   

I am torn between the approach in this PR vs checking for a value with an if statement within the call. If no driving info passed just log it as warning or debug as that is normal.  That would let the exception level still throw on unknown issues. 

Trying to resolve this: 

https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/472