### PR TITLE
Removed not from is_locked

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
@@ -242,7 +242,7 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
         vehicle.tire_pressure_all_warning_is_on = bool(get_child_value(
             state, "vehicleStatus.tirePressureLamp.tirePressureWarningLampAll"
         ))
-        vehicle.is_locked = (not get_child_value(state, "vehicleStatus.doorLock"))
+        vehicle.is_locked = (get_child_value(state, "vehicleStatus.doorLock"))
         vehicle.front_left_door_is_open = get_child_value(
             state, "vehicleStatus.doorOpen.frontLeft"
         )


### PR DESCRIPTION
Removed the not status from is_locked to correct inversion of status.

Tested by changing kia_uvo lock.py with:
```python
    @property
    def is_locked(self):
        not_locked = not getattr(self.vehicle, "is_locked")
        return not_locked
        # return getattr(self.vehicle, "is_locked")
```
Found the upstream status and changed the toggle. This was also present in v1.X, which I corrected there as well.