### PR TITLE
fix(CA): timezone stored per vehicle

### DIFF
--- a/hyundai_kia_connect_api/Vehicle.py
+++ b/hyundai_kia_connect_api/Vehicle.py
@@ -55,6 +55,7 @@ class Vehicle:
     car_battery_percentage: int = None
     engine_is_running: bool = None
     last_updated_at: datetime.datetime = datetime.datetime.min
+    timezone: datetime.timezone = None
 
     smart_key_battery_warning_is_on: bool = None
     washer_fluid_warning_is_on: bool = None


### PR DESCRIPTION
In CA api, store timezone per vehicle to avoid issues for a user who has two vehicles on different timezones.

Tested and working as expected for me.