### PR TITLE
feat(EU): Android Bluelink App language reset to English #145

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python 3.9 or newer is required to use this package. Vehicle manager is the key 
     brand: int, 
     username: str
     password: str
-    pin: str (required for CA, and potentially USA, otherwise pass a blank string) 
+    pin: str (required for CA, and potentially USA, otherwise pass a blank string)
 
 Key values for the int exist in the constant(https://github.com/fuatakgun/hyundai_kia_connect_api/blob/master/hyundai_kia_connect_api/const.py) file as::
 
@@ -59,4 +59,29 @@ If geolocation is required you can also allow this by running::
     vm = VehicleManager(region=2, brand=1, username="username@gmail.com", password="password", pin="1234", geocode_api_enable=True, geocode_api_use_email=True)
     
 This will populate the address of the vehicle in the vehicle instance. 
+
+The Bluelink App is reset to English for users who have set another language in the Bluelink App in Europe when using hyundai_kia_connect_api.
+To avoid this, you can pass the optional parameter language (default is "en") to the constructor of VehicleManager, e.g. for Dutch:
+    vm = VehicleManager(region=2, brand=1, username="username@gmail.com", password="password", pin="1234", language="nl")
+
+Note: this is only implemented for Europe currently.
+[For a list of language codes, see here.](https://www.science.co.il/language/Codes.php). Currently in Europe the Bluelink App shows the following languages:
+- "en" English
+- "de" German 
+- "fr" French
+- "it" Italian
+- "es" Spanish
+- "sv" Swedish
+- "nl" Dutch
+- "no" Norwegian
+- "cs" Czech
+- "sk" Slovak
+- "hu" Hungarian
+- "da" Danish
+- "pl" Polish
+- "fi" Finnish
+- "pt" Portuguese
+
+
+
 

--- a/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
@@ -44,7 +44,9 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
         self,
         region: int,
         brand: int,
+        language: str
     ):
+        self.LANGUAGE: str = language
         self.BASE_URL: str = "api.telematics.hyundaiusa.com"
         self.LOGIN_API: str = "https://" + self.BASE_URL + "/v2/ac/"
         self.API_URL: str = "https://" + self.BASE_URL + "/ac/v2/"
@@ -60,7 +62,7 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
             "content-type": "application/json;charset=UTF-8",
             "accept": "application/json, text/plain, */*",
             "accept-encoding": "gzip, deflate, br",
-            "accept-language": "en-US,en;q=0.9",
+            "accept-language": self.LANGUAGE + ",en-US,en;q=0.9",
             "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36",
             "host": self.BASE_URL,
             "origin": "https://" + self.BASE_URL,

--- a/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
@@ -62,7 +62,7 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
             "content-type": "application/json;charset=UTF-8",
             "accept": "application/json, text/plain, */*",
             "accept-encoding": "gzip, deflate, br",
-            "accept-language": self.LANGUAGE + ",en-US,en;q=0.9",
+            "accept-language": "en-US,en;q=0.9",
             "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36",
             "host": self.BASE_URL,
             "origin": "https://" + self.BASE_URL,
@@ -450,7 +450,7 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
         headers["username"] = token.username
         headers["blueLinkServicePin"] = token.pin
         _LOGGER.debug(f"{DOMAIN} - Start engine headers: {headers}")
-        
+
         if options.climate is None:
             options.climate = True
         if options.set_temp is None:
@@ -461,8 +461,8 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
             options.heating = 0
         if options.defrost is None:
             options.defrost = False
-        
-        
+
+
         data = {
             "Ims": 0,
             "airCtrl": int(options.climate),

--- a/hyundai_kia_connect_api/KiaUvoAPIUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoAPIUSA.py
@@ -84,7 +84,9 @@ class KiaUvoAPIUSA(ApiImpl):
         self,
         region: int,
         brand: int,
+        language
     ) -> None:
+        self.LANGUAGE: str = language
         self.temperature_range = range(62, 82)
 
         # Randomly generate a plausible device id on startup
@@ -105,7 +107,7 @@ class KiaUvoAPIUSA(ApiImpl):
             "content-type": "application/json;charset=UTF-8",
             "accept": "application/json, text/plain, */*",
             "accept-encoding": "gzip, deflate, br",
-            "accept-language": "en-US,en;q=0.9",
+            "accept-language": self.LANGUAGE + ",en-US,en;q=0.9",
             "apptype": "L",
             "appversion": "4.10.0",
             "clientid": "MWAMOBILE",

--- a/hyundai_kia_connect_api/KiaUvoAPIUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoAPIUSA.py
@@ -107,7 +107,7 @@ class KiaUvoAPIUSA(ApiImpl):
             "content-type": "application/json;charset=UTF-8",
             "accept": "application/json, text/plain, */*",
             "accept-encoding": "gzip, deflate, br",
-            "accept-language": self.LANGUAGE + ",en-US,en;q=0.9",
+            "accept-language": "en-US,en;q=0.9",
             "apptype": "L",
             "appversion": "4.10.0",
             "clientid": "MWAMOBILE",
@@ -221,16 +221,16 @@ class KiaUvoAPIUSA(ApiImpl):
 
     def update_vehicle_with_cached_state(self, token: Token, vehicle: Vehicle) -> None:
         state = self._get_cached_vehicle_state(token, vehicle)
-        self._update_vehicle_properties(vehicle, state)     
-        
+        self._update_vehicle_properties(vehicle, state)
+
     def force_refresh_vehicle_state(self, token: Token, vehicle: Vehicle) -> None:
         self._get_forced_vehicle_state(token, vehicle)
         #TODO: Force update needs work to return the correct data for processing
         #self._update_vehicle_properties(vehicle, state)
         #Temp call a cached state since we are removing this from parent logic in other commits should be removed when the above is fixed
         self.update_vehicle_with_cached_state(token, vehicle)
-        
-    def _update_vehicle_properties(self, vehicle: Vehicle, state: dict) -> None:          
+
+    def _update_vehicle_properties(self, vehicle: Vehicle, state: dict) -> None:
         """Get cached vehicle data and update Vehicle instance with it"""
         vehicle.last_updated_at = self.get_last_updated_at(
             get_child_value(state, "vehicleStatus.syncDate.utc")
@@ -358,7 +358,7 @@ class KiaUvoAPIUSA(ApiImpl):
             get_child_value(state, "nextService.value"),
             DISTANCE_UNITS[get_child_value(state, "nextService.unit")],
         )
-    
+
         vehicle.data = state
 
     def get_last_updated_at(self, value) -> dt.datetime:
@@ -472,7 +472,7 @@ class KiaUvoAPIUSA(ApiImpl):
             token=token, url=url, json_body=body, vehicle=vehicle
         )
         response_body = response.json()
-       
+
 
     def check_last_action_status(self, token: Token, vehicle: Vehicle, action_id: str):
         url = self.API_URL + "cmm/gts"

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -49,7 +49,7 @@ class KiaUvoApiCA(ApiImpl):
             "content-type": "application/json;charset=UTF-8",
             "accept": "application/json, text/plain, */*",
             "accept-encoding": "gzip, deflate, br",
-            "accept-language": self.LANGUAGE + ",en-US,en;q=0.9",
+            "accept-language": "en-US,en;q=0.9",
             "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36",
             "host": self.BASE_URL,
             "origin": "https://" + self.BASE_URL,
@@ -102,7 +102,7 @@ class KiaUvoApiCA(ApiImpl):
                 entry_engine_type = ENGINE_TYPES.ICE
             elif(entry["fuelKindCode"] == "E"):
                 entry_engine_type = ENGINE_TYPES.EV
-            elif(entry["fuelKindCode"] == "P"): 
+            elif(entry["fuelKindCode"] == "P"):
                 entry_engine_type = ENGINE_TYPES.PHEV
             vehicle: Vehicle = Vehicle(
                 id=entry["vehicleId"],
@@ -119,10 +119,10 @@ class KiaUvoApiCA(ApiImpl):
     def update_vehicle_with_cached_state(self, token: Token, vehicle: Vehicle) -> None:
         state = self._get_cached_vehicle_state(token, vehicle)
         self._update_vehicle_properties_base(vehicle, state)
-        
-        # Service Status Call       
+
+        # Service Status Call
         service = self._get_next_service(token, vehicle)
-        
+
         #Get location if the car has moved since last call
         if vehicle.odometer:
             if vehicle.odometer < get_child_value(service, "currentOdometer"):
@@ -131,14 +131,14 @@ class KiaUvoApiCA(ApiImpl):
         else:
                 location = self.get_location(token, vehicle)
                 self._update_vehicle_properties_location(vehicle, location)
-                
-        #Update service after the fact so we still have the old odometer reading available for above.        
+
+        #Update service after the fact so we still have the old odometer reading available for above.
         self._update_vehicle_properties_service(vehicle, service)
         if vehicle.engine_type == ENGINE_TYPES.EV:
             charge = self._get_charge_limits(token, vehicle)
             self._update_vehicle_properties_charge(vehicle, charge)
-        
-        
+
+
     def force_refresh_vehicle_state(self, token: Token, vehicle: Vehicle) -> None:
         state = self._get_forced_vehicle_state(token, vehicle)
 
@@ -159,11 +159,11 @@ class KiaUvoApiCA(ApiImpl):
                 f"{DOMAIN} - Set vehicle.timezone to UTC + {offset} hours"
             )
 
-        self._update_vehicle_properties_base(vehicle, state)        
+        self._update_vehicle_properties_base(vehicle, state)
 
-        # Service Status Call       
+        # Service Status Call
         service = self._get_next_service(token, vehicle)
-        
+
         #Get location if the car has moved since last call
         if vehicle.odometer:
             if vehicle.odometer < get_child_value(service, "currentOdometer"):
@@ -172,16 +172,16 @@ class KiaUvoApiCA(ApiImpl):
         else:
                 location = self.get_location(token, vehicle)
                 self._update_vehicle_properties_location(vehicle, location)
-                
-        #Update service after the fact so we still have the old odometer reading available for above.        
+
+        #Update service after the fact so we still have the old odometer reading available for above.
         self._update_vehicle_properties_service(vehicle, service)
-        
+
         if vehicle.engine_type == ENGINE_TYPES.EV:
             charge = self._get_charge_limits(token, vehicle)
             self._update_vehicle_properties_charge(vehicle, charge)
-        
-        
-    def _update_vehicle_properties_base(self, vehicle: Vehicle, state: dict) -> None:   
+
+
+    def _update_vehicle_properties_base(self, vehicle: Vehicle, state: dict) -> None:
         _LOGGER.debug(f"{DOMAIN} - Old Vehicle Last Updated: {vehicle.last_updated_at}")
         vehicle.last_updated_at = self.get_last_updated_at(
             get_child_value(state, "status.lastStatusDate"),
@@ -196,7 +196,7 @@ class KiaUvoApiCA(ApiImpl):
 
             else:
                 state["status"]["airTemp"]["value"] = self.temperature_range_c_old[tempIndex]
-                
+
         vehicle.total_driving_range = (
             get_child_value(
                 state,
@@ -303,9 +303,9 @@ class KiaUvoApiCA(ApiImpl):
         if vehicle.data is None:
             vehicle.data = {}
         vehicle.data["status"] = state["status"]
-        
+
     def _update_vehicle_properties_service(self, vehicle: Vehicle, state: dict) -> None:
-        
+
         vehicle.odometer = (
             get_child_value(state, "currentOdometer"),
             DISTANCE_UNITS[get_child_value(state, "currentOdometerUnit")],
@@ -318,20 +318,20 @@ class KiaUvoApiCA(ApiImpl):
             get_child_value(state, "msopServiceOdometer"),
             DISTANCE_UNITS[get_child_value(state, "msopServiceOdometerUnit")],
         )
-        
+
         vehicle.data["service"] = state
-        
+
     def _update_vehicle_properties_location(self, vehicle: Vehicle, state: dict) -> None:
-        
+
         if get_child_value(state, "coord.lat"):
             vehicle.location = (
                 get_child_value(state, "coord.lat"),
                 get_child_value(state, "coord.lon"),
                 get_child_value(state, "time"),
 
-            )      
+            )
         vehicle.data["vehicleLocation"] = state
-        
+
 
     def get_last_updated_at(self, value, vehicle) -> dt.datetime:
         m = re.match(r"(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})", value)
@@ -365,7 +365,7 @@ class KiaUvoApiCA(ApiImpl):
         status["status"] = response
 
         return status
-    
+
     def _get_forced_vehicle_state(self, token: Token, vehicle: Vehicle) -> dict:
         url = self.API_URL + "rltmvhclsts"
         headers = self.API_HEADERS
@@ -379,7 +379,7 @@ class KiaUvoApiCA(ApiImpl):
         response = response["result"]["status"]
         status = {}
         status["status"] = response
-        
+
         return status
 
     def _get_next_service(self, token: Token, vehicle: Vehicle) -> dict:
@@ -454,7 +454,7 @@ class KiaUvoApiCA(ApiImpl):
     ) -> str:
         if vehicle.engine_type == ENGINE_TYPES.EV:
             url = self.API_URL + "evc/rfon"
-        else: 
+        else:
             url = self.API_URL + "rmtstrt"
         headers = self.API_HEADERS
         headers["accessToken"] = token.access_token
@@ -476,10 +476,10 @@ class KiaUvoApiCA(ApiImpl):
         if options.front_right_seat is None:
             options.front_right_seat = 0
         if options.rear_left_seat is None:
-            options.rear_left_seat = 0        
+            options.rear_left_seat = 0
         if options.rear_right_seat is None:
             options.rear_right_seat = 0
-            
+
         if vehicle.year >= self.temperature_range_model_year:
             hex_set_temp = get_index_into_hex_temp(
                 self.temperature_range_c_new.index(options.set_temp)
@@ -521,14 +521,14 @@ class KiaUvoApiCA(ApiImpl):
         response = requests.post(url, headers=headers, data=json.dumps(payload))
         response_headers = response.headers
         response = response.json()
-        
+
         _LOGGER.debug(f"{DOMAIN} - Received start_climate response {response}")
         return response_headers["transactionId"]
 
     def stop_climate(self, token: Token, vehicle: Vehicle) -> str:
         if vehicle.engine_type == ENGINE_TYPES.EV:
             url = self.API_URL + "evc/rfoff"
-        else: 
+        else:
             url = self.API_URL + "rmtstp"
         headers = self.API_HEADERS
         headers["accessToken"] = token.access_token
@@ -595,22 +595,22 @@ class KiaUvoApiCA(ApiImpl):
 
         _LOGGER.debug(f"{DOMAIN} - Received stop_charge response {response}")
         return response_headers["transactionId"]
-    
-    def _update_vehicle_properties_charge(self, vehicle: Vehicle, state: dict) -> None:   
+
+    def _update_vehicle_properties_charge(self, vehicle: Vehicle, state: dict) -> None:
         vehicle.ev_charge_limits_ac = [x['level'] for x in state if x['plugType'] == 1][-1]
         vehicle.ev_charge_limits_dc = [x['level'] for x in state if x['plugType'] == 0][-1]
 
-    
+
     def _get_charge_limits(self, token: Token, vehicle: Vehicle) -> dict:
         url = self.API_URL + "evc/selsoc"
         headers = self.API_HEADERS
         headers["accessToken"] = token.access_token
         headers["vehicleId"] = vehicle.id
-        
-        response = requests.post(url, headers=headers)    
+
+        response = requests.post(url, headers=headers)
         response = response.json()
         return response["result"]
-    
+
     def set_charge_limits(self, token: Token, vehicle: Vehicle, ac: int, dc: int)-> str:
         url = self.API_URL + "evc/setsoc"
         headers = self.API_HEADERS
@@ -625,7 +625,7 @@ class KiaUvoApiCA(ApiImpl):
                 },
                 {
                 "plugType": 1,
-                "level": ac,          
+                "level": ac,
                 }],
             "pin": token.pin,
         }

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -37,8 +37,8 @@ class KiaUvoApiCA(ApiImpl):
     temperature_range_c_new = [x * 0.5 for x in range(28, 64)]
     temperature_range_model_year = 2020
 
-    def __init__(self, region: int, brand: int) -> None:
-
+    def __init__(self, region: int, brand: int,  language: str) -> None:
+        self.LANGUAGE: str = language
         if BRANDS[brand] == BRAND_KIA:
             self.BASE_URL: str = "www.kiaconnect.ca"
         elif BRANDS[brand] == BRAND_HYUNDAI:
@@ -49,7 +49,7 @@ class KiaUvoApiCA(ApiImpl):
             "content-type": "application/json;charset=UTF-8",
             "accept": "application/json, text/plain, */*",
             "accept-encoding": "gzip, deflate, br",
-            "accept-language": "en-US,en;q=0.9",
+            "accept-language": self.LANGUAGE + ",en-US,en;q=0.9",
             "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36",
             "host": self.BASE_URL,
             "origin": "https://" + self.BASE_URL,

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -77,8 +77,9 @@ class KiaUvoApiEU(ApiImpl):
     data_timezone = tz.gettz("Europe/Berlin")
     temperature_range = [x * 0.5 for x in range(28, 60)]
 
-    def __init__(self, region: int, brand: int) -> None:
+    def __init__(self, region: int, brand: int, language: str) -> None:
         self.stamps = None
+        self.LANGUAGE: str = language
 
         if BRANDS[brand] == BRAND_KIA:
             self.BASE_DOMAIN: str = "prd.eu-ccapi.kia.com"
@@ -112,7 +113,7 @@ class KiaUvoApiEU(ApiImpl):
                 + auth_client_id
                 + "&scope=openid%20profile%20email%20phone&response_type=code&hkid_session_reset=true&redirect_uri="
                 + self.USER_API_URL
-                + "integration/redirect/login&ui_locales=en&state=$service_id:$user_id"
+                + "integration/redirect/login&ui_locales=" + self.LANGUAGE + "&state=$service_id:$user_id"
             )
         elif BRANDS[brand] == BRAND_HYUNDAI:
             auth_client_id = "64621b96-0f0d-11ec-82a8-0242ac130003"
@@ -123,7 +124,7 @@ class KiaUvoApiEU(ApiImpl):
                 + auth_client_id
                 + "&scope=openid%20profile%20email%20phone&response_type=code&hkid_session_reset=true&redirect_uri="
                 + self.USER_API_URL
-                + "integration/redirect/login&ui_locales=en&state=$service_id:$user_id"
+                + "integration/redirect/login&ui_locales=" + self.LANGUAGE + "&state=$service_id:$user_id"
             )
 
         self.stamps_url: str = (

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -39,6 +39,24 @@ USER_AGENT_OK_HTTP: str = "okhttp/3.12.0"
 USER_AGENT_MOZILLA: str = "Mozilla/5.0 (Linux; Android 4.1.1; Galaxy Nexus Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19"
 ACCEPT_HEADER_ALL: str = "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
 
+SUPPORTED_LANGUAGES_LIST = [
+    "en",   # English
+    "de",   # German
+    "fr",   # French
+    "it",   # Italian
+    "es",   # Spanish
+    "sv",   # Swedish
+    "nl",   # Dutch
+    "no",   # Norwegian
+    "cs",   # Czech
+    "sk",   # Slovak
+    "hu",   # Hungarian
+    "da",   # Danish
+    "pl",   # Polish
+    "fi",   # Finnish
+    "pt"    # Portuguese
+]
+
 
 def _check_response_for_errors(response: dict) -> None:
     """
@@ -79,6 +97,10 @@ class KiaUvoApiEU(ApiImpl):
 
     def __init__(self, region: int, brand: int, language: str) -> None:
         self.stamps = None
+
+        if language not in SUPPORTED_LANGUAGES_LIST:
+            _LOGGER.warning(f"Unsupported language: {language}, fallback to en")
+            language = "en"  # fallback to English
         self.LANGUAGE: str = language
 
         if BRANDS[brand] == BRAND_KIA:
@@ -198,9 +220,9 @@ class KiaUvoApiEU(ApiImpl):
                 entry_engine_type = ENGINE_TYPES.ICE
             elif(entry["type"] == "EV"):
                 entry_engine_type = ENGINE_TYPES.EV
-            elif(entry["type"] == "PHEV"): 
+            elif(entry["type"] == "PHEV"):
                 entry_engine_type = ENGINE_TYPES.PHEV
-            elif(entry["type"] == "HV"): 
+            elif(entry["type"] == "HV"):
                 entry_engine_type = ENGINE_TYPES.HEV
             vehicle: Vehicle = Vehicle(
                 id=entry["vehicleId"],
@@ -232,7 +254,7 @@ class KiaUvoApiEU(ApiImpl):
     def update_vehicle_with_cached_state(self, token: Token, vehicle: Vehicle) -> None:
         state = self._get_cached_vehicle_state(token, vehicle)
         self._update_vehicle_properties(vehicle, state)
-        
+
         if vehicle.engine_type == ENGINE_TYPES.EV:
             try:
                 state = self._get_driving_info(token, vehicle)
@@ -252,7 +274,7 @@ class KiaUvoApiEU(ApiImpl):
         state = self._get_forced_vehicle_state(token, vehicle)
         state["vehicleLocation"] = self._get_location(token, vehicle)
         self._update_vehicle_properties(vehicle, state)
-        #Only call for driving info on cars we know have a chance of supporting it.   Could be expanded if other types do support it. 
+        #Only call for driving info on cars we know have a chance of supporting it.   Could be expanded if other types do support it.
         if vehicle.engine_type == ENGINE_TYPES.EV:
             try:
                 state = self._get_driving_info(token, vehicle)
@@ -274,7 +296,7 @@ class KiaUvoApiEU(ApiImpl):
             )
         else:
             vehicle.last_updated_at = dt.datetime.now(self.data_timezone)
-            
+
         vehicle.total_driving_range = (
             get_child_value(
                 state,
@@ -287,8 +309,8 @@ class KiaUvoApiEU(ApiImpl):
                 )
             ],
         )
-        
-        #Only update odometer if present.   It isn't present in a force update.  Dec 2022 update also reports 0 when the car is off.  This tries to remediate best we can.  Can be removed once fixed in the cars firmware. 
+
+        #Only update odometer if present.   It isn't present in a force update.  Dec 2022 update also reports 0 when the car is off.  This tries to remediate best we can.  Can be removed once fixed in the cars firmware.
         if get_child_value(state, "odometer.value") is not None:
             if get_child_value(state, "odometer.value") != 0:
                 vehicle.odometer = (
@@ -336,7 +358,7 @@ class KiaUvoApiEU(ApiImpl):
             vehicle.steering_wheel_heater_is_on = False
         elif steer_wheel_heat == 1:
             vehicle.steering_wheel_heater_is_on = True
-            
+
         vehicle.back_window_heater_is_on = get_child_value(
             state, "vehicleStatus.sideBackWindowHeat"
         )
@@ -397,16 +419,16 @@ class KiaUvoApiEU(ApiImpl):
         vehicle.ev_battery_is_plugged_in = get_child_value(
             state, "vehicleStatus.evStatus.batteryPlugin"
         )
-        
+
         ev_charge_port_door_is_open = get_child_value(
             state, "vehicleStatus.evStatus.chargePortDoorOpenStatus"
         )
-        
-        if ev_charge_port_door_is_open == 1:         
+
+        if ev_charge_port_door_is_open == 1:
             vehicle.ev_charge_port_door_is_open = True
         elif ev_charge_port_door_is_open == 2:
-            vehicle.ev_charge_port_door_is_open = False   
-        
+            vehicle.ev_charge_port_door_is_open = False
+
         vehicle.ev_driving_range = (
             get_child_value(
                 state,
@@ -470,7 +492,7 @@ class KiaUvoApiEU(ApiImpl):
                 ),
                 DISTANCE_UNITS[get_child_value(state, "vehicleStatus.dte.unit")],
             )
-        
+
         vehicle.ev_target_range_charge_AC = (
             get_child_value(
                 state,
@@ -496,12 +518,12 @@ class KiaUvoApiEU(ApiImpl):
             ],
         )
 
-        vehicle.washer_fluid_warning_is_on = get_child_value(state, "vehicleStatus.washerFluidStatus")           
+        vehicle.washer_fluid_warning_is_on = get_child_value(state, "vehicleStatus.washerFluidStatus")
         vehicle.fuel_level = get_child_value(state, "vehicleStatus.fuelLevel")
         vehicle.fuel_level_is_low = get_child_value(state, "vehicleStatus.lowFuelLight")
         vehicle.air_control_is_on = get_child_value(state, "vehicleStatus.airCtrlOn")
         vehicle.smart_key_battery_warning_is_on = get_child_value(state, "vehicleStatus.smartKeyBatteryWarning")
-        
+
 
         if get_child_value(state, "vehicleLocation.coord.lat"):
             vehicle.location = (
@@ -639,7 +661,7 @@ class KiaUvoApiEU(ApiImpl):
         _check_response_for_errors(response)
 
     def _get_charge_limits(self, token: Token, vehicle: Vehicle) -> dict:
-        #Not currently used as value is in the general get.  Most likely this forces the car the update it. 
+        #Not currently used as value is in the general get.  Most likely this forces the car the update it.
         url = f"{self.SPA_API_URL}vehicles/{vehicle.id}/charge/target"
 
         _LOGGER.debug(f"{DOMAIN} - Get Charging Limits Request")
@@ -767,7 +789,7 @@ class KiaUvoApiEU(ApiImpl):
             + self.CLIENT_ID
             + "&redirect_uri="
             + self.USER_API_URL
-            + "oauth2/redirect&lang=en"
+            + "oauth2/redirect&lang=" + self.LANGUAGE
         )
         payload = {}
         headers = {
@@ -782,7 +804,7 @@ class KiaUvoApiEU(ApiImpl):
             "Sec-Fetch-User": "?1",
             "Sec-Fetch-Dest": "document",
             "Accept-Encoding": "gzip, deflate",
-            "Accept-Language": "en,en-US;q=0.9",
+            "Accept-Language": "en,en-US," + self.LANGUAGE + ";q=0.9",
         }
 
         _LOGGER.debug(f"{DOMAIN} - Get cookies request: {url}")
@@ -796,7 +818,7 @@ class KiaUvoApiEU(ApiImpl):
         ### Set Language for Session ###
         url = self.USER_API_URL + "language"
         headers = {"Content-type": "application/json"}
-        payload = {"lang": "en"}
+        payload = {"lang": self.LANGUAGE}
         response = requests.post(url, json=payload, headers=headers, cookies=cookies)
 
     def _get_authorization_code_with_redirect_url(

--- a/hyundai_kia_connect_api/VehicleManager.py
+++ b/hyundai_kia_connect_api/VehicleManager.py
@@ -29,7 +29,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class VehicleManager:
-    def __init__(self, region: int, brand: int, username: str, password: str, pin: str, geocode_api_enable: bool = False, geocode_api_use_email: bool = False):
+    def __init__(self, region: int, brand: int, username: str, password: str, pin: str, geocode_api_enable: bool = False, geocode_api_use_email: bool = False, language: str = "en"):
         self.region: int = region
         self.brand: int = brand
         self.username: str = username
@@ -37,9 +37,10 @@ class VehicleManager:
         self.geocode_api_enable: bool = geocode_api_enable   
         self.geocode_api_use_email: bool = geocode_api_use_email
         self.pin: str = pin
+        self.language: str = language
 
         self.api: ApiImpl = self.get_implementation_by_region_brand(
-            self.region, self.brand
+            self.region, self.brand, self.language
         )
 
         self.token: Token = None
@@ -129,12 +130,12 @@ class VehicleManager:
         return self.api.charge_port_action(self.token, self.get_vehicle(vehicle_id), CHARGE_PORT_ACTION.CLOSE)
 
     @staticmethod
-    def get_implementation_by_region_brand(region: int, brand: int) -> ApiImpl:
+    def get_implementation_by_region_brand(region: int, brand: int, language: str) -> ApiImpl:
         if REGIONS[region] == REGION_CANADA:
-            return KiaUvoApiCA(region, brand)
+            return KiaUvoApiCA(region, brand, language)
         elif REGIONS[region] == REGION_EUROPE:
-            return KiaUvoApiEU(region, brand)
+            return KiaUvoApiEU(region, brand, language)
         elif REGIONS[region] == REGION_USA and BRANDS[brand] == BRAND_HYUNDAI:
-            return HyundaiBlueLinkAPIUSA(region, brand)
+            return HyundaiBlueLinkAPIUSA(region, brand, language)
         elif REGIONS[region] == REGION_USA and BRANDS[brand] == BRAND_KIA:
-            return KiaUvoAPIUSA(region, brand)
+            return KiaUvoAPIUSA(region, brand, language)


### PR DESCRIPTION
Implemented issue:  Android Bluelink App language is reset to English when using hyundai_kia_connect_api #145 

Added optional language to constructor of VehicleManager, defaults to "en" and pass them to the implementation classes constructor and use the language where appropriate. 

Note that I could only test KiaUvoApiEU.py.