### PR TITLE
feat(EU): TripReports

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,3 +84,23 @@ For a list of language codes, see here: https://www.science.co.il/language/Codes
 - "pl" Polish
 - "fi" Finnish
 - "pt" Portuguese
+
+In Europe also trip info can be retrieved. For a month you can ask the days with trips. And you can ask for a specific day for all the trips of that specific day.::
+- First call vm.update_month_trip_info(vehicle.id, yyymm) before getting vehicle.month_trip_info for that month
+- First call vm.update_day_trip_info(vehicle.id, day.yyyymmdd) before getting vehicle.day_trip_info for that day
+
+Example of getting trip info of the current month and day (vm is VehicleManager instance)::
+
+    now = datetime.now()
+    yyymm = now.strftime("%Y%m")
+    yyyymmdd = now.strftime("%Y%m%d")
+    vm.update_month_trip_info(vehicle.id, yyymm)
+    if vehicle.month_trip_info is not None:
+        for day in vehicle.month_trip_info.day_list:  # ordered on day
+            if yyyymmdd == day.yyyymmdd:  # in example only interested in current day
+                vm.update_day_trip_info(vehicle.id, day.yyyymmdd)
+                if vehicle.day_trip_info is not None:
+                    for trip in reversed(vehicle.day_trip_info.trip_list):  # show oldest first
+                        print(f"{day.yyyymmdd},{trip.hhmmss},{trip.drive_time},{trip.idle_time},{trip.distance},{trip.avg_speed},{trip.max_speed}")
+
+   

--- a/README.rst
+++ b/README.rst
@@ -103,4 +103,3 @@ Example of getting trip info of the current month and day (vm is VehicleManager 
                     for trip in reversed(vehicle.day_trip_info.trip_list):  # show oldest first
                         print(f"{day.yyyymmdd},{trip.hhmmss},{trip.drive_time},{trip.idle_time},{trip.distance},{trip.avg_speed},{trip.max_speed}")
 
-   

--- a/hyundai_kia_connect_api/ApiImpl.py
+++ b/hyundai_kia_connect_api/ApiImpl.py
@@ -1,3 +1,5 @@
+# pylint:disable=unnecessary-pass,missing-class-docstring,invalid-name,missing-function-docstring,wildcard-import,unused-wildcard-import,unused-argument
+"""ApiImpl.py"""
 import datetime as dt
 import logging
 from dataclasses import dataclass
@@ -8,11 +10,7 @@ from .const import *
 from .Token import Token
 from .Vehicle import Vehicle
 
-from .utils import (
-    get_child_value,
-    get_hex_temp_into_index,
-    get_index_into_hex_temp,
-)
+from .utils import get_child_value
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,7 +52,9 @@ class ApiImpl:
         """Convert last updated value of vehicle into into datetime"""
         pass
 
-    def update_vehicle_with_cached_state(self, token: Token, vehicle: Vehicle) -> None:
+    def update_vehicle_with_cached_state(
+        self, token: Token, vehicle: Vehicle
+    ) -> None:
         """Get cached vehicle data and update Vehicle instance with it"""
         pass
 
@@ -65,7 +65,9 @@ class ApiImpl:
         False if not.  Does not confirm if successful only confirms if complete"""
         pass
 
-    def force_refresh_vehicle_state(self, token: Token, vehicle: Vehicle) -> None:
+    def force_refresh_vehicle_state(
+        self, token: Token, vehicle: Vehicle
+    ) -> None:
         """Triggers the system to contact the car and get fresh data"""
         pass
 
@@ -100,7 +102,6 @@ class ApiImpl:
         self, token: Token, vehicle: Vehicle, options: ClimateRequestOptions
     ) -> str:
         """Starts climate or remote start.  Returns the tracking ID"""
-
         pass
 
     def stop_climate(self, token: Token, vehicle: Vehicle) -> str:
@@ -125,4 +126,30 @@ class ApiImpl:
         self, token: Token, vehicle: Vehicle, action: CHARGE_PORT_ACTION
     ) -> str:
         """Opens or closes the charging port of the car. Returns the tracking ID"""
+        pass
+
+    def update_month_trip_info(
+        self, token: Token, vehicle: Vehicle, yyyymm_string: str
+    ) -> None:
+        """
+        Europe feature only.
+        Updates the vehicle.month_trip_info for the specified month.
+
+        Default this information is None:
+
+        month_trip_info: MonthTripInfo = None
+        """
+        pass
+
+    def update_day_trip_info(
+        self, token: Token, vehicle: Vehicle, yyyymmdd_string: str
+    ) -> None:
+        """
+        Europe feature only.
+        Updates the vehicle.day_trip_info information for the specified day.
+
+        Default this information is None:
+
+        day_trip_info: DayTripInfo = None
+        """
         pass

--- a/hyundai_kia_connect_api/ApiImpl.py
+++ b/hyundai_kia_connect_api/ApiImpl.py
@@ -52,9 +52,7 @@ class ApiImpl:
         """Convert last updated value of vehicle into into datetime"""
         pass
 
-    def update_vehicle_with_cached_state(
-        self, token: Token, vehicle: Vehicle
-    ) -> None:
+    def update_vehicle_with_cached_state(self, token: Token, vehicle: Vehicle) -> None:
         """Get cached vehicle data and update Vehicle instance with it"""
         pass
 
@@ -65,9 +63,7 @@ class ApiImpl:
         False if not.  Does not confirm if successful only confirms if complete"""
         pass
 
-    def force_refresh_vehicle_state(
-        self, token: Token, vehicle: Vehicle
-    ) -> None:
+    def force_refresh_vehicle_state(self, token: Token, vehicle: Vehicle) -> None:
         """Triggers the system to contact the car and get fresh data"""
         pass
 

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -932,19 +932,9 @@ class KiaUvoApiEU(ApiImpl):
     ) -> dict:
         url = self.SPA_API_URL + "vehicles/" + vehicle.id + "/tripinfo"
         if trip_period_type == 0:  # month
-            if len(date_string) != 6:
-                raise APIError(
-                    f"Invalid date_string, expected yyyymm: {date_string}"
-                )
             payload = {"tripPeriodType": 0, "setTripMonth": date_string}
-        elif trip_period_type == 1:  # day
-            if len(date_string) != 8:
-                raise APIError(
-                    f"Invalid date_string, expected yyyymmdd: {date_string}"
-                )
-            payload = {"tripPeriodType": 1, "setTripDay": date_string}
         else:
-            raise APIError(f"Invalid trip period type: {trip_period_type}")
+            payload = {"tripPeriodType": 1, "setTripDay": date_string}
 
         _LOGGER.debug(f"{DOMAIN} - get_trip_info Request {payload}")
         response = requests.post(
@@ -954,6 +944,7 @@ class KiaUvoApiEU(ApiImpl):
         )
         response = response.json()
         _LOGGER.debug(f"{DOMAIN} - get_trip_info response {response}")
+        _check_response_for_errors(response)
         return response
 
     def update_month_trip_info(
@@ -1059,6 +1050,7 @@ class KiaUvoApiEU(ApiImpl):
         _LOGGER.debug(
             f"{DOMAIN} - get_driving_info responseAlltime {responseAlltime}"
         )
+        _check_response_for_errors(responseAlltime)
 
         response30d = requests.post(
             url,
@@ -1067,6 +1059,7 @@ class KiaUvoApiEU(ApiImpl):
         )
         response30d = response30d.json()
         _LOGGER.debug(f"{DOMAIN} - get_driving_info response30d {response30d}")
+        _check_response_for_errors(response30d)
         if get_child_value(responseAlltime, "resMsg.drivingInfoDetail.0"):
             drivingInfo = responseAlltime["resMsg"]["drivingInfoDetail"][0]
 

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -116,9 +116,7 @@ class KiaUvoApiEU(ApiImpl):
         self.stamps = None
 
         if language not in SUPPORTED_LANGUAGES_LIST:
-            _LOGGER.warning(
-                f"Unsupported language: {language}, fallback to en"
-            )
+            _LOGGER.warning(f"Unsupported language: {language}, fallback to en")
             language = "en"  # fallback to English
         self.LANGUAGE: str = language
 
@@ -126,7 +124,9 @@ class KiaUvoApiEU(ApiImpl):
             self.BASE_DOMAIN: str = "prd.eu-ccapi.kia.com"
             self.CCSP_SERVICE_ID: str = "fdc85c00-0a2f-4c64-bcb4-2cfb1500730a"
             self.APP_ID: str = "e7bcd186-a5fd-410d-92cb-6876a42288bd"
-            self.BASIC_AUTHORIZATION: str = "Basic ZmRjODVjMDAtMGEyZi00YzY0LWJjYjQtMmNmYjE1MDA3MzBhOnNlY3JldA=="
+            self.BASIC_AUTHORIZATION: str = (
+                "Basic ZmRjODVjMDAtMGEyZi00YzY0LWJjYjQtMmNmYjE1MDA3MzBhOnNlY3JldA=="
+            )
             self.LOGIN_FORM_HOST = "eu-account.kia.com"
         elif BRANDS[brand] == BRAND_HYUNDAI:
             self.BASE_DOMAIN: str = "prd.eu-ccapi.hyundai.com"
@@ -199,15 +199,11 @@ class KiaUvoApiEU(ApiImpl):
         self._set_session_language(cookies)
         authorization_code = None
         try:
-            authorization_code = (
-                self._get_authorization_code_with_redirect_url(
-                    username, password, cookies
-                )
+            authorization_code = self._get_authorization_code_with_redirect_url(
+                username, password, cookies
             )
         except Exception:
-            _LOGGER.debug(
-                f"{DOMAIN} - get_authorization_code_with_redirect_url failed"
-            )
+            _LOGGER.debug(f"{DOMAIN} - get_authorization_code_with_redirect_url failed")
             authorization_code = self._get_authorization_code_with_form(
                 username, password, cookies
             )
@@ -291,9 +287,7 @@ class KiaUvoApiEU(ApiImpl):
                 value = dt.datetime.strptime(value, "%I%M %p").time()
         return value
 
-    def update_vehicle_with_cached_state(
-        self, token: Token, vehicle: Vehicle
-    ) -> None:
+    def update_vehicle_with_cached_state(self, token: Token, vehicle: Vehicle) -> None:
         state = self._get_cached_vehicle_state(token, vehicle)
         self._update_vehicle_properties(vehicle, state)
 
@@ -315,9 +309,7 @@ class KiaUvoApiEU(ApiImpl):
             else:
                 self._update_vehicle_drive_info(vehicle, state)
 
-    def force_refresh_vehicle_state(
-        self, token: Token, vehicle: Vehicle
-    ) -> None:
+    def force_refresh_vehicle_state(self, token: Token, vehicle: Vehicle) -> None:
         state = self._get_forced_vehicle_state(token, vehicle)
         state["vehicleLocation"] = self._get_location(token, vehicle)
         self._update_vehicle_properties(vehicle, state)
@@ -339,9 +331,7 @@ class KiaUvoApiEU(ApiImpl):
             else:
                 self._update_vehicle_drive_info(vehicle, state)
 
-    def _update_vehicle_properties(
-        self, vehicle: Vehicle, state: dict
-    ) -> None:
+    def _update_vehicle_properties(self, vehicle: Vehicle, state: dict) -> None:
         if get_child_value(state, "vehicleStatus.time"):
             vehicle.last_updated_at = self.get_last_updated_at(
                 get_child_value(state, "vehicleStatus.time")
@@ -374,9 +364,7 @@ class KiaUvoApiEU(ApiImpl):
         vehicle.car_battery_percentage = get_child_value(
             state, "vehicleStatus.battery.batSoc"
         )
-        vehicle.engine_is_running = get_child_value(
-            state, "vehicleStatus.engine"
-        )
+        vehicle.engine_is_running = get_child_value(state, "vehicleStatus.engine")
 
         # Converts temp to usable number. Currently only support celsius. Future to do is check unit in case the care itself is set to F.
         if get_child_value(state, "vehicleStatus.airTemp.value"):
@@ -394,9 +382,7 @@ class KiaUvoApiEU(ApiImpl):
                 ],
             )
         vehicle.defrost_is_on = get_child_value(state, "vehicleStatus.defrost")
-        steer_wheel_heat = get_child_value(
-            state, "vehicleStatus.steerWheelHeat"
-        )
+        steer_wheel_heat = get_child_value(state, "vehicleStatus.steerWheelHeat")
         if steer_wheel_heat in [0, 2]:
             vehicle.steering_wheel_heater_is_on = False
         elif steer_wheel_heat == 1:
@@ -409,24 +395,16 @@ class KiaUvoApiEU(ApiImpl):
             state, "vehicleStatus.sideMirrorHeat"
         )
         vehicle.front_left_seat_status = SEAT_STATUS[
-            get_child_value(
-                state, "vehicleStatus.seatHeaterVentState.flSeatHeatState"
-            )
+            get_child_value(state, "vehicleStatus.seatHeaterVentState.flSeatHeatState")
         ]
         vehicle.front_right_seat_status = SEAT_STATUS[
-            get_child_value(
-                state, "vehicleStatus.seatHeaterVentState.frSeatHeatState"
-            )
+            get_child_value(state, "vehicleStatus.seatHeaterVentState.frSeatHeatState")
         ]
         vehicle.rear_left_seat_status = SEAT_STATUS[
-            get_child_value(
-                state, "vehicleStatus.seatHeaterVentState.rlSeatHeatState"
-            )
+            get_child_value(state, "vehicleStatus.seatHeaterVentState.rlSeatHeatState")
         ]
         vehicle.rear_right_seat_status = SEAT_STATUS[
-            get_child_value(
-                state, "vehicleStatus.seatHeaterVentState.rrSeatHeatState"
-            )
+            get_child_value(state, "vehicleStatus.seatHeaterVentState.rrSeatHeatState")
         ]
         vehicle.is_locked = get_child_value(state, "vehicleStatus.doorLock")
         vehicle.front_left_door_is_open = get_child_value(
@@ -443,33 +421,21 @@ class KiaUvoApiEU(ApiImpl):
         )
         vehicle.hood_is_open = get_child_value(state, "vehicleStatus.hoodOpen")
         vehicle.tire_pressure_rear_left_warning_is_on = bool(
-            get_child_value(
-                state, "vehicleStatus.tirePressureLamp.tirePressureLampRL"
-            )
+            get_child_value(state, "vehicleStatus.tirePressureLamp.tirePressureLampRL")
         )
         vehicle.tire_pressure_front_left_warning_is_on = bool(
-            get_child_value(
-                state, "vehicleStatus.tirePressureLamp.tirePressureLampFL"
-            )
+            get_child_value(state, "vehicleStatus.tirePressureLamp.tirePressureLampFL")
         )
         vehicle.tire_pressure_front_right_warning_is_on = bool(
-            get_child_value(
-                state, "vehicleStatus.tirePressureLamp.tirePressureLampFR"
-            )
+            get_child_value(state, "vehicleStatus.tirePressureLamp.tirePressureLampFR")
         )
         vehicle.tire_pressure_rear_right_warning_is_on = bool(
-            get_child_value(
-                state, "vehicleStatus.tirePressureLamp.tirePressureLampRR"
-            )
+            get_child_value(state, "vehicleStatus.tirePressureLamp.tirePressureLampRR")
         )
         vehicle.tire_pressure_all_warning_is_on = bool(
-            get_child_value(
-                state, "vehicleStatus.tirePressureLamp.tirePressureLampAll"
-            )
+            get_child_value(state, "vehicleStatus.tirePressureLamp.tirePressureLampAll")
         )
-        vehicle.trunk_is_open = get_child_value(
-            state, "vehicleStatus.trunkOpen"
-        )
+        vehicle.trunk_is_open = get_child_value(state, "vehicleStatus.trunkOpen")
         vehicle.ev_battery_percentage = get_child_value(
             state, "vehicleStatus.evStatus.batteryStatus"
         )
@@ -532,27 +498,19 @@ class KiaUvoApiEU(ApiImpl):
                 ],
             )
         vehicle.ev_estimated_current_charge_duration = (
-            get_child_value(
-                state, "vehicleStatus.evStatus.remainTime2.atc.value"
-            ),
+            get_child_value(state, "vehicleStatus.evStatus.remainTime2.atc.value"),
             "m",
         )
         vehicle.ev_estimated_fast_charge_duration = (
-            get_child_value(
-                state, "vehicleStatus.evStatus.remainTime2.etc1.value"
-            ),
+            get_child_value(state, "vehicleStatus.evStatus.remainTime2.etc1.value"),
             "m",
         )
         vehicle.ev_estimated_portable_charge_duration = (
-            get_child_value(
-                state, "vehicleStatus.evStatus.remainTime2.etc2.value"
-            ),
+            get_child_value(state, "vehicleStatus.evStatus.remainTime2.etc2.value"),
             "m",
         )
         vehicle.ev_estimated_station_charge_duration = (
-            get_child_value(
-                state, "vehicleStatus.evStatus.remainTime2.etc3.value"
-            ),
+            get_child_value(state, "vehicleStatus.evStatus.remainTime2.etc3.value"),
             "m",
         )
 
@@ -561,19 +519,13 @@ class KiaUvoApiEU(ApiImpl):
         )
         try:
             vehicle.ev_charge_limits_ac = [
-                x["targetSOClevel"]
-                for x in target_soc_list
-                if x["plugType"] == 1
+                x["targetSOClevel"] for x in target_soc_list if x["plugType"] == 1
             ][-1]
             vehicle.ev_charge_limits_dc = [
-                x["targetSOClevel"]
-                for x in target_soc_list
-                if x["plugType"] == 0
+                x["targetSOClevel"] for x in target_soc_list if x["plugType"] == 0
             ][-1]
         except:
-            _LOGGER.debug(
-                f"{DOMAIN} - SOC Levels couldn't be found. May not be an EV."
-            )
+            _LOGGER.debug(f"{DOMAIN} - SOC Levels couldn't be found. May not be an EV.")
         if get_child_value(
             state,
             "vehicleStatus.evStatus.drvDistance.0.rangeByFuel.gasModeRange.value",
@@ -599,9 +551,7 @@ class KiaUvoApiEU(ApiImpl):
                     state,
                     "vehicleStatus.dte.value",
                 ),
-                DISTANCE_UNITS[
-                    get_child_value(state, "vehicleStatus.dte.unit")
-                ],
+                DISTANCE_UNITS[get_child_value(state, "vehicleStatus.dte.unit")],
             )
 
         vehicle.ev_target_range_charge_AC = (
@@ -714,12 +664,8 @@ class KiaUvoApiEU(ApiImpl):
             state, "vehicleStatus.washerFluidStatus"
         )
         vehicle.fuel_level = get_child_value(state, "vehicleStatus.fuelLevel")
-        vehicle.fuel_level_is_low = get_child_value(
-            state, "vehicleStatus.lowFuelLight"
-        )
-        vehicle.air_control_is_on = get_child_value(
-            state, "vehicleStatus.airCtrlOn"
-        )
+        vehicle.fuel_level_is_low = get_child_value(state, "vehicleStatus.lowFuelLight")
+        vehicle.air_control_is_on = get_child_value(state, "vehicleStatus.airCtrlOn")
         vehicle.smart_key_battery_warning_is_on = get_child_value(
             state, "vehicleStatus.smartKeyBatteryWarning"
         )
@@ -734,26 +680,18 @@ class KiaUvoApiEU(ApiImpl):
             )
         vehicle.data = state
 
-    def _update_vehicle_drive_info(
-        self, vehicle: Vehicle, state: dict
-    ) -> None:
+    def _update_vehicle_drive_info(self, vehicle: Vehicle, state: dict) -> None:
         vehicle.total_power_consumed = get_child_value(state, "totalPwrCsp")
-        vehicle.power_consumption_30d = get_child_value(
-            state, "consumption30d"
-        )
+        vehicle.power_consumption_30d = get_child_value(state, "consumption30d")
         vehicle.daily_stats = get_child_value(state, "dailyStats")
 
-    def _get_cached_vehicle_state(
-        self, token: Token, vehicle: Vehicle
-    ) -> dict:
+    def _get_cached_vehicle_state(self, token: Token, vehicle: Vehicle) -> dict:
         url = self.SPA_API_URL + "vehicles/" + vehicle.id + "/status/latest"
 
         response = requests.get(
             url, headers=self._get_authenticated_headers(token)
         ).json()
-        _LOGGER.debug(
-            f"{DOMAIN} - get_cached_vehicle_status response: {response}"
-        )
+        _LOGGER.debug(f"{DOMAIN} - get_cached_vehicle_status response: {response}")
         _check_response_for_errors(response)
         response = response["resMsg"]["vehicleStatusInfo"]
 
@@ -773,9 +711,7 @@ class KiaUvoApiEU(ApiImpl):
             _LOGGER.warning(f"{DOMAIN} - _get_location failed")
             return None
 
-    def _get_forced_vehicle_state(
-        self, token: Token, vehicle: Vehicle
-    ) -> dict:
+    def _get_forced_vehicle_state(self, token: Token, vehicle: Vehicle) -> dict:
         url = self.SPA_API_URL + "vehicles/" + vehicle.id + "/status"
         response = requests.get(
             url, headers=self._get_authenticated_headers(token)
@@ -802,12 +738,7 @@ class KiaUvoApiEU(ApiImpl):
     def charge_port_action(
         self, token: Token, vehicle: Vehicle, action: CHARGE_PORT_ACTION
     ) -> None:
-        url = (
-            self.SPA_API_URL_V2
-            + "vehicles/"
-            + vehicle.id
-            + "/control/portdoor"
-        )
+        url = self.SPA_API_URL_V2 + "vehicles/" + vehicle.id + "/control/portdoor"
 
         payload = {"action": action.value, "deviceId": token.device_id}
         _LOGGER.debug(f"{DOMAIN} - Charge Port Action Request: {payload}")
@@ -820,12 +751,7 @@ class KiaUvoApiEU(ApiImpl):
     def start_climate(
         self, token: Token, vehicle: Vehicle, options: ClimateRequestOptions
     ) -> None:
-        url = (
-            self.SPA_API_URL
-            + "vehicles/"
-            + vehicle.id
-            + "/control/temperature"
-        )
+        url = self.SPA_API_URL + "vehicles/" + vehicle.id + "/control/temperature"
 
         # Defaults are located here to be region specific
 
@@ -862,12 +788,7 @@ class KiaUvoApiEU(ApiImpl):
         _check_response_for_errors(response)
 
     def stop_climate(self, token: Token, vehicle: Vehicle) -> None:
-        url = (
-            self.SPA_API_URL
-            + "vehicles/"
-            + vehicle.id
-            + "/control/temperature"
-        )
+        url = self.SPA_API_URL + "vehicles/" + vehicle.id + "/control/temperature"
 
         payload = {
             "action": "stop",
@@ -1047,9 +968,7 @@ class KiaUvoApiEU(ApiImpl):
             headers=self._get_authenticated_headers(token),
         )
         responseAlltime = responseAlltime.json()
-        _LOGGER.debug(
-            f"{DOMAIN} - get_driving_info responseAlltime {responseAlltime}"
-        )
+        _LOGGER.debug(f"{DOMAIN} - get_driving_info responseAlltime {responseAlltime}")
         _check_response_for_errors(responseAlltime)
 
         response30d = requests.post(
@@ -1181,9 +1100,7 @@ class KiaUvoApiEU(ApiImpl):
         _LOGGER.debug(f"{DOMAIN} - Get cookies request: {url}")
         session = requests.Session()
         _ = session.get(url)
-        _LOGGER.debug(
-            f"{DOMAIN} - Get cookies response: {session.cookies.get_dict()}"
-        )
+        _LOGGER.debug(f"{DOMAIN} - Get cookies response: {session.cookies.get_dict()}")
         return session.cookies.get_dict()
         # return session
 
@@ -1208,9 +1125,7 @@ class KiaUvoApiEU(ApiImpl):
         authorization_code = "".join(parse_qs(parsed_url.query)["code"])
         return authorization_code
 
-    def _get_authorization_code_with_form(
-        self, username, password, cookies
-    ) -> str:
+    def _get_authorization_code_with_form(self, username, password, cookies) -> str:
         url = self.USER_API_URL + "integrationinfo"
         headers = {"User-Agent": USER_AGENT_MOZILLA}
         response = requests.get(url, headers=headers, cookies=cookies)
@@ -1224,17 +1139,13 @@ class KiaUvoApiEU(ApiImpl):
         login_form_url = login_form_url.replace("$service_id", service_id)
         login_form_url = login_form_url.replace("$user_id", user_id)
 
-        response = requests.get(
-            login_form_url, headers=headers, cookies=cookies
-        )
+        response = requests.get(login_form_url, headers=headers, cookies=cookies)
         cookies = cookies | response.cookies.get_dict()
         _LOGGER.debug(
             f"{DOMAIN} - LoginForm {login_form_url} - Response: {response.text}"
         )
         soup = BeautifulSoup(response.content, "html.parser")
-        login_form_action_url = soup.find("form")["action"].replace(
-            "&amp;", "&"
-        )
+        login_form_action_url = soup.find("form")["action"].replace("&amp;", "&")
 
         data = {
             "username": username,
@@ -1274,9 +1185,7 @@ class KiaUvoApiEU(ApiImpl):
         intUserId = 0
         if "account-find-link" in response.text:
             soup = BeautifulSoup(response.content, "html.parser")
-            login_form_action_url = soup.find("form")["action"].replace(
-                "&amp;", "&"
-            )
+            login_form_action_url = soup.find("form")["action"].replace("&amp;", "&")
             data = {"actionType": "FIND", "createToUVO": "UVO", "email": ""}
             headers = {
                 "Content-Type": "application/x-www-form-urlencoded",
@@ -1299,15 +1208,11 @@ class KiaUvoApiEU(ApiImpl):
             cookies = cookies | response.cookies.get_dict()
             redirect_url = response.headers["Location"]
             headers = {"User-Agent": USER_AGENT_MOZILLA}
-            response = requests.get(
-                redirect_url, headers=headers, cookies=cookies
-            )
+            response = requests.get(redirect_url, headers=headers, cookies=cookies)
             _LOGGER.debug(
                 f"{DOMAIN} - Redirect User Id 2 {redirect_url} - Response {response.url}"
             )
-            _LOGGER.debug(
-                f"{DOMAIN} - Redirect 2 - Response Text {response.text}"
-            )
+            _LOGGER.debug(f"{DOMAIN} - Redirect 2 - Response Text {response.text}")
             parsed_url = urlparse(response.url)
             intUserId = "".join(parse_qs(parsed_url.query)["int_user_id"])
         else:

--- a/hyundai_kia_connect_api/Vehicle.py
+++ b/hyundai_kia_connect_api/Vehicle.py
@@ -1,15 +1,54 @@
+# pylint:disable=missing-class-docstring,missing-function-docstring,wildcard-import,unused-wildcard-import,invalid-name
+"""Vehicle class"""
 import logging
-
-import dataclasses
 import datetime
 import typing
+from dataclasses import dataclass, field
 
 from .const import *
 
 _LOGGER = logging.getLogger(__name__)
 
 
-@dataclasses.dataclass
+@dataclass
+class TripInfo:
+    """Trip Info"""
+
+    hhmmss: str = None  # will not be filled by summary
+    drive_time: int = None
+    idle_time: int = None
+    distance: int = None
+    avg_speed: float = None
+    max_speed: int = None
+
+
+@dataclass
+class DayTripCounts:
+    """Day trip counts"""
+
+    yyyymmdd: str = None
+    trip_count: int = None
+
+
+@dataclass
+class MonthTripInfo:
+    """Month Trip Info"""
+
+    yyyymm: str = None
+    summary: TripInfo = None
+    day_list: list[DayTripCounts] = field(default_factory=list)
+
+
+@dataclass
+class DayTripInfo:
+    """Day Trip Info"""
+
+    yyyymmdd: str = None
+    summary: TripInfo = None
+    trip_list: list[TripInfo] = field(default_factory=list)
+
+
+@dataclass
 class DailyDrivingStats:
     # energy stats are expressed in watthours (Wh)
     date: datetime.datetime = None
@@ -19,12 +58,13 @@ class DailyDrivingStats:
     onboard_electronics_consumption: int = None
     battery_care_consumption: int = None
     regenerated_energy: int = None
-    # distance is expressed in (I assume) whatever unit the vehicle is configured in. KMs (rounded) in my case
+    # distance is expressed in (I assume) whatever unit the vehicle is
+    # configured in. KMs (rounded) in my case
     distance: int = None
-    distance_unit = DISTANCE_UNITS[1]  # set to kms by default for now
+    distance_unit = DISTANCE_UNITS[1]  # set to kms by default
 
 
-@dataclasses.dataclass
+@dataclass
 class Vehicle:
     id: str = None
     name: str = None
@@ -111,14 +151,19 @@ class Vehicle:
     ev_charge_limits_dc: typing.Union[int, None] = None
     ev_charge_limits_ac: typing.Union[int, None] = None
 
-    # energy consumed since the vehicle was paired with the account (so not necessarily for the vehicle's lifetime)
+    # energy consumed since the vehicle was paired with the account
+    # (so not necessarily for the vehicle's lifetime)
     # expressed in watt-hours (Wh)
-    total_power_consumed: float = None
+    total_power_consumed: float = None  # Europe feature only
     # energy consumed in the last ~30 days
     # expressed in watt-hours (Wh)
-    power_consumption_30d: float = None
+    power_consumption_30d: float = None  # Europe feature only
 
-    daily_stats: list[DailyDrivingStats] = dataclasses.field(default_factory=list)
+    # Europe feature only
+    daily_stats: list[DailyDrivingStats] = field(default_factory=list)
+
+    month_trip_info: MonthTripInfo = None  # Europe feature only
+    day_trip_info: DayTripInfo = None  # Europe feature only
 
     ev_battery_percentage: int = None
     ev_battery_is_charging: bool = None

--- a/hyundai_kia_connect_api/VehicleManager.py
+++ b/hyundai_kia_connect_api/VehicleManager.py
@@ -1,3 +1,5 @@
+# pylint:disable=logging-fstring-interpolation,missing-class-docstring,missing-function-docstring,line-too-long,invalid-name
+"""VehicleManager.py"""
 import datetime as dt
 import logging
 
@@ -79,7 +81,9 @@ class VehicleManager:
         else:
             _LOGGER.debug(f"{DOMAIN} - Vehicle Disabled, skipping.")
 
-    def check_and_force_update_vehicles(self, force_refresh_interval: int) -> None:
+    def check_and_force_update_vehicles(
+        self, force_refresh_interval: int
+    ) -> None:
         # Force refresh only if current data is older than the value bassed in seconds.  Otherwise runs a cached update.
         started_at_utc: dt = dt.datetime.now(pytz.utc)
         for vehicle_id in self.vehicles.keys():
@@ -115,12 +119,18 @@ class VehicleManager:
             _LOGGER.debug(f"{DOMAIN} - Refresh token expired")
             self.token: Token = self.api.login(self.username, self.password)
             self.token.pin = self.pin
-            self.vehicles = self.api.refresh_vehicles(self.token, self.vehicles)
+            self.vehicles = self.api.refresh_vehicles(
+                self.token, self.vehicles
+            )
             return True
         return False
 
-    def start_climate(self, vehicle_id: str, options: ClimateRequestOptions) -> str:
-        return self.api.start_climate(self.token, self.get_vehicle(vehicle_id), options)
+    def start_climate(
+        self, vehicle_id: str, options: ClimateRequestOptions
+    ) -> str:
+        return self.api.start_climate(
+            self.token, self.get_vehicle(vehicle_id), options
+        )
 
     def stop_climate(self, vehicle_id: str) -> str:
         return self.api.stop_climate(self.token, self.get_vehicle(vehicle_id))
@@ -132,7 +142,9 @@ class VehicleManager:
 
     def unlock(self, vehicle_id: str) -> str:
         return self.api.lock_action(
-            self.token, self.get_vehicle(vehicle_id), VEHICLE_LOCK_ACTION.UNLOCK
+            self.token,
+            self.get_vehicle(vehicle_id),
+            VEHICLE_LOCK_ACTION.UNLOCK,
         )
 
     def start_charge(self, vehicle_id: str) -> str:
@@ -146,11 +158,6 @@ class VehicleManager:
             self.token, self.get_vehicle(vehicle_id), ac, dc
         )
 
-    def check_action_status(self, vehicle_id: str, action_id: str):
-        return self.api.check_action_status(
-            self.token, self.get_vehicle(vehicle_id), action_id
-        )
-
     def open_charge_port(self, vehicle_id: str) -> str:
         return self.api.charge_port_action(
             self.token, self.get_vehicle(vehicle_id), CHARGE_PORT_ACTION.OPEN
@@ -160,6 +167,34 @@ class VehicleManager:
         return self.api.charge_port_action(
             self.token, self.get_vehicle(vehicle_id), CHARGE_PORT_ACTION.CLOSE
         )
+
+    def update_month_trip_info(
+        self, vehicle_id: str, yyyymm_string: str
+    ) -> None:
+        """
+        Europe feature only.
+        Updates the vehicle.month_trip_info for the specified month.
+
+        Default this information is None:
+
+        month_trip_info: MonthTripInfo = None
+        """
+        vehicle = self.get_vehicle(vehicle_id)
+        self.api.update_month_trip_info(self.token, vehicle, yyyymm_string)
+
+    def update_day_trip_info(
+        self, vehicle_id: str, yyyymmdd_string: str
+    ) -> None:
+        """
+        Europe feature only.
+        Updates the vehicle.day_trip_info information for the specified day.
+
+        Default this information is None:
+
+        day_trip_info: DayTripInfo = None
+        """
+        vehicle = self.get_vehicle(vehicle_id)
+        self.api.update_day_trip_info(self.token, vehicle, yyyymmdd_string)
 
     def disable_vehicle(self, vehicle_id: str) -> None:
         self.get_vehicle(vehicle_id).enabled = False

--- a/hyundai_kia_connect_api/VehicleManager.py
+++ b/hyundai_kia_connect_api/VehicleManager.py
@@ -81,9 +81,7 @@ class VehicleManager:
         else:
             _LOGGER.debug(f"{DOMAIN} - Vehicle Disabled, skipping.")
 
-    def check_and_force_update_vehicles(
-        self, force_refresh_interval: int
-    ) -> None:
+    def check_and_force_update_vehicles(self, force_refresh_interval: int) -> None:
         # Force refresh only if current data is older than the value bassed in seconds.  Otherwise runs a cached update.
         started_at_utc: dt = dt.datetime.now(pytz.utc)
         for vehicle_id in self.vehicles.keys():
@@ -119,18 +117,12 @@ class VehicleManager:
             _LOGGER.debug(f"{DOMAIN} - Refresh token expired")
             self.token: Token = self.api.login(self.username, self.password)
             self.token.pin = self.pin
-            self.vehicles = self.api.refresh_vehicles(
-                self.token, self.vehicles
-            )
+            self.vehicles = self.api.refresh_vehicles(self.token, self.vehicles)
             return True
         return False
 
-    def start_climate(
-        self, vehicle_id: str, options: ClimateRequestOptions
-    ) -> str:
-        return self.api.start_climate(
-            self.token, self.get_vehicle(vehicle_id), options
-        )
+    def start_climate(self, vehicle_id: str, options: ClimateRequestOptions) -> str:
+        return self.api.start_climate(self.token, self.get_vehicle(vehicle_id), options)
 
     def stop_climate(self, vehicle_id: str) -> str:
         return self.api.stop_climate(self.token, self.get_vehicle(vehicle_id))
@@ -168,9 +160,7 @@ class VehicleManager:
             self.token, self.get_vehicle(vehicle_id), CHARGE_PORT_ACTION.CLOSE
         )
 
-    def update_month_trip_info(
-        self, vehicle_id: str, yyyymm_string: str
-    ) -> None:
+    def update_month_trip_info(self, vehicle_id: str, yyyymm_string: str) -> None:
         """
         Europe feature only.
         Updates the vehicle.month_trip_info for the specified month.
@@ -182,9 +172,7 @@ class VehicleManager:
         vehicle = self.get_vehicle(vehicle_id)
         self.api.update_month_trip_info(self.token, vehicle, yyyymm_string)
 
-    def update_day_trip_info(
-        self, vehicle_id: str, yyyymmdd_string: str
-    ) -> None:
+    def update_day_trip_info(self, vehicle_id: str, yyyymmdd_string: str) -> None:
         """
         Europe feature only.
         Updates the vehicle.day_trip_info information for the specified day.

--- a/hyundai_kia_connect_api/utils.py
+++ b/hyundai_kia_connect_api/utils.py
@@ -1,3 +1,7 @@
+# pylint:disable=bare-except,missing-function-docstring,invalid-name
+"""utils.py"""
+
+
 def get_child_value(data, key):
     value = data
     for x in key.split("."):


### PR DESCRIPTION
General:
- I developed with Visual Studio Code on Windows 10 with pylint and flake8 enabled and black formatting at save of file
- For touched files, added as first line a # pylint:disable warnings, so I could concentrate on the real warnings
- Some warnings I did solve
- Maybe something in the future to solve pylint/flake8 warnings or ignore at place where it occurs?
- Feel free to remove the first lines with # pylint:disable
- Sometimes black reformatted some lines

README.rst:
- added usage information of the trip info methods/fields

ApiImpl.py:
- line 13: removed unused imports
- added methods update_month_trip_info and update_day_trip_info

KiaUvoApiEU.py:
- added imports for new dataclasses
- line 207: ex1 was not used, so removed
- line 218 and 221: token_type not used, so replaced with _
- line 920: added response parameter, I did not understand this code was working?
- added methods _get_trip_info, update_month_trip_info and update_day_trip_info
- line 1186: removed unused payload and headers code
- line 1190, 1202: resonse not used, so replaced with _

Vehicle.py:
- import dataclass and field
- added trip info dataclasses
- added Europe only comments

VehicleManager.py:
- added methods update_month_trip_info and update_day_trip_info

utils.py:
- see general