### PR TITLE
fix(EU):  Remove Odometer Logic

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -339,28 +339,15 @@ class KiaUvoApiEU(ApiImpl):
         else:
             vehicle.last_updated_at = dt.datetime.now(self.data_timezone)
 
-        # Only update odometer if present.   It isn't present in a force update.  Dec 2022 update also reports 0 when the car is off.  This tries to remediate best we can.  Can be removed once fixed in the cars firmware.
-        if get_child_value(state, "odometer.value") is not None:
-            if get_child_value(state, "odometer.value") != 0:
-                vehicle.odometer = (
-                    get_child_value(state, "odometer.value"),
-                    DISTANCE_UNITS[
-                        get_child_value(
-                            state,
-                            "odometer.unit",
-                        )
-                    ],
+        vehicle.odometer = (
+            get_child_value(state, "odometer.value"),
+            DISTANCE_UNITS[
+                get_child_value(
+                    state,
+                    "odometer.unit",
                 )
-            elif vehicle.odometer is None:
-                vehicle.odometer = (
-                    get_child_value(state, "odometer.value"),
-                    DISTANCE_UNITS[
-                        get_child_value(
-                            state,
-                            "odometer.unit",
-                        )
-                    ],
-                )
+            ],
+        )
         vehicle.car_battery_percentage = get_child_value(
             state, "vehicleStatus.battery.batSoc"
         )


### PR DESCRIPTION
Remove the logic to combat bad data.  This only existed in a single EU version that has since been resolved.