### PR TITLE
feat(EU): Missing ServiceTemporaryUnavailable Exception in KiaUvoApiEU.py #267

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -91,7 +91,7 @@ def _check_response_for_errors(response: dict) -> None:
     error_code_mapping = {
         "4004": DuplicateRequestError,
         "4081": RequestTimeoutError,
-        "5031": APIError,
+        "5031": ServiceTemporaryUnavailable,
         "5091": RateLimitingError,
         "5921": NoDataFound,
         "9999": RequestTimeoutError,

--- a/hyundai_kia_connect_api/exceptions.py
+++ b/hyundai_kia_connect_api/exceptions.py
@@ -1,3 +1,7 @@
+# pylint:disable=unnecessary-pass
+"""exceptions.py"""
+
+
 class HyundaiKiaException(Exception):
     """
     Generic hyundaiKiaException exception.
@@ -33,6 +37,14 @@ class RateLimitingError(APIError):
 class NoDataFound(APIError):
     """
     Raised when the API doesn't have data for that car. Disabling the car is the solution.
+    """
+
+    pass
+
+
+class ServiceTemporaryUnavailable(APIError):
+    """
+    Raised when Service Temporary Unavailable
     """
 
     pass


### PR DESCRIPTION
It appears that in KiaUvoApiEU.py errorcode 5031: "Unavailable remote control - Service Temporary Unavailable" is mapped to the generic APIError:

````
"5031": APIError,
````

I expected a specific exception in exception.py, e.g. ServiceTemporaryUnavailable so I could catch that specific exception too and could add to my code:

````
        except exceptions.ServiceTemporaryUnavailable as ex:
            retries = handle_exception(ex, retries)
````