### PR TITLE
feat(EU): check action status

### DIFF
--- a/hyundai_kia_connect_api/ApiImpl.py
+++ b/hyundai_kia_connect_api/ApiImpl.py
@@ -56,7 +56,12 @@ class ApiImpl:
         pass
 
     def check_action_status(
-        self, token: Token, vehicle: Vehicle, action_id: str, synchronous: bool = False, timeout: int = 0
+        self,
+        token: Token,
+        vehicle: Vehicle,
+        action_id: str,
+        synchronous: bool = False,
+        timeout: int = 0,
     ) -> OrderStatus:
         pass
 
@@ -67,7 +72,6 @@ class ApiImpl:
     def update_geocoded_location(
         self, token: Token, vehicle: Vehicle, use_email: bool
     ) -> None:
-
         email_parameter = ""
         if use_email is True:
             email_parameter = "&email=" + token.username

--- a/hyundai_kia_connect_api/ApiImpl.py
+++ b/hyundai_kia_connect_api/ApiImpl.py
@@ -6,10 +6,9 @@ from dataclasses import dataclass
 
 import requests
 
-from .const import *
 from .Token import Token
 from .Vehicle import Vehicle
-
+from .const import *
 from .utils import get_child_value
 
 _LOGGER = logging.getLogger(__name__)
@@ -56,11 +55,9 @@ class ApiImpl:
         """Get cached vehicle data and update Vehicle instance with it"""
         pass
 
-    def check_last_action_status(
-        self, token: Token, vehicle: Vehicle, action_id: str
-    ) -> bool:
-        """Check if a previous placed call was successful. Returns true if complete.
-        False if not.  Does not confirm if successful only confirms if complete"""
+    def check_action_status(
+        self, token: Token, vehicle: Vehicle, action_id: str, synchronous: bool = False, timeout: int = 0
+    ) -> OrderStatus:
         pass
 
     def force_refresh_vehicle_state(self, token: Token, vehicle: Vehicle) -> None:

--- a/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
@@ -45,7 +45,6 @@ class cipherAdapter(HTTPAdapter):
 
 
 class HyundaiBlueLinkAPIUSA(ApiImpl):
-
     # initialize with a timestamp which will allow the first fetch to occur
     last_loc_timestamp = dt.datetime.now(pytz.utc) - dt.timedelta(hours=3)
 
@@ -91,7 +90,6 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
         _LOGGER.debug(f"{DOMAIN} - initial API headers: {self.API_HEADERS}")
 
     def login(self, username: str, password: str) -> Token:
-
         # Sign In with Email and Password and Get Authorization Code
 
         url = self.LOGIN_API + "oauth/token"

--- a/hyundai_kia_connect_api/KiaUvoAPIUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoAPIUSA.py
@@ -1,26 +1,26 @@
+import datetime as dt
 import logging
 import random
+import re
 import secrets
 import string
 import time
-from datetime import datetime
-import datetime as dt
-import re
 import typing
+from datetime import datetime
 
 import pytz
 import requests
 from requests import RequestException, Response
 
+from .ApiImpl import ApiImpl, ClimateRequestOptions
+from .Token import Token
+from .Vehicle import Vehicle
 from .const import (
     DOMAIN,
     VEHICLE_LOCK_ACTION,
     TEMPERATURE_UNITS,
-    DISTANCE_UNITS,
+    DISTANCE_UNITS, OrderStatus,
 )
-from .ApiImpl import ApiImpl, ClimateRequestOptions
-from .Token import Token
-from .Vehicle import Vehicle
 from .utils import get_child_value
 
 _LOGGER = logging.getLogger(__name__)
@@ -542,7 +542,8 @@ class KiaUvoAPIUSA(ApiImpl):
         )
         response_body = response.json()
 
-    def check_last_action_status(self, token: Token, vehicle: Vehicle, action_id: str):
+    def check_action_status(self, token: Token, vehicle: Vehicle, action_id: str, synchronous: bool = False,
+                            timeout: int = 0) -> OrderStatus:
         url = self.API_URL + "cmm/gts"
         body = {"xid": action_id}
         response = self.post_request_with_logging_and_active_session(

--- a/hyundai_kia_connect_api/KiaUvoAPIUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoAPIUSA.py
@@ -19,7 +19,8 @@ from .const import (
     DOMAIN,
     VEHICLE_LOCK_ACTION,
     TEMPERATURE_UNITS,
-    DISTANCE_UNITS, OrderStatus,
+    DISTANCE_UNITS,
+    OrderStatus,
 )
 from .utils import get_child_value
 
@@ -542,8 +543,14 @@ class KiaUvoAPIUSA(ApiImpl):
         )
         response_body = response.json()
 
-    def check_action_status(self, token: Token, vehicle: Vehicle, action_id: str, synchronous: bool = False,
-                            timeout: int = 0) -> OrderStatus:
+    def check_action_status(
+        self,
+        token: Token,
+        vehicle: Vehicle,
+        action_id: str,
+        synchronous: bool = False,
+        timeout: int = 0,
+    ) -> OrderStatus:
         url = self.API_URL + "cmm/gts"
         body = {"xid": action_id}
         response = self.post_request_with_logging_and_active_session(

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -1,13 +1,15 @@
+import datetime as dt
 import json
 import logging
-import datetime as dt
 import re
+
+import pytz
+import requests
 from dateutil.tz import *
 
-import requests
-import pytz
-
 from .ApiImpl import ApiImpl, ClimateRequestOptions
+from .Token import Token
+from .Vehicle import Vehicle
 from .const import (
     BRAND_HYUNDAI,
     BRAND_KIA,
@@ -17,16 +19,14 @@ from .const import (
     TEMPERATURE_UNITS,
     SEAT_STATUS,
     ENGINE_TYPES,
-    VEHICLE_LOCK_ACTION,
+    VEHICLE_LOCK_ACTION, OrderStatus,
 )
 from .exceptions import *
-from .Token import Token
 from .utils import (
     get_child_value,
     get_hex_temp_into_index,
     get_index_into_hex_temp,
 )
-from .Vehicle import Vehicle
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -588,9 +588,9 @@ class KiaUvoApiCA(ApiImpl):
         _LOGGER.debug(f"{DOMAIN} - Received stop_climate response: {response}")
         return response_headers["transactionId"]
 
-    def check_last_action_status(
-        self, token: Token, vehicle: Vehicle, action_id: str
-    ) -> bool:
+    def check_action_status(
+        self, token: Token, vehicle: Vehicle, action_id: str, synchronous: bool = False, timeout: int = 0
+    ) -> OrderStatus:
         url = self.API_URL + "rmtsts"
         headers = self.API_HEADERS
         headers["accessToken"] = token.access_token

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -19,7 +19,8 @@ from .const import (
     TEMPERATURE_UNITS,
     SEAT_STATUS,
     ENGINE_TYPES,
-    VEHICLE_LOCK_ACTION, OrderStatus,
+    VEHICLE_LOCK_ACTION,
+    OrderStatus,
 )
 from .exceptions import *
 from .utils import (
@@ -84,7 +85,6 @@ class KiaUvoApiCA(ApiImpl):
                 raise APIError(f"Server returned: '{response['error']['errorDesc']}'")
 
     def login(self, username: str, password: str) -> Token:
-
         # Sign In with Email and Password and Get Authorization Code
         url = self.API_URL + "lgn"
         data = {"loginId": username, "password": password}
@@ -345,7 +345,6 @@ class KiaUvoApiCA(ApiImpl):
         vehicle.data["status"] = state["status"]
 
     def _update_vehicle_properties_service(self, vehicle: Vehicle, state: dict) -> None:
-
         vehicle.odometer = (
             get_child_value(state, "currentOdometer"),
             DISTANCE_UNITS[get_child_value(state, "currentOdometerUnit")],
@@ -364,7 +363,6 @@ class KiaUvoApiCA(ApiImpl):
     def _update_vehicle_properties_location(
         self, vehicle: Vehicle, state: dict
     ) -> None:
-
         if get_child_value(state, "coord.lat"):
             vehicle.location = (
                 get_child_value(state, "coord.lat"),
@@ -589,7 +587,12 @@ class KiaUvoApiCA(ApiImpl):
         return response_headers["transactionId"]
 
     def check_action_status(
-        self, token: Token, vehicle: Vehicle, action_id: str, synchronous: bool = False, timeout: int = 0
+        self,
+        token: Token,
+        vehicle: Vehicle,
+        action_id: str,
+        synchronous: bool = False,
+        timeout: int = 0,
     ) -> OrderStatus:
         url = self.API_URL + "rmtsts"
         headers = self.API_HEADERS

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -36,7 +36,8 @@ from .const import (
     SEAT_STATUS,
     VEHICLE_LOCK_ACTION,
     CHARGE_PORT_ACTION,
-    ENGINE_TYPES, OrderStatus,
+    ENGINE_TYPES,
+    OrderStatus,
 )
 from .exceptions import *
 from .utils import (
@@ -193,7 +194,6 @@ class KiaUvoApiEU(ApiImpl):
         }
 
     def login(self, username: str, password: str) -> Token:
-
         stamp = self._get_stamp()
         device_id = self._get_device_id(stamp)
         cookies = self._get_cookies()
@@ -1285,20 +1285,25 @@ class KiaUvoApiEU(ApiImpl):
         return token_type, refresh_token
 
     def check_action_status(
-        self, token: Token, vehicle: Vehicle, action_id: str, synchronous: bool = False, timeout: int = 0
+        self,
+        token: Token,
+        vehicle: Vehicle,
+        action_id: str,
+        synchronous: bool = False,
+        timeout: int = 0,
     ) -> OrderStatus:
         url = self.SPA_API_URL + "notifications/" + vehicle.id + "/records"
 
         if synchronous:
-
             if timeout < 1:
                 raise Exception("Timeout must be 1 or higher")
 
             end_time = datetime.datetime.now() + datetime.timedelta(seconds=timeout)
             while end_time > datetime.datetime.now():
-
                 # recursive call with Synchronous set to False
-                state = self.check_action_status(token, vehicle, action_id, synchronous=False)
+                state = self.check_action_status(
+                    token, vehicle, action_id, synchronous=False
+                )
                 if state == OrderStatus.PENDING:
                     # state pending: recheck regularly (until we get a final state or exceed the timeout)
                     sleep(5)
@@ -1310,7 +1315,6 @@ class KiaUvoApiEU(ApiImpl):
             return OrderStatus.TIMEOUT
 
         else:
-
             response = requests.get(
                 url, headers=self._get_authenticated_headers(token)
             ).json()
@@ -1326,7 +1330,9 @@ class KiaUvoApiEU(ApiImpl):
                     elif action["result"] == "non-response":
                         return OrderStatus.TIMEOUT
                     elif action["result"] is None:
-                        _LOGGER.info("Action status not set yet by server - try again in a few seconds")
+                        _LOGGER.info(
+                            "Action status not set yet by server - try again in a few seconds"
+                        )
                         return OrderStatus.PENDING
 
             # if iterate the whole notifications list and can't find the action, raise an exception

--- a/hyundai_kia_connect_api/VehicleManager.py
+++ b/hyundai_kia_connect_api/VehicleManager.py
@@ -22,7 +22,8 @@ from .const import (
     REGION_USA,
     REGIONS,
     VEHICLE_LOCK_ACTION,
-    CHARGE_PORT_ACTION, OrderStatus,
+    CHARGE_PORT_ACTION,
+    OrderStatus,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -150,8 +151,13 @@ class VehicleManager:
             self.token, self.get_vehicle(vehicle_id), ac, dc
         )
 
-    def check_action_status(self, vehicle_id: str, action_id: str, synchronous: bool = False,
-                            timeout: int = 120) -> OrderStatus:
+    def check_action_status(
+        self,
+        vehicle_id: str,
+        action_id: str,
+        synchronous: bool = False,
+        timeout: int = 120,
+    ) -> OrderStatus:
         """
         Check for the status of a sent action/command.
 

--- a/hyundai_kia_connect_api/const.py
+++ b/hyundai_kia_connect_api/const.py
@@ -62,3 +62,14 @@ class CHARGE_PORT_ACTION(Enum):
 
 class EvChargeLimit(IntEnum):
     50, 60, 70, 80, 90, 100
+
+
+class OrderStatus(Enum):
+    # pending (waiting for response from vehicle)
+    PENDING = "PENDING"
+    # order executed by vehicle and response returned
+    SUCCESS = "SUCCESS"
+    # order refused by vehicle and response returned
+    FAILED = "FAILED"
+    # no response received from vehicle. no way to know if the order was executed, but most likely not
+    TIMEOUT = "TIMEOUT"


### PR DESCRIPTION
This PR is a follow up from https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/pull/195

I implemented the following changes:
- EU API support: check last action with the /notifications endpoint
- EU API support: modify action functions to return action ID
- rename `check_last_action_status` to `check_action_status`
- synchronous checks (detailed below)

## Synchronous checks

The function takes 2 new arguments:
- `synchronous` (bool): if True, then poll the API until a final state (success/fail/timeout) is returned. if False, then perform just 1 request and return the status immediately, even if still pending. This gives flexibility to developers: they can rely on the library to return a final state, or they can implement this logic at a higher level if they prefer.
-  `timeout` (int, seconds): if call is synchronous, defines how long to poll the API before giving up and returning a TIMEOUT status.

Here's how the function works:
1 - check for action status
2 - if status is still pending, wait 5 seconds then check again in a loop
3 - exit loop once one of these conditions is met: status is final, or the check timed out.

## Tests
Tested today on Kia EU with variations of this code:

```python
        action_id = vehicle_client.vm.start_climate(vehicle_client.vehicle.id, options)
        status = vehicle_client.vm.check_action_status(vehicle_client.vehicle.id, action_id, synchronous=True,
                                                       timeout=60)
        if status == OrderStatus.SUCCESS:
            print "Climate control enabled"
```

It works fine. The final response takes about 20 seconds to arrive.

## What's left
Not included in this PR: implementations for other regions.

## To do
Make sure the states and logic are compatible with all regions.