### PR TITLE
USA Hyundai force refresh

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
@@ -390,9 +390,7 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
         state["vehicleStatus"] = self._get_vehicle_status(token, vehicle, False)
 
         if vehicle.odometer:
-            if vehicle.odometer < get_child_value(
-                state["vehicleDetails"], "odometer"
-            ):
+            if vehicle.odometer < get_child_value(state["vehicleDetails"], "odometer"):
                 state["vehicleLocation"] = self._get_vehicle_location(token, vehicle)
             else:
                 state["vehicleLocation"] = None


### PR DESCRIPTION
I recently got a new Hyundai (in the US) and found this library via the `kia_uvo` Home Assistant integration. I found that the BlueLink data was often very stale, which makes sense given the lack of a force-refresh implementation. I've taken a shot at adding that to the `HyundaiBlueLinkAPIUSA` file. I incorporated some of the changes from #244 as part of a bit of refactoring of the various internal API call methods.

Fixes #31 

I tested this by:
- Setting up a Home Assistant dev environment
- Manually installing the `kia_uvo` integration
- Manually installing this library in the HA virtualenv with `pip3 install -e ../hyundai_kia_connect_api`
- Starting HA with pip skipping this library with `hass --skip-pip-packages hyundai-kia-connect-api -c config`
- Enabling debug logging per the docs in this repo

I was able to see that the integration was successfully refreshing the data at the configured interval, whereas before it would sit stale:
![coding-home-assistant-bluelink-updates](https://user-images.githubusercontent.com/3128434/218653153-47ca4b5e-0abe-429a-92f8-67b18da27495.png)

As far as tests go, I tried running `flake8` and it found a ton of existing warnings - I addressed some of the ones that this change touches, but fixing all of them seemed out of scope. I also ran the existing tests, some of which passed and others did not. :man_shrugging: I'm not primarily a Python developer, so if you'd like additional testing, I could use some pointers.

Hoping this looks good and I can start using it in my main Home Assistant instance soon!