### PR TITLE
fix(BluelinkUSA): always cached location used

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
@@ -393,7 +393,16 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
         vehicle.fuel_level_is_low = get_child_value(state, "vehicleStatus.lowFuelLight")
 
         vehicle.fuel_level = get_child_value(state, "vehicleStatus.fuelLevel")
-        if get_child_value(state, "vehicleStatus.vehicleLocation.coord.lat"):
+
+        if get_child_value(state, "vehicleLocation.coord.lat"):
+            vehicle.location = (
+                get_child_value(state, "vehicleLocation.coord.lat"),
+                get_child_value(state, "vehicleLocation.coord.lon"),
+                self.get_last_updated_at(
+                    get_child_value(state, "vehicleLocation.time")
+                ),
+            )
+        elif get_child_value(state, "vehicleStatus.vehicleLocation.coord.lat"):
             vehicle.location = (
                 get_child_value(state, "vehicleStatus.vehicleLocation.coord.lat"),
                 get_child_value(state, "vehicleStatus.vehicleLocation.coord.lon"),
@@ -442,6 +451,7 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
                 VIN=entry["vin"],
                 model=entry["modelCode"],
                 registration_date=["enrollmentDate"],
+                timezone=self.data_timezone,
             )
             result.append(vehicle)
 

--- a/hyundai_kia_connect_api/KiaUvoAPIUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoAPIUSA.py
@@ -199,6 +199,7 @@ class KiaUvoAPIUSA(ApiImpl):
                 name=entry["nickName"],
                 model=entry["modelName"],
                 key=entry["vehicleKey"],
+                timezone=self.data_timezone,
             )
             result.append(vehicle)
         return result
@@ -231,6 +232,7 @@ class KiaUvoAPIUSA(ApiImpl):
                         name=entry["nickName"],
                         model=entry["modelName"],
                         key=entry["vehicleKey"],
+                        timezone=self.data_timezone,
                     )
                     vehicles.append(vehicle)
                 return vehicles

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -252,6 +252,7 @@ class KiaUvoApiEU(ApiImpl):
                 model=entry["vehicleName"],
                 registration_date=entry["regDate"],
                 VIN=entry["vin"],
+                timezone=self.data_timezone,
                 engine_type=entry_engine_type,
             )
             result.append(vehicle)

--- a/hyundai_kia_connect_api/Vehicle.py
+++ b/hyundai_kia_connect_api/Vehicle.py
@@ -92,7 +92,7 @@ class Vehicle:
     car_battery_percentage: int = None
     engine_is_running: bool = None
     last_updated_at: datetime.datetime = None
-    timezone: datetime.timezone = None
+    timezone: datetime.timezone = datetime.timezone.utc  # default UTC
     dtc_count: typing.Union[int, None] = None
     dtc_descriptions: typing.Union[dict, None] = None
 


### PR DESCRIPTION
HyundaiBlueLinkAPIUSA.py always fills location with cached vehicle location, also when findMyCar is called. This results in the situation that _location_last_set_time is never filled with a datetime for the Bluelink USA implementation!

Another problem encountered is the inconsistent filling of vehicle.timezone. This is only filled by KiaUvoApiCA.py in the constructor of Vehicle. 

Issue analyzed here:
https://github.com/ZuinigeRijder/hyundai_kia_connect_monitor/issues/48#issuecomment-1447709689

Vehicle.timezone is not consistent used. Only in KiaUvoApiCA.py this is set, in the other implementations HyundaiBlueLinkAPIUSA.py, KiaUvoApiEU.py and KiaUvoAPIUSA.py these are NOT initialized when Vehicle is instantiated, while internally they use UTC.

Easy fix is changing the default timezone in Vehicle.py line 95:
However, more consistent is that (also) the implementations fill the timezone when calling the constructor of Vehicle.

Change:
````
timezone: datetime.timezone = None
```` 

Into:
````
timezone: datetime.timezone = datetime.timezone.utc  # default UTC
````

First, in the following get_cached_vehicle_status response you see only the VehicleLocation 'lat' and 'lon', not 'time' (I did a pretty print):
````
DEBUG:hyundai_kia_connect_api.HyundaiBlueLinkAPIUSA:hyundai_kia_connect_api - get_cached_vehicle_status response {
  "hataTID": "zqCe14XFQhOQHksA6zYsZA",
  "vehicleStatus": {
    "dateTime": "2023-02-27T20:24:30Z",
    "acc": false,
    "defrostStatus": "false",
    "transCond": true,
    "doorLockStatus": "false",
    "doorOpen": {
      "frontRight": 0,
      "frontLeft": 0,
      "backLeft": 0,
      "backRight": 0
    },
    "washerFluidStatus": false,
    "battery": {
      "batSoc": 80,
      "sjbDeliveryMode": 1
    },
    "hazardStatus": 0,
    "vehicleLocation": {
      "coord": {
        "lon": -79.123456,
        "type": 0,
        "lat": 39.123456
      }
    },
....
````

Thereafter a call is done, using findMyCar , where 'time' is available (agian in pretty print):
````
DEBUG:urllib3.connectionpool:https://api.telematics.hyundaiusa.com:443 "GET /ac/v2/rcs/rfc/findMyCar HTTP/1.1" 200 None
DEBUG:hyundai_kia_connect_api.HyundaiBlueLinkAPIUSA:hyundai_kia_connect_api - Get Vehicle Location {
  "head": 267,
  "coord": {
    "alt": 0,
    "lon": -79.123456,
    "type": 0,
    "lat": 39.123456
  },
  "accuracy": {
    "pdop": 14,
    "hdop": 8
  },
  "time": "2023-02-27T20:33:27Z",
  "speed": {
    "unit": 1,
    "value": 0
  }
}
````

And there I think I spotted the problem, why _location_last_set_time is not filled. 
There are two state entries in the dictionary:
- vehicleStatus.vehicleLocation (filled by get_cached_vehicle_status response)
- vehicleLocation (filled by _get_vehicle_location)

So _update_vehicle_properties should check first vehicleLocation (if filled), then vehicleStatus.vehicleLocation. 
Because in the current implementation always vehicleStatus.vehicleLocation is used to fill location and location_last_updated_at.

The implementation should be something like:

````
        if get_child_value(state, "vehicleLocation.coord.lat"):
            vehicle.location = (
                get_child_value(state, "vehicleLocation.coord.lat"),
                get_child_value(state, "vehicleLocation.coord.lon"),
                self.get_last_updated_at(
                    get_child_value(state, "vehicleLocation.time")
                ),
            )
        elif get_child_value(state, "vehicleStatus.vehicleLocation.coord.lat"):
            vehicle.location = (
                get_child_value(state, "vehicleStatus.vehicleLocation.coord.lat"),
                get_child_value(state, "vehicleStatus.vehicleLocation.coord.lon"),
                self.get_last_updated_at(
                    get_child_value(state, "vehicleStatus.vehicleLocation.time")
                ),
            )
````

This Pull Request solves both problems.
