### PR TITLE
#309: Kia (EU): fix login for additional cases

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -146,7 +146,7 @@ class KiaUvoApiEU(ApiImpl):
         self.GCM_SENDER_ID = 199360397125
 
         if BRANDS[brand] == BRAND_KIA:
-            auth_client_id = "f4d531c7-1043-444d-b09a-ad24bd913dd4"
+            auth_client_id = "572e0304-5f8d-4b4c-9dd5-41aa84eed160"
             self.LOGIN_FORM_URL: str = (
                 "https://"
                 + self.LOGIN_FORM_HOST

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ with open("HISTORY.rst") as history_file:
 # with open("requirements.txt") as f:
 #    requirements = f.read().splitlines()
 requirements = ["curlify", "bs4"]
-    
-    
+
+
 long_description = readme + "\n\n" + history
 long_description = readme
 


### PR DESCRIPTION
I updated the auth_client_id (sniffed from the iPhone app).

It fixes login for my account that was created in late 2022. issue #309 
If I understand correctly, accounts created before 2020 were UVO accounts and were merged at some point into a global Kia account.
The previous fix works with pre-2020 accounts but not post-2020 accounts.

This change should fix login for post-2020 accounts 🤞 

If someone with a pre-2020 account can test it to see if it causes any regressions, that'd be great.