### PR TITLE
fix(EU): Auth error on bad device id

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -88,6 +88,7 @@ def _check_response_for_errors(response: dict) -> None:
     - 5091: "Exceeds number of requests"
     - 5921: "No Data Found v2 - No Data Found v2"
     - 9999: "Undefined Error - Response timeout"
+    - Unknown:  "Invalid request body - invalid deviceId", relogin oftend required. 
     :param response: the API's JSON response
     """
 
@@ -108,7 +109,7 @@ def _check_response_for_errors(response: dict) -> None:
         if response["resCode"] in error_code_mapping:
             raise error_code_mapping[response["resCode"]](response["resMsg"])
         else:
-            raise APIError(f"Server returned: '{response['resMsg']}'")
+            raise APIError(f"Server returned:  '{response['rescode']}' '{response['resMsg']}'")
 
 
 class KiaUvoApiEU(ApiImpl):

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -88,7 +88,7 @@ def _check_response_for_errors(response: dict) -> None:
     - 5091: "Exceeds number of requests"
     - 5921: "No Data Found v2 - No Data Found v2"
     - 9999: "Undefined Error - Response timeout"
-    - Unknown:  "Invalid request body - invalid deviceId", relogin oftend required.
+    - 4002:  "Invalid request body - invalid deviceId", relogin oftend required.
     :param response: the API's JSON response
     """
 

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -82,17 +82,18 @@ def _check_response_for_errors(response: dict) -> None:
     - F: failure
     resCode / resMsg known values:
     - 0000: no error
+    - 4002:  "Invalid request body - invalid deviceId", relogin will resolve but a bandaid. 
     - 4004: "Duplicate request"
     - 4081: "Request timeout"
     - 5031: "Unavailable remote control - Service Temporary Unavailable"
     - 5091: "Exceeds number of requests"
     - 5921: "No Data Found v2 - No Data Found v2"
     - 9999: "Undefined Error - Response timeout"
-    - 4002:  "Invalid request body - invalid deviceId", relogin oftend required.
     :param response: the API's JSON response
     """
 
     error_code_mapping = {
+        "4002": DeviceIDError,
         "4004": DuplicateRequestError,
         "4081": RequestTimeoutError,
         "5031": ServiceTemporaryUnavailable,

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -82,7 +82,7 @@ def _check_response_for_errors(response: dict) -> None:
     - F: failure
     resCode / resMsg known values:
     - 0000: no error
-    - 4002:  "Invalid request body - invalid deviceId", relogin will resolve but a bandaid. 
+    - 4002:  "Invalid request body - invalid deviceId", relogin will resolve but a bandaid.
     - 4004: "Duplicate request"
     - 4081: "Request timeout"
     - 5031: "Unavailable remote control - Service Temporary Unavailable"

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -88,7 +88,7 @@ def _check_response_for_errors(response: dict) -> None:
     - 5091: "Exceeds number of requests"
     - 5921: "No Data Found v2 - No Data Found v2"
     - 9999: "Undefined Error - Response timeout"
-    - Unknown:  "Invalid request body - invalid deviceId", relogin oftend required. 
+    - Unknown:  "Invalid request body - invalid deviceId", relogin oftend required.
     :param response: the API's JSON response
     """
 
@@ -109,7 +109,9 @@ def _check_response_for_errors(response: dict) -> None:
         if response["resCode"] in error_code_mapping:
             raise error_code_mapping[response["resCode"]](response["resMsg"])
         else:
-            raise APIError(f"Server returned:  '{response['rescode']}' '{response['resMsg']}'")
+            raise APIError(
+                f"Server returned:  '{response['rescode']}' '{response['resMsg']}'"
+            )
 
 
 class KiaUvoApiEU(ApiImpl):

--- a/hyundai_kia_connect_api/exceptions.py
+++ b/hyundai_kia_connect_api/exceptions.py
@@ -17,13 +17,13 @@ class AuthenticationError(HyundaiKiaException):
 
     pass
 
+
 class DeviceIDError(AuthenticationError):
     """
     Raised upon receipt of an Invalid Device ID error.
     """
 
     pass
-
 
 
 class APIError(HyundaiKiaException):

--- a/hyundai_kia_connect_api/exceptions.py
+++ b/hyundai_kia_connect_api/exceptions.py
@@ -17,6 +17,14 @@ class AuthenticationError(HyundaiKiaException):
 
     pass
 
+class DeviceIDError(AuthenticationError):
+    """
+    Raised upon receipt of an Invalid Device ID error.
+    """
+
+    pass
+
+
 
 class APIError(HyundaiKiaException):
     """


### PR DESCRIPTION
This will do a few things:

1. Log the error code itself to make this easier for me in the future.
2. Throw an device ID exception which is a child of Authentication Error.   My understanding is when a device ID error occurs we should re-login.  The Home assistant integration does this if it catches auth error.  So this will automatically take care of it in theory.  I can't test as I am not in EU. This should be removed in the future if we find out how to not invalidate the device id. 
https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/672