### PR TITLE
Set ssl.OP_LEGACY_SERVER_CONNECT in order to be able to connect to unsafe SSL servers that OpenSSL 3.0.0 prohibits by default now.

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
@@ -32,14 +32,20 @@ class cipherAdapter(HTTPAdapter):
     A HTTPAdapter that re-enables poor ciphers required by Hyundai.
     """
 
-    def init_poolmanager(self, *args, **kwargs):
+    def _setup_ssl_context(self):
         context = create_urllib3_context(ciphers=CIPHERS)
-        kwargs["ssl_context"] = context
+        context.options |= 0x4
+
+        return context
+
+    def init_poolmanager(self, *args, **kwargs):
+        kwargs["ssl_context"] = self._setup_ssl_context()
+
         return super().init_poolmanager(*args, **kwargs)
 
     def proxy_manager_for(self, *args, **kwargs):
-        context = create_urllib3_context(ciphers=CIPHERS)
-        kwargs["ssl_context"] = context
+        kwargs["ssl_context"] = self._setup_ssl_context()
+
         return super().proxy_manager_for(*args, **kwargs)
 
 


### PR DESCRIPTION
Update SSL context to enable ssl.OP_LEGACY_SERVER_CONNECT, which isn't in Python yet (see python/cpython#89051, it'll be in 3.12), but in OpenSSL its value is 0x4 in the bitfield.

Fixes Hyundai-Kia-Connect/kia_uvo#678 and Hyundai-Kia-Connect/kia_uvo#679.

Once this is merged, you'll need to do a version bump of this and then bump the version of the required API in Hyundai-Kia-Connect/kia_uvo, obviously.