### PR TITLE
fix: add wrapping status layer for Australia vehicle parsing

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiAU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiAU.py
@@ -229,7 +229,7 @@ class KiaUvoApiAU(ApiImpl):
 
     def update_vehicle_with_cached_state(self, token: Token, vehicle: Vehicle) -> None:
         state = self._get_cached_vehicle_state(token, vehicle)
-        self._update_vehicle_properties(vehicle, state)
+        self._update_vehicle_properties(vehicle, {"status": state})
 
         if vehicle.engine_type == ENGINE_TYPES.EV:
             try:
@@ -252,7 +252,7 @@ class KiaUvoApiAU(ApiImpl):
     def force_refresh_vehicle_state(self, token: Token, vehicle: Vehicle) -> None:
         state = self._get_forced_vehicle_state(token, vehicle)
         state["vehicleLocation"] = self._get_location(token, vehicle)
-        self._update_vehicle_properties(vehicle, state)
+        self._update_vehicle_properties(vehicle, {"status": state})
         # Only call for driving info on cars we know have a chance of supporting it.
         # Could be expanded if other types do support it.
         if vehicle.engine_type == ENGINE_TYPES.EV:


### PR DESCRIPTION
Fixes the missing sensors - looks like Australia's API response skips the extra `status` layer. 
I've rewrapped it at the call site instead because I'm looking to start sharing the vehicle parsing code across regions instead. 

With this I'm now able to get the battery level correctly :) 

![image](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/assets/4076797/ed814e2f-c7f1-425b-b56c-9e8634271f61)
