### PR TITLE
Enable Genesis path for USA

### DIFF
--- a/hyundai_kia_connect_api/VehicleManager.py
+++ b/hyundai_kia_connect_api/VehicleManager.py
@@ -244,7 +244,9 @@ class VehicleManager:
             return KiaUvoApiCA(region, brand, language)
         elif REGIONS[region] == REGION_EUROPE:
             return KiaUvoApiEU(region, brand, language)
-        elif REGIONS[region] == REGION_USA and (BRANDS[brand] == BRAND_HYUNDAI or BRANDS[brand] == BRAND_GENESIS):
+        elif REGIONS[region] == REGION_USA and (
+            BRANDS[brand] == BRAND_HYUNDAI or BRANDS[brand] == BRAND_GENESIS
+        ):
             return HyundaiBlueLinkAPIUSA(region, brand, language)
         elif REGIONS[region] == REGION_USA and BRANDS[brand] == BRAND_KIA:
             return KiaUvoAPIUSA(region, brand, language)

--- a/hyundai_kia_connect_api/VehicleManager.py
+++ b/hyundai_kia_connect_api/VehicleManager.py
@@ -17,6 +17,7 @@ from .KiaUvoApiAU import KiaUvoApiAU
 from .Token import Token
 from .Vehicle import Vehicle
 from .const import (
+    BRAND_GENESIS,
     BRAND_HYUNDAI,
     BRAND_KIA,
     BRANDS,
@@ -243,7 +244,7 @@ class VehicleManager:
             return KiaUvoApiCA(region, brand, language)
         elif REGIONS[region] == REGION_EUROPE:
             return KiaUvoApiEU(region, brand, language)
-        elif REGIONS[region] == REGION_USA and BRANDS[brand] == BRAND_HYUNDAI:
+        elif REGIONS[region] == REGION_USA and (BRANDS[brand] == BRAND_HYUNDAI or BRANDS[brand] == BRAND_GENESIS):
             return HyundaiBlueLinkAPIUSA(region, brand, language)
         elif REGIONS[region] == REGION_USA and BRANDS[brand] == BRAND_KIA:
             return KiaUvoAPIUSA(region, brand, language)


### PR DESCRIPTION
This change enables handling of Genesis vehicles in the USA region to be handled by HyundaiBlueLinkAPIUSA module. In limited testing this was successful in retrieving vehicle details.