### PR TITLE
fix(eu): Add 12h using datetime

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -315,11 +315,10 @@ class KiaUvoApiEU(ApiImpl):
             if int(value) > 1260:
                 value = dt.datetime.strptime(str(value), "%H%M").time()
             else:
-                if timesection == 0:
-                    value = str(value) + " AM"
-                elif timesection == 1:
-                    value = str(value) + " PM"
-                value = dt.datetime.strptime(value, "%I%M %p").time()
+                d = dt.datetime.strptime(value, "%I%M")
+                if timesection > 0:
+                    d += dt.timedelta(hours=12)
+                value = d.time()
         return value
 
     def update_vehicle_with_cached_state(self, token: Token, vehicle: Vehicle) -> None:


### PR DESCRIPTION
Rather than relying on am/pm parsing (which can fail based on locale) rather add 12h using the datetime module.

I hit this when using this module embedded in a tiny [Rust application](https://gitlab.gnome.org/guidog/phosh-ev/)
with pyo3.

Thanks a lot for providing this very useful module!