### PR TITLE
refactor(Hyundai USA): Migration from climate actions methods to engine action methods

### DIFF
--- a/hyundai_kia_connect_api/ApiImpl.py
+++ b/hyundai_kia_connect_api/ApiImpl.py
@@ -104,6 +104,10 @@ class ApiImpl:
         """Lock or unlocks a vehicle.  Returns the tracking ID"""
         pass
 
+    def engine_control_action(self, token: Token, vehicle: Vehicle, action: VEHICLE_ENGINE_CONTROL_ACTION, options: ClimateRequestOptions) -> str:
+        """Perform an engine control action on the vehicle"""
+        pass
+
     def start_climate(
         self, token: Token, vehicle: Vehicle, options: ClimateRequestOptions
     ) -> str:

--- a/hyundai_kia_connect_api/ApiImpl.py
+++ b/hyundai_kia_connect_api/ApiImpl.py
@@ -105,7 +105,7 @@ class ApiImpl:
         pass
 
     def engine_control_action(self, token: Token, vehicle: Vehicle, action: VEHICLE_ENGINE_CONTROL_ACTION, options: ClimateRequestOptions) -> str:
-        """Perform an engine control action on the vehicle"""
+        """Starts or stops an engine depending on the action provided."""
         pass
 
     def start_climate(

--- a/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
@@ -513,6 +513,15 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
         )
         _LOGGER.debug(f"{DOMAIN} - Received lock_action response: {response.text}")
 
+    def engine_control_action(self, token: Token, vehicle: Vehicle, action: VEHICLE_ENGINE_CONTROL_ACTION, options: ClimateRequestOptions) -> str:
+        _LOGGER.debug(f"{DOMAIN} - {action.value} engine..")
+
+        match action:
+            case VEHICLE_ENGINE_CONTROL_ACTION.START:
+                self.start_climate(token, vehicle, options)
+            case VEHICLE_ENGINE_CONTROL_ACTION.STOP:
+                self.stop_climate(token, vehicle)
+
     def _determine_climate_options(self, options: ClimateRequestOptions) -> ClimateRequestOptions:
         if not options:
             options = ClimateRequestOptions()

--- a/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
@@ -518,9 +518,9 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
 
         match action:
             case VEHICLE_ENGINE_CONTROL_ACTION.START:
-                self.start_climate(token, vehicle, options)
+                self.start_engine(token, vehicle, options)
             case VEHICLE_ENGINE_CONTROL_ACTION.STOP:
-                self.stop_climate(token, vehicle)
+                self.stop_engine(token, vehicle)
 
     def _determine_climate_options(self, options: ClimateRequestOptions) -> ClimateRequestOptions:
         if not options:
@@ -581,6 +581,11 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
     def start_climate(
         self, token: Token, vehicle: Vehicle, options: ClimateRequestOptions
     ) -> str:
+        self.start_engine(token, vehicle, options)
+
+    def start_engine(
+        self, token: Token, vehicle: Vehicle, options: ClimateRequestOptions
+    ) -> str:
         _LOGGER.debug(f"{DOMAIN} - Start engine..")
         if vehicle.engine_type == ENGINE_TYPES.EV:
             url = self.API_URL + "evc/fatc/start"
@@ -601,7 +606,7 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
         )
         _LOGGER.debug(f"{DOMAIN} - Start engine response: {response.text}")
 
-    def stop_climate(self, token: Token, vehicle: Vehicle) -> None:
+    def stop_engine(self, token: Token, vehicle: Vehicle) -> None:
         _LOGGER.debug(f"{DOMAIN} - Stop engine..")
 
         if vehicle.engine_type == ENGINE_TYPES.EV:
@@ -618,6 +623,9 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
             f"{DOMAIN} - Stop engine response status code: {response.status_code}"
         )
         _LOGGER.debug(f"{DOMAIN} - Stop engine response: {response.text}")
+
+    def stop_climate(self, token: Token, vehicle: Vehicle) -> None:
+        self.stop_engine(token, vehicle)
 
     def start_charge(self, token: Token, vehicle: Vehicle) -> None:
         pass

--- a/hyundai_kia_connect_api/VehicleManager.py
+++ b/hyundai_kia_connect_api/VehicleManager.py
@@ -29,6 +29,7 @@ from .const import (
     REGION_CHINA,
     REGIONS,
     VEHICLE_LOCK_ACTION,
+    VEHICLE_ENGINE_CONTROL_ACTION,
     CHARGE_PORT_ACTION,
     OrderStatus,
 )
@@ -129,6 +130,9 @@ class VehicleManager:
             self.vehicles = self.api.refresh_vehicles(self.token, self.vehicles)
             return True
         return False
+
+    def start_engine(self, vehicle_id: str, options: ClimateRequestOptions) -> str:
+        return self.api.engine_control_action(self.token, self.get_vehicle(vehicle_id), VEHICLE_ENGINE_CONTROL_ACTION.START, options)
 
     def start_climate(self, vehicle_id: str, options: ClimateRequestOptions) -> str:
         return self.api.start_climate(self.token, self.get_vehicle(vehicle_id), options)

--- a/hyundai_kia_connect_api/VehicleManager.py
+++ b/hyundai_kia_connect_api/VehicleManager.py
@@ -131,12 +131,6 @@ class VehicleManager:
             return True
         return False
 
-    def start_engine(self, vehicle_id: str, options: ClimateRequestOptions) -> str:
-        return self.api.engine_control_action(self.token, self.get_vehicle(vehicle_id), VEHICLE_ENGINE_CONTROL_ACTION.START, options)
-
-    def stop_engine(self, vehicle_id: str) -> str:
-        return self.api.engine_control_action(self.token, self.get_vehicle(vehicle_id), VEHICLE_ENGINE_CONTROL_ACTION.STOP)
-
     def start_climate(self, vehicle_id: str, options: ClimateRequestOptions) -> str:
         return self.api.start_climate(self.token, self.get_vehicle(vehicle_id), options)
 

--- a/hyundai_kia_connect_api/VehicleManager.py
+++ b/hyundai_kia_connect_api/VehicleManager.py
@@ -134,6 +134,9 @@ class VehicleManager:
     def start_engine(self, vehicle_id: str, options: ClimateRequestOptions) -> str:
         return self.api.engine_control_action(self.token, self.get_vehicle(vehicle_id), VEHICLE_ENGINE_CONTROL_ACTION.START, options)
 
+    def stop_engine(self, vehicle_id: str) -> str:
+        return self.api.engine_control_action(self.token, self.get_vehicle(vehicle_id), VEHICLE_ENGINE_CONTROL_ACTION.STOP)
+
     def start_climate(self, vehicle_id: str, options: ClimateRequestOptions) -> str:
         return self.api.start_climate(self.token, self.get_vehicle(vehicle_id), options)
 

--- a/hyundai_kia_connect_api/const.py
+++ b/hyundai_kia_connect_api/const.py
@@ -61,6 +61,9 @@ class ENGINE_TYPES(Enum):
     PHEV = "PHEV"
     HEV = "HEV"
 
+class VEHICLE_ENGINE_CONTROL_ACTION(Enum):
+    START = "start"
+    STOP = "stop"
 
 class VEHICLE_LOCK_ACTION(Enum):
     LOCK = "close"


### PR DESCRIPTION
Continuation of https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/pull/404

There's still a lot to be done for other API implementations. This is purely focused on the BlueLink USA API for the time being.

It may be time to create a utils.py file to put the `_determine_climate_options` and other helper methods into. 

Each API request seems to follow the same pattern:

1. Determine variables (vehicle type, the action being taken, options)
2. Generate the needed data/parameters to make a request using variables
3. Send the request

With some more refactoring effort, the codebase could be simplified.