### PR TITLE
fix: vehicle.odometer can be float-string instead of float

### DIFF
--- a/hyundai_kia_connect_api/Vehicle.py
+++ b/hyundai_kia_connect_api/Vehicle.py
@@ -5,6 +5,7 @@ import datetime
 import typing
 from dataclasses import dataclass, field
 
+from .utils import get_float
 from .const import *
 
 _LOGGER = logging.getLogger(__name__)
@@ -301,11 +302,16 @@ class Vehicle:
     def odometer(self):
         return self._odometer
 
+    @property
+    def odometer_unit(self):
+        return self._odometer_unit
+
     @odometer.setter
     def odometer(self, value):
-        self._odometer_value = value[0]
+        float_value = get_float(value[0])
+        self._odometer_value = float_value
         self._odometer_unit = value[1]
-        self._odometer = value[0]
+        self._odometer = float_value
 
     @property
     def air_temperature(self):

--- a/hyundai_kia_connect_api/utils.py
+++ b/hyundai_kia_connect_api/utils.py
@@ -15,6 +15,21 @@ def get_child_value(data, key):
     return value
 
 
+def get_float(value):
+    if value is None:
+        return None
+    if isinstance(value, float):
+        return value
+    if isinstance(value, int):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return value  # original fallback
+    return value  # original fallback
+
+
 def get_hex_temp_into_index(value):
     if value is not None:
         value = value.replace("H", "")


### PR DESCRIPTION
Class Vehicle in Vehicle.py declares _odometer as a float (so the intention and users of the API are expecting a float):

_odometer: float = None
 
It appears that _odometer als can be a string with a float or int embedded inside the string. At least this is the case with HyundaiBlueLinkAPIUSA.py. I do not know if other classes also can deliver a string, so added this in the Vehicle class, when assigning the instance value. 

To avoid the callers of the API to handle these strange deviations, it is better that the API convert safely to a float, when a string is encountered instead of a float.

See also this issue: Vehicle.odometer is string instead of float for HyundaiBlueLinkAPIUSA.py #433