### PR TITLE
Support for brake_fluid_warning_is_on

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
@@ -257,6 +257,9 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
         vehicle.washer_fluid_warning_is_on = get_child_value(
             state, "vehicleStatus.washerFluidStatus"
         )
+        vehicle.brake_fluid_warning_is_on = get_child_value(
+            state, "vehicleStatus.breakOilStatus"
+        )
         vehicle.smart_key_battery_warning_is_on = get_child_value(
             state, "vehicleStatus.smartKeyBatteryWarning"
         )

--- a/hyundai_kia_connect_api/KiaUvoAPIUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoAPIUSA.py
@@ -302,6 +302,9 @@ class KiaUvoAPIUSA(ApiImpl):
         vehicle.washer_fluid_warning_is_on = get_child_value(
             state, "lastVehicleInfo.vehicleStatusRpt.vehicleStatus.washerFluidStatus"
         )
+        vehicle.brake_fluid_warning_is_on = get_child_value(
+            state, "lastVehicleInfo.vehicleStatusRpt.vehicleStatus.breakOilStatus"
+        )
         vehicle.smart_key_battery_warning_is_on = get_child_value(
             state,
             "lastVehicleInfo.vehicleStatusRpt.vehicleStatus.smartKeyBatteryWarning",

--- a/hyundai_kia_connect_api/KiaUvoApiAU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiAU.py
@@ -623,6 +623,9 @@ class KiaUvoApiAU(ApiImpl):
         vehicle.washer_fluid_warning_is_on = get_child_value(
             state, "status.washerFluidStatus"
         )
+        vehicle.brake_fluid_warning_is_on = get_child_value(
+            state, "status.breakOilStatus"
+        )
         vehicle.fuel_level = get_child_value(state, "status.fuelLevel")
         vehicle.fuel_level_is_low = get_child_value(state, "status.lowFuelLight")
         vehicle.air_control_is_on = get_child_value(state, "status.airCtrlOn")

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -276,6 +276,9 @@ class KiaUvoApiCA(ApiImpl):
         vehicle.washer_fluid_warning_is_on = get_child_value(
             state, "status.washerFluidStatus"
         )
+        vehicle.brake_fluid_warning_is_on = get_child_value(
+            state, "status.breakOilStatus"
+        )
         vehicle.tire_pressure_rear_left_warning_is_on = bool(
             get_child_value(state, "status.tirePressureLamp.tirePressureLampRL")
         )

--- a/hyundai_kia_connect_api/KiaUvoApiCN.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCN.py
@@ -617,6 +617,9 @@ class KiaUvoApiCN(ApiImpl):
         vehicle.washer_fluid_warning_is_on = get_child_value(
             state, "status.washerFluidStatus"
         )
+        vehicle.brake_fluid_warning_is_on = get_child_value(
+            state, "status.breakOilStatus"
+        )
         vehicle.fuel_level = get_child_value(state, "status.fuelLevel")
         vehicle.fuel_level_is_low = get_child_value(state, "status.lowFuelLight")
         vehicle.air_control_is_on = get_child_value(state, "status.airCtrlOn")

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -707,6 +707,9 @@ class KiaUvoApiEU(ApiImpl):
         vehicle.washer_fluid_warning_is_on = get_child_value(
             state, "vehicleStatus.washerFluidStatus"
         )
+        vehicle.brake_fluid_warning_is_on = get_child_value(
+            state, "vehicleStatus.breakOilStatus"
+        )
         vehicle.fuel_level = get_child_value(state, "vehicleStatus.fuelLevel")
         vehicle.fuel_level_is_low = get_child_value(state, "vehicleStatus.lowFuelLight")
         vehicle.air_control_is_on = get_child_value(state, "vehicleStatus.airCtrlOn")


### PR DESCRIPTION
Implemented support for the field brake_fluid_warning_is_on which was already present in Vehicle but not filled by the APIs.
I tested it with my EU car and it seems to work properly.