### PR TITLE
fix: Add login token lifetime to consts and use it in all API clients

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoAPIUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoAPIUSA.py
@@ -18,11 +18,12 @@ from .ApiImpl import ApiImpl, ClimateRequestOptions
 from .Token import Token
 from .Vehicle import Vehicle
 from .const import (
-    DOMAIN,
-    VEHICLE_LOCK_ACTION,
-    TEMPERATURE_UNITS,
     DISTANCE_UNITS,
+    DOMAIN,
+    LOGIN_TOKEN_LIFETIME,
     OrderStatus,
+    TEMPERATURE_UNITS,
+    VEHICLE_LOCK_ACTION,
 )
 from .utils import get_child_value
 
@@ -176,7 +177,7 @@ class KiaUvoAPIUSA(ApiImpl):
                 f"{DOMAIN} - No session id returned in login. Response: {response.text} headers {response.headers} cookies {response.cookies}"  # noqa
             )
         _LOGGER.debug(f"got session id {session_id}")
-        valid_until = dt.datetime.now(pytz.utc) + dt.timedelta(hours=1)
+        valid_until = dt.datetime.now(pytz.utc) + LOGIN_TOKEN_LIFETIME
         return Token(
             username=username,
             password=password,

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -15,17 +15,18 @@ from .ApiImpl import ApiImpl, ClimateRequestOptions
 from .Token import Token
 from .Vehicle import Vehicle
 from .const import (
+    BRAND_GENESIS,
     BRAND_HYUNDAI,
     BRAND_KIA,
-    BRAND_GENESIS,
     BRANDS,
-    DOMAIN,
     DISTANCE_UNITS,
-    TEMPERATURE_UNITS,
-    SEAT_STATUS,
+    DOMAIN,
     ENGINE_TYPES,
-    VEHICLE_LOCK_ACTION,
+    LOGIN_TOKEN_LIFETIME,
     OrderStatus,
+    SEAT_STATUS,
+    TEMPERATURE_UNITS,
+    VEHICLE_LOCK_ACTION,
 )
 
 from .exceptions import AuthenticationError, APIError
@@ -133,7 +134,7 @@ class KiaUvoApiCA(ApiImpl):
         _LOGGER.debug(f"{DOMAIN} - Access Token Value {access_token}")
         _LOGGER.debug(f"{DOMAIN} - Refresh Token Value {refresh_token}")
 
-        valid_until = dt.datetime.now(pytz.utc) + dt.timedelta(hours=23)
+        valid_until = dt.datetime.now(pytz.utc) + LOGIN_TOKEN_LIFETIME
 
         return Token(
             username=username,

--- a/hyundai_kia_connect_api/KiaUvoApiCN.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCN.py
@@ -31,14 +31,15 @@ from .const import (
     BRAND_HYUNDAI,
     BRAND_KIA,
     BRANDS,
-    DOMAIN,
-    DISTANCE_UNITS,
-    TEMPERATURE_UNITS,
-    SEAT_STATUS,
-    VEHICLE_LOCK_ACTION,
     CHARGE_PORT_ACTION,
+    DISTANCE_UNITS,
+    DOMAIN,
     ENGINE_TYPES,
+    LOGIN_TOKEN_LIFETIME,
     OrderStatus,
+    SEAT_STATUS,
+    TEMPERATURE_UNITS,
+    VEHICLE_LOCK_ACTION,
 )
 from .exceptions import *
 from .utils import (
@@ -158,7 +159,7 @@ class KiaUvoApiCN(ApiImpl):
 
         _, access_token, authorization_code = self._get_access_token(authorization_code)
         _, refresh_token = self._get_refresh_token(authorization_code)
-        valid_until = dt.datetime.now(pytz.utc) + dt.timedelta(hours=23)
+        valid_until = dt.datetime.now(pytz.utc) + LOGIN_TOKEN_LIFETIME
 
         return Token(
             username=username,

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -29,18 +29,19 @@ from .Vehicle import (
     DayTripCounts,
 )
 from .const import (
+    BRAND_GENESIS,
     BRAND_HYUNDAI,
     BRAND_KIA,
-    BRAND_GENESIS,
     BRANDS,
-    DOMAIN,
-    DISTANCE_UNITS,
-    TEMPERATURE_UNITS,
-    SEAT_STATUS,
-    VEHICLE_LOCK_ACTION,
     CHARGE_PORT_ACTION,
+    DISTANCE_UNITS,
+    DOMAIN,
     ENGINE_TYPES,
+    LOGIN_TOKEN_LIFETIME,
     OrderStatus,
+    SEAT_STATUS,
+    TEMPERATURE_UNITS,
+    VEHICLE_LOCK_ACTION,
 )
 from .exceptions import *
 from .utils import (
@@ -250,7 +251,7 @@ class KiaUvoApiEU(ApiImpl):
             stamp, authorization_code
         )
         _, refresh_token = self._get_refresh_token(stamp, authorization_code)
-        valid_until = dt.datetime.now(pytz.utc) + dt.timedelta(hours=23)
+        valid_until = dt.datetime.now(pytz.utc) + LOGIN_TOKEN_LIFETIME
 
         return Token(
             username=username,

--- a/hyundai_kia_connect_api/const.py
+++ b/hyundai_kia_connect_api/const.py
@@ -1,6 +1,7 @@
 """const.py"""
 # pylint:disable=invalid-name,missing-class-docstring
 
+import datetime
 from enum import Enum, IntEnum
 
 DOMAIN: str = "hyundai_kia_connect_api"
@@ -22,6 +23,8 @@ REGIONS = {
     4: REGION_CHINA,
     5: REGION_AUSTRALIA,
 }
+
+LOGIN_TOKEN_LIFETIME = datetime.timedelta(hours=23)
 
 LENGTH_KILOMETERS = "km"
 LENGTH_MILES = "mi"


### PR DESCRIPTION
fix: Add the token lifetime to `const.py` and use the value across all API endpoints.