### PR TITLE
fix: convert heat/cool seating option from string to int

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoAPIUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoAPIUSA.py
@@ -649,32 +649,32 @@ class KiaUvoAPIUSA(ApiImpl):
         rear_right_heatVentLevel = 0
 
         # heated
-        if options.front_left_seat in (6, 7, 8):
+        if int(options.front_left_seat) in (6, 7, 8):
             front_left_heatVentType = 1
-            front_left_heatVentLevel = options.front_left_seat - 4
-        if options.front_right_seat in (6, 7, 8):
+            front_left_heatVentLevel = int(options.front_left_seat) - 4
+        if int(options.front_right_seat) in (6, 7, 8):
             front_right_heatVentType = 1
-            front_right_heatVentLevel = options.front_right_seat - 4
-        if options.rear_left_seat in (6, 7, 8):
+            front_right_heatVentLevel = int(options.front_right_seat) - 4
+        if int(options.rear_left_seat) in (6, 7, 8):
             rear_left_heatVentType = 1
-            rear_left_heatVentLevel = options.rear_left_seat - 4
-        if options.rear_right_seat in (6, 7, 8):
+            rear_left_heatVentLevel = int(options.rear_left_seat) - 4
+        if int(options.rear_right_seat) in (6, 7, 8):
             rear_right_heatVentType = 1
-            rear_right_heatVentLevel = options.rear_right_seat - 4
+            rear_right_heatVentLevel = int(options.rear_right_seat) - 4
 
         # ventilated
-        if options.front_left_seat in (3, 4, 5):
+        if int(options.front_left_seat) in (3, 4, 5):
             front_left_heatVentType = 2
-            front_left_heatVentLevel = options.front_left_seat - 1
-        if options.front_right_seat in (3, 4, 5):
+            front_left_heatVentLevel = int(options.front_left_seat) - 1
+        if int(options.front_right_seat) in (3, 4, 5):
             front_right_heatVentType = 2
-            front_right_heatVentLevel = options.front_right_seat - 1
-        if options.rear_left_seat in (3, 4, 5):
+            front_right_heatVentLevel = int(options.front_right_seat) - 1
+        if int(options.rear_left_seat) in (3, 4, 5):
             rear_left_heatVentType = 2
-            rear_left_heatVentLevel = options.rear_left_seat - 1
-        if options.rear_right_seat in (3, 4, 5):
+            rear_left_heatVentLevel = int(options.rear_left_seat) - 1
+        if int(options.rear_right_seat) in (3, 4, 5):
             rear_right_heatVentType = 2
-            rear_right_heatVentLevel = options.rear_right_seat - 1
+            rear_right_heatVentLevel = int(options.rear_right_seat) - 1
 
         body = {
             "remoteClimate": {


### PR DESCRIPTION
these values are set as a string when you configure these properties with the UI. this is a dirty hack for now. is it possible to have the UI configurator set these are ints instead of strings? then we couldn't need this.