### PR TITLE
feat(USA): Expose EV Trip Details (#473)

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
@@ -177,6 +177,9 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
         return status
 
     def _get_ev_trip_details(self, token: Token, vehicle: Vehicle) -> dict:
+        if vehicle.engine_type != ENGINE_TYPES.EV:
+            return {}
+
         url = self.API_URL + "ts/alerts/maintenance/evTripDetails"
         headers = self._get_vehicle_headers(token, vehicle)
         headers["userId"] = headers["username"]
@@ -431,7 +434,7 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
         vehicle.air_control_is_on = get_child_value(state, "vehicleStatus.airCtrlOn")
 
         tripStats = []
-        tripDetails = get_child_value(state, "evTripDetails.tripdetails")
+        tripDetails = get_child_value(state, "evTripDetails.tripdetails") or {}
         for trip in tripDetails:
             processedTrip = DailyDrivingStats(
                 date=dt.datetime.strptime(trip["startdate"], "%Y-%m-%d %H:%M:%S.%f"),

--- a/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
@@ -21,10 +21,7 @@ from .const import (
 from .utils import get_child_value, get_float
 from .ApiImpl import ApiImpl, ClimateRequestOptions
 from .Token import Token
-from .Vehicle import (
-    DailyDrivingStats,
-    Vehicle
-)
+from .Vehicle import DailyDrivingStats, Vehicle
 
 
 CIPHERS = "DEFAULT@SECLEVEL=1"
@@ -441,12 +438,8 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
                 total_consumed=get_child_value(trip, "totalused"),
                 engine_consumption=get_child_value(trip, "drivetrain"),
                 climate_consumption=get_child_value(trip, "climate"),
-                onboard_electronics_consumption=get_child_value(
-                    trip, "accessories"
-                ),
-                battery_care_consumption=get_child_value(
-                    trip, "batterycare"
-                ),
+                onboard_electronics_consumption=get_child_value(trip, "accessories"),
+                battery_care_consumption=get_child_value(trip, "batterycare"),
                 regenerated_energy=get_child_value(trip, "regen"),
                 distance=get_child_value(trip, "distance"),
             )


### PR DESCRIPTION
The US version of the MyHyundai app shows some details about the most recent trips; extract and expose this.

This change uses the same API call to pull the trip data and add to `vehicle.daily_stats`. The data in the Hyundai API response matches exactly with the existing EU `Vehicle.DailyDrivingStats`, so I reused that data structure despite the slight name difference.

A simple example:

```python
#!/usr/bin/env python3

from hyundai_kia_connect_api import *
import pprint

vm = VehicleManager(region=3, brand=2, username="me@example.com", password="hunter2", pin="1234")
vm.check_and_refresh_token()

vm.update_all_vehicles_with_cached_state()

for v in vm.vehicles:
    pprint.pprint(vm.vehicles[v].name)
    for s in vm.vehicles[v].daily_stats:
        # Avoid DIV0
        distance = (s.distance if s.distance > 0 else 1)
        # Total watt hours per mile
        whpmi = int(s.total_consumed / distance)
        # "Overhead" (anything except engine) Watt hours per mile
        whpmi_overhead = int((s.climate_consumption + s.onboard_electronics_consumption + s.onboard_electronics_consumption) / distance)
        # Regeneration as a percentage of total consumption
        regen_pct = int((s.regenerated_energy / s.total_consumed) * 100)

        print(f"{s.date} - {s.distance} miles - {s.total_consumed} watt hours - {whpmi} Wh/mi - {whpmi_overhead} Wh/mi overhead - {regen_pct}% regen pct")

    pprint.pprint(vm.vehicles[v].daily_stats)
```

And output:

```
$ python3 example.py
hyundai_kia_connect_api - get vehicle location rate limit exceeded.
'2023 IONIQ 5'
2024-01-04 21:11:45 - 1 miles - 509 watt hours - 509 Wh/mi - 320 Wh/mi overhead - 82% regen pct
2024-01-04 20:44:01 - 1 miles - 751 watt hours - 751 Wh/mi - 335 Wh/mi overhead - 72% regen pct
```