### PR TITLE
fix: Fix temperature range to include 82 degrees as max

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoAPIUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoAPIUSA.py
@@ -94,7 +94,7 @@ class KiaUvoAPIUSA(ApiImpl):
 
     def __init__(self, region: int, brand: int, language) -> None:
         self.LANGUAGE: str = language
-        self.temperature_range = range(62, 82)
+        self.temperature_range = range(62, 83)
 
         # Randomly generate a plausible device id on startup
         self.device_id = (


### PR DESCRIPTION
I changed the temperature_range from `range(62, 82)` to `range(62, 83)` so the range includes 82 degrees, which is the max temp setting supported by the USA api prior to changing to HIGH. As it is currently, when the car reads HIGH, the api reads 81, which is incorrect. In reality even 82 is technically incorrect, as 82 comes before HIGH, but I think it's reasonable to cap the display to that in order to avoid mixing numbers and strings (if one were to try and actually display "HIGH"). 