### PR TITLE
fix(EU): fill Vehicle.ev_driving_range with Vehicle.total_driving_range for cc2 for pure EV to have similar behaviour for non-cc2 

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -535,8 +535,6 @@ class KiaUvoApiEU(ApiImpl):
         elif charging_door_state == 1:
             vehicle.ev_charge_port_door_is_open = True
 
-        # TODO: vehicle.ev_driving_range
-
         vehicle.total_driving_range = (
             float(
                 get_child_value(
@@ -551,6 +549,14 @@ class KiaUvoApiEU(ApiImpl):
                 )
             ],
         )
+
+        if vehicle.engine_type == ENGINE_TYPES.EV:
+            # ev_driving_range is the same as total_driving_range for pure EV
+            vehicle.ev_driving_range = (
+                vehicle.total_driving_range,
+                vehicle.total_driving_range_unit,
+            )
+        # TODO: vehicle.ev_driving_range for non EV
 
         vehicle.washer_fluid_warning_is_on = get_child_value(
             state, "Body.Windshield.Front.WasherFluid.LevelLow"


### PR DESCRIPTION
A Kona Model 2024 user complained about the non-filled Vehicle.ev_total_driving_range. In the debug log I do not see this information for this cc2 model. When it is a pure EV, the Vehicle.ev_total_driving_range should be identical to the Vehicle.total_driving_range, as is with non-cc2 EU API. 

So for pure EV, this can be fixed for cc2 models (identical behaviour for cc2 and non-cc2 users of the API), to fill Vehicle.ev_total_driving_range with Vehicle.ev_total_driving_range. For non pure EV's (e.g. PHEV) it should be investigated further how to get the Vehicle.ev_total_driving_range (TODO kept).