### PR TITLE
fix(EU): sort daily stats for same behaviour between cc2 and non-cc2

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -1387,6 +1387,12 @@ class KiaUvoApiEU(ApiImpl):
                     )
                     break
 
+            daily_stats = drivingInfo["dailyStats"]
+            _LOGGER.debug(f"KiaUvoApiEU: before daily_stats: {daily_stats}")  # noqa
+            if len(daily_stats) > 0:  # sort on decreasing date
+                daily_stats.sort(reverse=True, key=lambda k: k.date)
+                drivingInfo["dailyStats"] = daily_stats
+                _LOGGER.debug(f"KiaUvoApiEU: after  daily_stats: {daily_stats}")  # noqa
             return drivingInfo
         else:
             _LOGGER.debug(


### PR DESCRIPTION
For non cc2 the behaviour was that the daily stats were sorted by the bluelink/Connect server.

This previous pull request already sorted daily stats: https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/pull/498

However, it appeared that the following was not yet sorted: drivingInfo["dailyStats"]


