### PR TITLE
fix: step over calculativeodo if not found or zero, to avoid exceptions.

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -1379,7 +1379,15 @@ class KiaUvoApiEU(ApiImpl):
             for drivingInfoItem in response30d["resMsg"]["drivingInfo"]:
                 if (
                     drivingInfoItem["drivingPeriod"] == 0
-                    and next((v for k, v in drivingInfoItem.items() if k.lower() == "calculativeodo"), 0) > 0
+                    and next(
+                        (
+                            v
+                            for k, v in drivingInfoItem.items()
+                            if k.lower() == "calculativeodo"
+                        ),
+                        0,
+                    )
+                    > 0
                 ):
                     drivingInfo["consumption30d"] = round(
                         drivingInfoItem["totalPwrCsp"]

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -1379,7 +1379,7 @@ class KiaUvoApiEU(ApiImpl):
             for drivingInfoItem in response30d["resMsg"]["drivingInfo"]:
                 if (
                     drivingInfoItem["drivingPeriod"] == 0
-                    and drivingInfoItem["calculativeOdo"] > 0
+                    and next((v for k, v in drivingInfoItem.items() if k.lower() == "calculativeodo"), 0) > 0
                 ):
                     drivingInfo["consumption30d"] = round(
                         drivingInfoItem["totalPwrCsp"]


### PR DESCRIPTION
For vechicles lacking CalculativeOdo in the eu, this change means that it will silently continue and not throw as is in the current version. 
Fixes the exception mentioned in https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/842.
Note, if this key is actually suposed to be present for all vechicles (including phev which seems to be the issue here), then this will just hush the exception and obv not fix the main issue.