### PR TITLE
feat(EU): Support setting the charging current

### DIFF
--- a/hyundai_kia_connect_api/ApiImpl.py
+++ b/hyundai_kia_connect_api/ApiImpl.py
@@ -146,6 +146,12 @@ class ApiImpl:
         """Sets charge limits. Returns the tracking ID"""
         pass
 
+    def set_charging_current(
+        self, token: Token, vehicle: Vehicle, level: int
+    ) -> str:
+    """Sets charge current level (1=100%, 2=90%, 3=60%). Returns the tracking ID"""
+    pass
+
     def set_windows_state(
         self, token: Token, vehicle: Vehicle, options: WindowRequestOptions
     ) -> str:

--- a/hyundai_kia_connect_api/ApiImpl.py
+++ b/hyundai_kia_connect_api/ApiImpl.py
@@ -146,9 +146,7 @@ class ApiImpl:
         """Sets charge limits. Returns the tracking ID"""
         pass
 
-    def set_charging_current(
-        self, token: Token, vehicle: Vehicle, level: int
-    ) -> str:
+    def set_charging_current(self, token: Token, vehicle: Vehicle, level: int) -> str:
         """Sets charge current level (1=100%, 2=90%, 3=60%). Returns the tracking ID"""
         pass
 

--- a/hyundai_kia_connect_api/ApiImpl.py
+++ b/hyundai_kia_connect_api/ApiImpl.py
@@ -149,8 +149,8 @@ class ApiImpl:
     def set_charging_current(
         self, token: Token, vehicle: Vehicle, level: int
     ) -> str:
-    """Sets charge current level (1=100%, 2=90%, 3=60%). Returns the tracking ID"""
-    pass
+        """Sets charge current level (1=100%, 2=90%, 3=60%). Returns the tracking ID"""
+        pass
 
     def set_windows_state(
         self, token: Token, vehicle: Vehicle, options: WindowRequestOptions

--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -231,6 +231,9 @@ class ApiImplType1(ApiImpl):
         vehicle.ev_charge_limits_dc = get_child_value(
             state, "Green.ChargingInformation.TargetSoC.Quick"
         )
+        vehicle.ev_charging_current = get_child_value(
+            state, "Green.ChargingInformation.ElectricCurrentLevel.State"
+        )
         vehicle.ev_v2l_discharge_limit = get_child_value(
             state, "Green.Electric.SmartGrid.VehicleToLoad.DischargeLimitation.SoC"
         )

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -1285,6 +1285,25 @@ class KiaUvoApiEU(ApiImplType1):
         _check_response_for_errors(response)
         return response["msgId"]
 
+    def set_charging_current(
+        self, token: Token, vehicle: Vehicle, level: int
+    ) -> str:
+        url = self.SPA_API_URL + "vehicles/" + vehicle.id + "/ccs2/charge/chargingcurrent"
+
+        body = {
+            "chargingCurrent": level
+        }
+        response = requests.post(
+            url,
+            json=body,
+            headers=self._get_authenticated_headers(
+                token, vehicle.ccu_ccs2_protocol_support
+            ),
+        ).json()
+        _LOGGER.debug(f"{DOMAIN} - Set Charging Current Response: {response}")
+        _check_response_for_errors(response)
+        return response["msgId"]
+
     def schedule_charging_and_climate(
         self,
         token: Token,

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -1285,14 +1285,12 @@ class KiaUvoApiEU(ApiImplType1):
         _check_response_for_errors(response)
         return response["msgId"]
 
-    def set_charging_current(
-        self, token: Token, vehicle: Vehicle, level: int
-    ) -> str:
-        url = self.SPA_API_URL + "vehicles/" + vehicle.id + "/ccs2/charge/chargingcurrent"
+    def set_charging_current(self, token: Token, vehicle: Vehicle, level: int) -> str:
+        url = (
+            self.SPA_API_URL + "vehicles/" + vehicle.id + "/ccs2/charge/chargingcurrent"
+        )
 
-        body = {
-            "chargingCurrent": level
-        }
+        body = {"chargingCurrent": level}
         response = requests.post(
             url,
             json=body,

--- a/hyundai_kia_connect_api/Vehicle.py
+++ b/hyundai_kia_connect_api/Vehicle.py
@@ -159,7 +159,7 @@ class Vehicle:
 
     ev_charge_limits_dc: typing.Union[int, None] = None
     ev_charge_limits_ac: typing.Union[int, None] = None
-    ev_charging_current: typing.Union[int, None] = None # Europe feature only
+    ev_charging_current: typing.Union[int, None] = None  # Europe feature only
     ev_v2l_discharge_limit: typing.Union[int, None] = None
 
     # energy consumed and regenerated since the vehicle was paired with the account

--- a/hyundai_kia_connect_api/Vehicle.py
+++ b/hyundai_kia_connect_api/Vehicle.py
@@ -159,6 +159,7 @@ class Vehicle:
 
     ev_charge_limits_dc: typing.Union[int, None] = None
     ev_charge_limits_ac: typing.Union[int, None] = None
+    ev_charging_current: typing.Union[int, None] = None # Europe feature only
     ev_v2l_discharge_limit: typing.Union[int, None] = None
 
     # energy consumed and regenerated since the vehicle was paired with the account


### PR DESCRIPTION
Hi! I noticed this feature missing and I have a need for it (including others apparently: https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/864).

I sniffed the traffic on my EU app, so I don't know if other regions also have support for this, the above mentioned issue has screenshots in German so that is EU too :)

With this implemented we can set the charging current to 60%, 90% or 100%