### PR TITLE
feat: Add AC and DC charge limits for Hyundai USA Bluelink

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
@@ -377,6 +377,19 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
         vehicle.ev_battery_is_plugged_in = get_child_value(
             state, "vehicleStatus.evStatus.batteryPlugin"
         )
+        ChargeDict = get_child_value(
+            state, "vehicleStatus.evStatus.reservChargeInfos.targetSOClist"
+        )
+        try:
+            vehicle.ev_charge_limits_ac = [
+                x["targetSOClevel"] for x in ChargeDict if x["plugType"] == 1
+            ][-1]
+            vehicle.ev_charge_limits_dc = [
+                x["targetSOClevel"] for x in ChargeDict if x["plugType"] == 0
+            ][-1]
+        except Exception:
+            _LOGGER.debug(f"{DOMAIN} - SOC Levels couldn't be found. May not be an EV.")
+
         vehicle.ev_driving_range = (
             get_child_value(
                 state,


### PR DESCRIPTION
The Bluelink API returns AC and DC charge limit data for EVs, similar to Kia's API. This change selects for it identically to KiaUvoAPIUSA.py, but with the correct object path for Bluelink's API response.