### PR TITLE
fix: SSL error for USA KIA

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoAPIUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoAPIUSA.py
@@ -37,7 +37,6 @@ _LOGGER = logging.getLogger(__name__)
 # This is the key part of our patch. We get the standard SSLContext that requests would
 # normally use, and add ciphers that Kia USA may need for compatibility.
 class KiaSSLAdapter(HTTPAdapter):
-    
     def init_poolmanager(self, *args, **kwargs):
         context = create_urllib3_context(
             ciphers="DEFAULT:@SECLEVEL=1", ssl_version=ssl.PROTOCOL_TLSv1_2

--- a/hyundai_kia_connect_api/KiaUvoAPIUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoAPIUSA.py
@@ -37,10 +37,12 @@ _LOGGER = logging.getLogger(__name__)
 # This is the key part of our patch. We get the standard SSLContext that requests would
 # normally use, and add ciphers that Kia USA may need for compatibility.
 class KiaSSLAdapter(HTTPAdapter):
+    
     def init_poolmanager(self, *args, **kwargs):
         context = create_urllib3_context(
             ciphers="DEFAULT:@SECLEVEL=1", ssl_version=ssl.PROTOCOL_TLSv1_2
         )
+        context.options |= 0x4
         kwargs["ssl_context"] = context
         kwargs["ca_certs"] = certifi.where()
         return super().init_poolmanager(*args, **kwargs)


### PR DESCRIPTION
Hi.  Sorry for the out of the blue PR from a random contributor on the internet.

Please see https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/913

This PR sets the 0x4 flag on the SSL context for the KIA USA SSL adapter.

Thank you for your great work!