### PR TITLE
fix: sort daily_stats for all implementations in setter of Vehicle.daily_stats

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,16 +89,16 @@ For a list of language codes, see here: https://www.science.co.il/language/Codes
 - "pt" Portuguese
 
 
-In Europe also trip info can be retrieved. For a month you can ask the days with trips. And you can ask for a specific day for all the trips of that specific day.::
-- First call vm.update_month_trip_info(vehicle.id, yyymm) before getting vehicle.month_trip_info for that month
+In Europe and some other regions also trip info can be retrieved. For a month you can ask the days with trips. And you can ask for a specific day for all the trips of that specific day.::
+- First call vm.update_month_trip_info(vehicle.id, yyyymm) before getting vehicle.month_trip_info for that month
 - First call vm.update_day_trip_info(vehicle.id, day.yyyymmdd) before getting vehicle.day_trip_info for that day
 
 Example of getting trip info of the current month and day (vm is VehicleManager instance)::
 
     now = datetime.now()
-    yyymm = now.strftime("%Y%m")
+    yyyymm = now.strftime("%Y%m")
     yyyymmdd = now.strftime("%Y%m%d")
-    vm.update_month_trip_info(vehicle.id, yyymm)
+    vm.update_month_trip_info(vehicle.id, yyyymm)
     if vehicle.month_trip_info is not None:
         for day in vehicle.month_trip_info.day_list:  # ordered on day
             if yyyymmdd == day.yyyymmdd:  # in example only interested in current day

--- a/hyundai_kia_connect_api/ApiImpl.py
+++ b/hyundai_kia_connect_api/ApiImpl.py
@@ -1,6 +1,6 @@
 """ApiImpl.py"""
 
-# pylint:disable=unnecessary-pass,missing-class-docstring,invalid-name,missing-function-docstring,wildcard-import,unused-wildcard-import,unused-argument,missing-timeout
+# pylint:disable=unnecessary-pass,missing-class-docstring,invalid-name,missing-function-docstring,wildcard-import,unused-wildcard-import,unused-argument,missing-timeout,logging-fstring-interpolation
 
 import datetime as dt
 import logging
@@ -158,7 +158,7 @@ class ApiImpl:
 
     def set_charging_current(self, token: Token, vehicle: Vehicle, level: int) -> str:
         """
-        Europe feature only.
+        feature only available for some regions.
         Sets charge current level (1=100%, 2=90%, 3=60%). Returns the tracking ID
         """
         pass
@@ -179,7 +179,7 @@ class ApiImpl:
         self, token: Token, vehicle: Vehicle, yyyymm_string: str
     ) -> None:
         """
-        Europe feature only.
+        feature only available for some regions.
         Updates the vehicle.month_trip_info for the specified month.
 
         Default this information is None:
@@ -192,7 +192,7 @@ class ApiImpl:
         self, token: Token, vehicle: Vehicle, yyyymmdd_string: str
     ) -> None:
         """
-        Europe feature only.
+        feature only available for some regions.
         Updates the vehicle.day_trip_info information for the specified day.
 
         Default this information is None:
@@ -208,7 +208,7 @@ class ApiImpl:
         options: ScheduleChargingClimateRequestOptions,
     ) -> str:
         """
-        Europe feature only.
+        feature only available for some regions.
         Schedule charging and climate control. Returns the tracking ID
         """
         pass

--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -1,3 +1,5 @@
+""""ApiImplType1.py"""
+
 import datetime as dt
 from typing import Optional
 
@@ -23,6 +25,8 @@ USER_AGENT_OK_HTTP: str = "okhttp/3.12.0"
 
 
 class ApiImplType1(ApiImpl):
+    """ApiImplType1"""
+
     def __init__(self) -> None:
         """Initialize."""
 

--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -1,4 +1,4 @@
-""""ApiImplType1.py"""
+""" "ApiImplType1.py"""
 
 import datetime as dt
 from typing import Optional

--- a/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
@@ -710,6 +710,6 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
 
         response = self.sessions.post(url, json=data, headers=headers)
         _LOGGER.debug(
-            f"{DOMAIN} - Setting charge limits response status code: {response.status_code}"
+            f"{DOMAIN} - Setting charge limits response status code: {response.status_code}"  # noqa
         )
         _LOGGER.debug(f"{DOMAIN} - Setting charge limits: {response.text}")

--- a/hyundai_kia_connect_api/KiaUvoApiAU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiAU.py
@@ -62,7 +62,9 @@ from .utils import (
 _LOGGER = logging.getLogger(__name__)
 
 USER_AGENT_OK_HTTP: str = "okhttp/3.12.0"
-USER_AGENT_MOZILLA: str = "Mozilla/5.0 (Linux; Android 4.1.1; Galaxy Nexus Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19"  # noqa
+USER_AGENT_MOZILLA: str = (
+    "Mozilla/5.0 (Linux; Android 4.1.1; Galaxy Nexus Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19"  # noqa
+)
 
 
 def _check_response_for_errors(response: dict) -> None:
@@ -113,12 +115,16 @@ class KiaUvoApiAU(ApiImplType1):
             self.BASE_URL: str = "au-apigw.ccs.kia.com.au:8082"
             self.CCSP_SERVICE_ID: str = "8acb778a-b918-4a8d-8624-73a0beb64289"
             self.APP_ID: str = "4ad4dcde-be23-48a8-bc1c-91b94f5c06f8"  # Android app ID
-            self.BASIC_AUTHORIZATION: str = "Basic OGFjYjc3OGEtYjkxOC00YThkLTg2MjQtNzNhMGJlYjY0Mjg5OjdTY01NbTZmRVlYZGlFUEN4YVBhUW1nZVlkbFVyZndvaDRBZlhHT3pZSVMyQ3U5VA=="
+            self.BASIC_AUTHORIZATION: str = (
+                "Basic OGFjYjc3OGEtYjkxOC00YThkLTg2MjQtNzNhMGJlYjY0Mjg5OjdTY01NbTZmRVlYZGlFUEN4YVBhUW1nZVlkbFVyZndvaDRBZlhHT3pZSVMyQ3U5VA=="  # noqa
+            )
         elif BRANDS[brand] == BRAND_HYUNDAI:
             self.BASE_URL: str = "au-apigw.ccs.hyundai.com.au:8080"
             self.CCSP_SERVICE_ID: str = "855c72df-dfd7-4230-ab03-67cbf902bb1c"
             self.APP_ID: str = "f9ccfdac-a48d-4c57-bd32-9116963c24ed"  # Android app ID
-            self.BASIC_AUTHORIZATION: str = "Basic ODU1YzcyZGYtZGZkNy00MjMwLWFiMDMtNjdjYmY5MDJiYjFjOmU2ZmJ3SE0zMllOYmhRbDBwdmlhUHAzcmY0dDNTNms5MWVjZUEzTUpMZGJkVGhDTw=="
+            self.BASIC_AUTHORIZATION: str = (
+                "Basic ODU1YzcyZGYtZGZkNy00MjMwLWFiMDMtNjdjYmY5MDJiYjFjOmU2ZmJ3SE0zMllOYmhRbDBwdmlhUHAzcmY0dDNTNms5MWVjZUEzTUpMZGJkVGhDTw=="  # noqa
+            )
 
         self.USER_API_URL: str = "https://" + self.BASE_URL + "/api/v1/user/"
         self.SPA_API_URL: str = "https://" + self.BASE_URL + "/api/v1/spa/"
@@ -847,7 +853,7 @@ class KiaUvoApiAU(ApiImplType1):
         yyyymm_string,
     ) -> None:
         """
-        Europe feature only.
+        feature only available for some regions.
         Updates the vehicle.month_trip_info for the specified month.
 
         Default this information is None:
@@ -891,7 +897,7 @@ class KiaUvoApiAU(ApiImplType1):
         yyyymmdd_string,
     ) -> None:
         """
-        Europe feature only.
+        feature only available for some regions.
         Updates the vehicle.day_trip_info information for the specified day.
 
         Default this information is None:

--- a/hyundai_kia_connect_api/KiaUvoApiAU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiAU.py
@@ -62,9 +62,7 @@ from .utils import (
 _LOGGER = logging.getLogger(__name__)
 
 USER_AGENT_OK_HTTP: str = "okhttp/3.12.0"
-USER_AGENT_MOZILLA: str = (
-    "Mozilla/5.0 (Linux; Android 4.1.1; Galaxy Nexus Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19"  # noqa
-)
+USER_AGENT_MOZILLA: str = "Mozilla/5.0 (Linux; Android 4.1.1; Galaxy Nexus Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19"  # noqa
 
 
 def _check_response_for_errors(response: dict) -> None:
@@ -115,16 +113,12 @@ class KiaUvoApiAU(ApiImplType1):
             self.BASE_URL: str = "au-apigw.ccs.kia.com.au:8082"
             self.CCSP_SERVICE_ID: str = "8acb778a-b918-4a8d-8624-73a0beb64289"
             self.APP_ID: str = "4ad4dcde-be23-48a8-bc1c-91b94f5c06f8"  # Android app ID
-            self.BASIC_AUTHORIZATION: str = (
-                "Basic OGFjYjc3OGEtYjkxOC00YThkLTg2MjQtNzNhMGJlYjY0Mjg5OjdTY01NbTZmRVlYZGlFUEN4YVBhUW1nZVlkbFVyZndvaDRBZlhHT3pZSVMyQ3U5VA=="  # noqa
-            )
+            self.BASIC_AUTHORIZATION: str = "Basic OGFjYjc3OGEtYjkxOC00YThkLTg2MjQtNzNhMGJlYjY0Mjg5OjdTY01NbTZmRVlYZGlFUEN4YVBhUW1nZVlkbFVyZndvaDRBZlhHT3pZSVMyQ3U5VA=="  # noqa
         elif BRANDS[brand] == BRAND_HYUNDAI:
             self.BASE_URL: str = "au-apigw.ccs.hyundai.com.au:8080"
             self.CCSP_SERVICE_ID: str = "855c72df-dfd7-4230-ab03-67cbf902bb1c"
             self.APP_ID: str = "f9ccfdac-a48d-4c57-bd32-9116963c24ed"  # Android app ID
-            self.BASIC_AUTHORIZATION: str = (
-                "Basic ODU1YzcyZGYtZGZkNy00MjMwLWFiMDMtNjdjYmY5MDJiYjFjOmU2ZmJ3SE0zMllOYmhRbDBwdmlhUHAzcmY0dDNTNms5MWVjZUEzTUpMZGJkVGhDTw=="  # noqa
-            )
+            self.BASIC_AUTHORIZATION: str = "Basic ODU1YzcyZGYtZGZkNy00MjMwLWFiMDMtNjdjYmY5MDJiYjFjOmU2ZmJ3SE0zMllOYmhRbDBwdmlhUHAzcmY0dDNTNms5MWVjZUEzTUpMZGJkVGhDTw=="  # noqa
 
         self.USER_API_URL: str = "https://" + self.BASE_URL + "/api/v1/user/"
         self.SPA_API_URL: str = "https://" + self.BASE_URL + "/api/v1/spa/"

--- a/hyundai_kia_connect_api/KiaUvoApiCN.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCN.py
@@ -6,6 +6,7 @@ import datetime as dt
 import math
 import logging
 import uuid
+from typing import Optional
 from time import sleep
 from urllib.parse import parse_qs, urlparse
 
@@ -61,8 +62,12 @@ from .utils import (
 _LOGGER = logging.getLogger(__name__)
 
 USER_AGENT_OK_HTTP: str = "okhttp/3.12.0"
-USER_AGENT_MOZILLA: str = "Mozilla/5.0 (Linux; Android 4.1.1; Galaxy Nexus Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19"  # noqa
-ACCEPT_HEADER_ALL: str = "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"  # noqa
+USER_AGENT_MOZILLA: str = (
+    "Mozilla/5.0 (Linux; Android 4.1.1; Galaxy Nexus Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19"  # noqa
+)
+ACCEPT_HEADER_ALL: str = (
+    "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"  # noqa
+)
 
 
 def _check_response_for_errors(response: dict) -> None:
@@ -112,7 +117,9 @@ class KiaUvoApiCN(ApiImplType1):
             self.BASE_DOMAIN: str = "prd.cn-ccapi.kia.com"
             self.CCSP_SERVICE_ID: str = "9d5df92a-06ae-435f-b459-8304f2efcc67"
             self.APP_ID: str = "eea8762c-adfc-4ee4-8d7a-6e2452ddf342"
-            self.BASIC_AUTHORIZATION: str = "Basic OWQ1ZGY5MmEtMDZhZS00MzVmLWI0NTktODMwNGYyZWZjYzY3OnRzWGRrVWcwOEF2MlpaelhPZ1d6Snl4VVQ2eWVTbk5OUWtYWFBSZEtXRUFOd2wxcA=="
+            self.BASIC_AUTHORIZATION: str = (
+                "Basic OWQ1ZGY5MmEtMDZhZS00MzVmLWI0NTktODMwNGYyZWZjYzY3OnRzWGRrVWcwOEF2MlpaelhPZ1d6Snl4VVQ2eWVTbk5OUWtYWFBSZEtXRUFOd2wxcA=="  # noqa
+            )
         elif BRANDS[brand] == BRAND_HYUNDAI:
             self.BASE_DOMAIN: str = "prd.cn-ccapi.hyundai.com"
             self.CCSP_SERVICE_ID: str = "72b3d019-5bc7-443d-a437-08f307cf06e2"
@@ -128,7 +135,9 @@ class KiaUvoApiCN(ApiImplType1):
         self.CLIENT_ID: str = self.CCSP_SERVICE_ID
         self.GCM_SENDER_ID = 199360397125
 
-    def _get_authenticated_headers(self, token: Token) -> dict:
+    def _get_authenticated_headers(
+        self, token: Token, ccs2_support: Optional[int] = None
+    ) -> dict:
         return {
             "Authorization": token.access_token,
             "ccsp-service-id": self.CCSP_SERVICE_ID,
@@ -826,7 +835,7 @@ class KiaUvoApiCN(ApiImplType1):
         yyyymm_string,
     ) -> None:
         """
-        Europe feature only.
+        feature only available for some regions.
         Updates the vehicle.month_trip_info for the specified month.
 
         Default this information is None:
@@ -870,7 +879,7 @@ class KiaUvoApiCN(ApiImplType1):
         yyyymmdd_string,
     ) -> None:
         """
-        Europe feature only.
+        feature only available for some regions.
         Updates the vehicle.day_trip_info information for the specified day.
 
         Default this information is None:

--- a/hyundai_kia_connect_api/KiaUvoApiCN.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCN.py
@@ -62,12 +62,8 @@ from .utils import (
 _LOGGER = logging.getLogger(__name__)
 
 USER_AGENT_OK_HTTP: str = "okhttp/3.12.0"
-USER_AGENT_MOZILLA: str = (
-    "Mozilla/5.0 (Linux; Android 4.1.1; Galaxy Nexus Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19"  # noqa
-)
-ACCEPT_HEADER_ALL: str = (
-    "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"  # noqa
-)
+USER_AGENT_MOZILLA: str = "Mozilla/5.0 (Linux; Android 4.1.1; Galaxy Nexus Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19"  # noqa
+ACCEPT_HEADER_ALL: str = "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"  # noqa
 
 
 def _check_response_for_errors(response: dict) -> None:
@@ -117,9 +113,7 @@ class KiaUvoApiCN(ApiImplType1):
             self.BASE_DOMAIN: str = "prd.cn-ccapi.kia.com"
             self.CCSP_SERVICE_ID: str = "9d5df92a-06ae-435f-b459-8304f2efcc67"
             self.APP_ID: str = "eea8762c-adfc-4ee4-8d7a-6e2452ddf342"
-            self.BASIC_AUTHORIZATION: str = (
-                "Basic OWQ1ZGY5MmEtMDZhZS00MzVmLWI0NTktODMwNGYyZWZjYzY3OnRzWGRrVWcwOEF2MlpaelhPZ1d6Snl4VVQ2eWVTbk5OUWtYWFBSZEtXRUFOd2wxcA=="  # noqa
-            )
+            self.BASIC_AUTHORIZATION: str = "Basic OWQ1ZGY5MmEtMDZhZS00MzVmLWI0NTktODMwNGYyZWZjYzY3OnRzWGRrVWcwOEF2MlpaelhPZ1d6Snl4VVQ2eWVTbk5OUWtYWFBSZEtXRUFOd2wxcA=="  # noqa
         elif BRANDS[brand] == BRAND_HYUNDAI:
             self.BASE_DOMAIN: str = "prd.cn-ccapi.hyundai.com"
             self.CCSP_SERVICE_ID: str = "72b3d019-5bc7-443d-a437-08f307cf06e2"

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -67,8 +67,12 @@ from .utils import (
 _LOGGER = logging.getLogger(__name__)
 
 USER_AGENT_OK_HTTP: str = "okhttp/3.12.0"
-USER_AGENT_MOZILLA: str = "Mozilla/5.0 (Linux; Android 4.1.1; Galaxy Nexus Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19"  # noqa
-ACCEPT_HEADER_ALL: str = "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"  # noqa
+USER_AGENT_MOZILLA: str = (
+    "Mozilla/5.0 (Linux; Android 4.1.1; Galaxy Nexus Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19"  # noqa
+)
+ACCEPT_HEADER_ALL: str = (
+    "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"  # noqa
+)
 
 SUPPORTED_LANGUAGES_LIST = [
     "en",  # English
@@ -167,7 +171,9 @@ class KiaUvoApiEU(ApiImplType1):
             self.CFB: str = base64.b64decode(
                 "RFtoRq/vDXJmRndoZaZQyfOot7OrIqGVFj96iY2WL3yyH5Z/pUvlUhqmCxD2t+D65SQ="
             )
-            self.BASIC_AUTHORIZATION: str = "Basic NmQ0NzdjMzgtM2NhNC00Y2YzLTk1NTctMmExOTI5YTk0NjU0OktVeTQ5WHhQekxwTHVvSzB4aEJDNzdXNlZYaG10UVI5aVFobUlGampvWTRJcHhzVg=="  # noqa
+            self.BASIC_AUTHORIZATION: str = (
+                "Basic NmQ0NzdjMzgtM2NhNC00Y2YzLTk1NTctMmExOTI5YTk0NjU0OktVeTQ5WHhQekxwTHVvSzB4aEJDNzdXNlZYaG10UVI5aVFobUlGampvWTRJcHhzVg=="  # noqa
+            )
             self.LOGIN_FORM_HOST = "eu-account.hyundai.com"
             self.PUSH_TYPE = "GCM"
         elif BRANDS[self.brand] == BRAND_GENESIS:
@@ -178,7 +184,9 @@ class KiaUvoApiEU(ApiImplType1):
             self.CFB: str = base64.b64decode(
                 "RFtoRq/vDXJmRndoZaZQyYo3/qFLtVReW8P7utRPcc0ZxOzOELm9mexvviBk/qqIp4A="
             )
-            self.BASIC_AUTHORIZATION: str = "Basic NmQ0NzdjMzgtM2NhNC00Y2YzLTk1NTctMmExOTI5YTk0NjU0OktVeTQ5WHhQekxwTHVvSzB4aEJDNzdXNlZYaG10UVI5aVFobUlGampvWTRJcHhzVg=="  # noqa
+            self.BASIC_AUTHORIZATION: str = (
+                "Basic NmQ0NzdjMzgtM2NhNC00Y2YzLTk1NTctMmExOTI5YTk0NjU0OktVeTQ5WHhQekxwTHVvSzB4aEJDNzdXNlZYaG10UVI5aVFobUlGampvWTRJcHhzVg=="  # noqa
+            )
             self.LOGIN_FORM_HOST = "accounts-eu.genesis.com"
             self.PUSH_TYPE = "GCM"
 
@@ -706,13 +714,13 @@ class KiaUvoApiEU(ApiImplType1):
 
         if get_child_value(
             state,
-            "vehicleStatus.evStatus.reservChargeInfos.reservChargeInfo.reservChargeInfoDetail.reservFatcSet.airTemp.value",
-        ):  # noqa
+            "vehicleStatus.evStatus.reservChargeInfos.reservChargeInfo.reservChargeInfoDetail.reservFatcSet.airTemp.value",  # noqa
+        ):
             temp_index = get_hex_temp_into_index(
                 get_child_value(
                     state,
-                    "vehicleStatus.evStatus.reservChargeInfos.reservChargeInfo.reservChargeInfoDetail.reservFatcSet.airTemp.value",
-                )  # noqa
+                    "vehicleStatus.evStatus.reservChargeInfos.reservChargeInfo.reservChargeInfoDetail.reservFatcSet.airTemp.value",  # noqa
+                )
             )
 
             vehicle.ev_first_departure_climate_temperature = (
@@ -727,13 +735,13 @@ class KiaUvoApiEU(ApiImplType1):
 
         if get_child_value(
             state,
-            "vehicleStatus.evStatus.reservChargeInfos.reserveChargeInfo2.reservChargeInfoDetail.reservFatcSet.airTemp.value",
-        ):  # noqa
+            "vehicleStatus.evStatus.reservChargeInfos.reserveChargeInfo2.reservChargeInfoDetail.reservFatcSet.airTemp.value",  # noqa
+        ):
             temp_index = get_hex_temp_into_index(
                 get_child_value(
                     state,
-                    "vehicleStatus.evStatus.reservChargeInfos.reserveChargeInfo2.reservChargeInfoDetail.reservFatcSet.airTemp.value",
-                )  # noqa
+                    "vehicleStatus.evStatus.reservChargeInfos.reserveChargeInfo2.reservChargeInfoDetail.reservFatcSet.airTemp.value",  # noqa
+                )
             )
 
             vehicle.ev_second_departure_climate_temperature = (
@@ -1088,7 +1096,7 @@ class KiaUvoApiEU(ApiImplType1):
         yyyymm_string,
     ) -> None:
         """
-        Europe feature only.
+        feature only available for some regions.
         Updates the vehicle.month_trip_info for the specified month.
 
         Default this information is None:
@@ -1123,9 +1131,6 @@ class KiaUvoApiEU(ApiImplType1):
                 )
                 result.day_list.append(processed_day)
 
-            if len(result.day_list) > 0:  # sort on increasing yyyymmdd
-                result.day_list.sort(key=lambda k: k.yyyymmdd)
-
             vehicle.month_trip_info = result
 
     def update_day_trip_info(
@@ -1135,7 +1140,7 @@ class KiaUvoApiEU(ApiImplType1):
         yyyymmdd_string,
     ) -> None:
         """
-        Europe feature only.
+        feature only available for some regions.
         Updates the vehicle.day_trip_info information for the specified day.
 
         Default this information is None:
@@ -1173,9 +1178,6 @@ class KiaUvoApiEU(ApiImplType1):
                     max_speed=trip["tripMaxSpeed"],
                 )
                 result.trip_list.append(processed_trip)
-
-            if len(result.trip_list) > 0:  # sort on descending hhmmss
-                result.trip_list.sort(reverse=True, key=lambda k: k.hhmmss)
 
             vehicle.day_trip_info = result
 
@@ -1244,12 +1246,6 @@ class KiaUvoApiEU(ApiImplType1):
                     )
                     break
 
-            daily_stats = drivingInfo["dailyStats"]
-            _LOGGER.debug(f"KiaUvoApiEU: before daily_stats: {daily_stats}")  # noqa
-            if len(daily_stats) > 0:  # sort on decreasing date
-                daily_stats.sort(reverse=True, key=lambda k: k.date)
-                drivingInfo["dailyStats"] = daily_stats
-                _LOGGER.debug(f"KiaUvoApiEU: after  daily_stats: {daily_stats}")  # noqa
             return drivingInfo
         else:
             _LOGGER.debug(
@@ -1363,7 +1359,8 @@ class KiaUvoApiEU(ApiImplType1):
                 temperature = 17.0
 
         payload = {
-            "reservChargeInfo" + str(i + 1): {
+            "reservChargeInfo"
+            + str(i + 1): {
                 "reservChargeSet": departures[i].enabled,
                 "reservInfo": {
                     "day": departures[i].days,
@@ -1375,7 +1372,7 @@ class KiaUvoApiEU(ApiImplType1):
                 "reservFatcSet": {
                     "airCtrl": 1 if options.climate_enabled else 0,
                     "airTemp": {
-                        "value": "{:.1f}".format(temperature),
+                        "value": f"{temperature:.1f}",
                         "hvacTempType": 1,
                         "unit": options.temperature_unit,
                     },
@@ -1390,15 +1387,15 @@ class KiaUvoApiEU(ApiImplType1):
             "offPeakPowerInfo": {
                 "offPeakPowerTime1": {
                     "endtime": {
-                        "timeSection": 1
-                        if options.off_peak_end_time >= dt.time(12, 0)
-                        else 0,
+                        "timeSection": (
+                            1 if options.off_peak_end_time >= dt.time(12, 0) else 0
+                        ),
                         "time": options.off_peak_end_time.strftime("%I%M"),
                     },
                     "starttime": {
-                        "timeSection": 1
-                        if options.off_peak_start_time >= dt.time(12, 0)
-                        else 0,
+                        "timeSection": (
+                            1 if options.off_peak_start_time >= dt.time(12, 0) else 0
+                        ),
                         "time": options.off_peak_start_time.strftime("%I%M"),
                     },
                 },

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -67,12 +67,8 @@ from .utils import (
 _LOGGER = logging.getLogger(__name__)
 
 USER_AGENT_OK_HTTP: str = "okhttp/3.12.0"
-USER_AGENT_MOZILLA: str = (
-    "Mozilla/5.0 (Linux; Android 4.1.1; Galaxy Nexus Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19"  # noqa
-)
-ACCEPT_HEADER_ALL: str = (
-    "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"  # noqa
-)
+USER_AGENT_MOZILLA: str = "Mozilla/5.0 (Linux; Android 4.1.1; Galaxy Nexus Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19"  # noqa
+ACCEPT_HEADER_ALL: str = "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"  # noqa
 
 SUPPORTED_LANGUAGES_LIST = [
     "en",  # English
@@ -171,9 +167,7 @@ class KiaUvoApiEU(ApiImplType1):
             self.CFB: str = base64.b64decode(
                 "RFtoRq/vDXJmRndoZaZQyfOot7OrIqGVFj96iY2WL3yyH5Z/pUvlUhqmCxD2t+D65SQ="
             )
-            self.BASIC_AUTHORIZATION: str = (
-                "Basic NmQ0NzdjMzgtM2NhNC00Y2YzLTk1NTctMmExOTI5YTk0NjU0OktVeTQ5WHhQekxwTHVvSzB4aEJDNzdXNlZYaG10UVI5aVFobUlGampvWTRJcHhzVg=="  # noqa
-            )
+            self.BASIC_AUTHORIZATION: str = "Basic NmQ0NzdjMzgtM2NhNC00Y2YzLTk1NTctMmExOTI5YTk0NjU0OktVeTQ5WHhQekxwTHVvSzB4aEJDNzdXNlZYaG10UVI5aVFobUlGampvWTRJcHhzVg=="  # noqa
             self.LOGIN_FORM_HOST = "eu-account.hyundai.com"
             self.PUSH_TYPE = "GCM"
         elif BRANDS[self.brand] == BRAND_GENESIS:
@@ -184,9 +178,7 @@ class KiaUvoApiEU(ApiImplType1):
             self.CFB: str = base64.b64decode(
                 "RFtoRq/vDXJmRndoZaZQyYo3/qFLtVReW8P7utRPcc0ZxOzOELm9mexvviBk/qqIp4A="
             )
-            self.BASIC_AUTHORIZATION: str = (
-                "Basic NmQ0NzdjMzgtM2NhNC00Y2YzLTk1NTctMmExOTI5YTk0NjU0OktVeTQ5WHhQekxwTHVvSzB4aEJDNzdXNlZYaG10UVI5aVFobUlGampvWTRJcHhzVg=="  # noqa
-            )
+            self.BASIC_AUTHORIZATION: str = "Basic NmQ0NzdjMzgtM2NhNC00Y2YzLTk1NTctMmExOTI5YTk0NjU0OktVeTQ5WHhQekxwTHVvSzB4aEJDNzdXNlZYaG10UVI5aVFobUlGampvWTRJcHhzVg=="  # noqa
             self.LOGIN_FORM_HOST = "accounts-eu.genesis.com"
             self.PUSH_TYPE = "GCM"
 
@@ -1359,8 +1351,7 @@ class KiaUvoApiEU(ApiImplType1):
                 temperature = 17.0
 
         payload = {
-            "reservChargeInfo"
-            + str(i + 1): {
+            "reservChargeInfo" + str(i + 1): {
                 "reservChargeSet": departures[i].enabled,
                 "reservInfo": {
                     "day": departures[i].days,

--- a/hyundai_kia_connect_api/Vehicle.py
+++ b/hyundai_kia_connect_api/Vehicle.py
@@ -1,4 +1,4 @@
-# pylint:disable=missing-class-docstring,missing-function-docstring,wildcard-import,unused-wildcard-import,invalid-name
+# pylint:disable=missing-class-docstring,missing-function-docstring,wildcard-import,unused-wildcard-import,invalid-name,logging-fstring-interpolation
 """Vehicle class"""
 
 import logging
@@ -173,11 +173,61 @@ class Vehicle:
     # expressed in watt-hours (Wh)
     power_consumption_30d: float = None  # Europe feature only
 
-    # Europe feature only
-    daily_stats: list[DailyDrivingStats] = field(default_factory=list)
+    # feature only available for some regions (getter/setter for sorting)
+    _daily_stats: list[DailyDrivingStats] = field(default_factory=list)
 
-    month_trip_info: MonthTripInfo = None  # Europe feature only
-    day_trip_info: DayTripInfo = None  # Europe feature only
+    @property
+    def daily_stats(self):
+        return self._daily_stats
+
+    @daily_stats.setter
+    def daily_stats(self, value):
+        result = value
+        if result is not None and len(result) > 0:  # sort on decreasing date
+            _LOGGER.debug(f"before daily_stats: {result}")
+            result.sort(reverse=True, key=lambda k: k.date)
+            _LOGGER.debug(f"after  daily_stats: {result}")
+        self._daily_stats = result
+
+    # feature only available for some regions (getter/setter for sorting)
+    _month_trip_info: MonthTripInfo = None
+
+    @property
+    def month_trip_info(self):
+        return self._month_trip_info
+
+    @month_trip_info.setter
+    def month_trip_info(self, value):
+        result = value
+        if (
+            result is not None
+            and hasattr(result, "day_list")
+            and len(result.day_list) > 0
+        ):  # sort on increasing yyyymmdd
+            _LOGGER.debug(f"before month_trip_info: {result}")
+            result.day_list.sort(key=lambda k: k.yyyymmdd)
+            _LOGGER.debug(f"after  month_trip_info: {result}")
+        self._month_trip_info = result
+
+    # feature only available for some regions (getter/setter for sorting)
+    _day_trip_info: DayTripInfo = None
+
+    @property
+    def day_trip_info(self):
+        return self._day_trip_info
+
+    @day_trip_info.setter
+    def day_trip_info(self, value):
+        result = value
+        if (
+            result is not None
+            and hasattr(result, "trip_list")
+            and len(result.trip_list) > 0
+        ):  # sort on descending hhmmss
+            _LOGGER.debug(f"before day_trip_info: {result}")
+            result.trip_list.sort(reverse=True, key=lambda k: k.hhmmss)
+            _LOGGER.debug(f"after day_trip_info: {result}")
+        self._day_trip_info = result
 
     ev_battery_percentage: int = None
     ev_battery_soh_percentage: int = None

--- a/hyundai_kia_connect_api/VehicleManager.py
+++ b/hyundai_kia_connect_api/VehicleManager.py
@@ -219,7 +219,7 @@ class VehicleManager:
 
     def update_month_trip_info(self, vehicle_id: str, yyyymm_string: str) -> None:
         """
-        Europe feature only.
+        feature only available for some regions.
         Updates the vehicle.month_trip_info for the specified month.
 
         Default this information is None:
@@ -231,7 +231,7 @@ class VehicleManager:
 
     def update_day_trip_info(self, vehicle_id: str, yyyymmdd_string: str) -> None:
         """
-        Europe feature only.
+        feature only available for some regions.
         Updates the vehicle.day_trip_info information for the specified day.
 
         Default this information is None:

--- a/hyundai_kia_connect_api/utils.py
+++ b/hyundai_kia_connect_api/utils.py
@@ -1,4 +1,4 @@
-# pylint:disable=bare-except,missing-function-docstring,invalid-name
+# pylint:disable=bare-except,missing-function-docstring,invalid-name,broad-exception-caught
 """utils.py"""
 
 import datetime


### PR DESCRIPTION
Only KiaUvoApiEU.py was sorting Vehicle.daily_stats, Vehicle.month_trip_info and Vehicle.day_trip_info, other implementations did not.

Moved the sorting to Vehicle in each setter.
Changed the Europe only comment.
Fixed or suppressed flake and lint warnings.

This partly solves (problem 1) this issue: https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/617