### PR TITLE
fix: Removed possible decimals from get_hex_temp_into_index

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -247,7 +247,10 @@ class KiaUvoApiCA(ApiImpl):
         )
         # Converts temp to usable number. Currently only support celsius.
         # Future to do is check unit in case the care itself is set to F.
-        if get_child_value(state, "status.airTemp.value") != "OFF" and get_child_value(state, "status.airTemp.value")[-1] == "H":
+        if (
+            get_child_value(state, "status.airTemp.value") != "OFF"
+            and get_child_value(state, "status.airTemp.value")[-1] == "H"
+        ):
             tempIndex = get_hex_temp_into_index(
                 get_child_value(state, "status.airTemp.value")
             )

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -247,7 +247,7 @@ class KiaUvoApiCA(ApiImpl):
         )
         # Converts temp to usable number. Currently only support celsius.
         # Future to do is check unit in case the care itself is set to F.
-        if get_child_value(state, "status.airTemp.value") != "OFF":
+        if get_child_value(state, "status.airTemp.value") != "OFF" and get_child_value(state, "status.airTemp.value")[-1] == "H":
             tempIndex = get_hex_temp_into_index(
                 get_child_value(state, "status.airTemp.value")
             )

--- a/hyundai_kia_connect_api/utils.py
+++ b/hyundai_kia_connect_api/utils.py
@@ -35,7 +35,7 @@ def get_float(value):
 
 def get_hex_temp_into_index(value):
     if value is not None:
-        value = value.replace("H", "")
+        value = value.replace("H", "").split(".")[0]
         value = int(value, 16)
         return value
     else:

--- a/hyundai_kia_connect_api/utils.py
+++ b/hyundai_kia_connect_api/utils.py
@@ -35,7 +35,7 @@ def get_float(value):
 
 def get_hex_temp_into_index(value):
     if value is not None:
-        value = value.replace("H", "").split(".")[0]
+        value = value.replace("H", "")
         value = int(value, 16)
         return value
     else:


### PR DESCRIPTION
The Canadian website (and surely others) sometimes returns a decimal for temperatures. Since the expected value is an integer, it crashes everything. See crash report below.

> Failed setup, will retry: Config Not Ready: Error communicating with API: Traceback (most recent call last): File "/config/custom_components/kia_uvo/coordinator.py", line 126, in _async_update_data await self.hass.async_add_executor_job( File "/usr/local/lib/python3.12/concurrent/futures/thread.py", line 58, in run result = self.fn(*self.args, **self.kwargs) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/usr/local/lib/python3.12/site-packages/hyundai_kia_connect_api/VehicleManager.py", line 115, in check_and_force_update_vehicles self.update_vehicle_with_cached_state(vehicle_id) File "/usr/local/lib/python3.12/site-packages/hyundai_kia_connect_api/VehicleManager.py", line 90, in update_vehicle_with_cached_state self.api.update_vehicle_with_cached_state(self.token, vehicle) File "/usr/local/lib/python3.12/site-packages/hyundai_kia_connect_api/KiaUvoApiCA.py", line 180, in update_vehicle_with_cached_state self._update_vehicle_properties_base(vehicle, state) File "/usr/local/lib/python3.12/site-packages/hyundai_kia_connect_api/KiaUvoApiCA.py", line 251, in _update_vehicle_properties_base tempIndex = get_hex_temp_into_index( ^^^^^^^^^^^^^^^^^^^^^^^^ File "/usr/local/lib/python3.12/site-packages/hyundai_kia_connect_api/utils.py", line 39, in get_hex_temp_into_index value = int(value, 16) ^^^^^^^^^^^^^^ ValueError: invalid literal for int() with base 16: '24.5' During handling of the above exception, another exception occurred: Traceback (most recent call last): File "/config/custom_components/kia_uvo/coordinator.py", line 135, in _async_update_data await self.hass.async_add_executor_job( File "/usr/local/lib/python3.12/concurrent/futures/thread.py", line 58, in run result = self.fn(*self.args, **self.kwargs) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/usr/local/lib/python3.12/site-packages/hyundai_kia_connect_api/VehicleManager.py", line 85, in update_all_vehicles_with_cached_state self.update_vehicle_with_cached_state(vehicle_id) File "/usr/local/lib/python3.12/site-packages/hyundai_kia_connect_api/VehicleManager.py", line 90, in update_vehicle_with_cached_state self.api.update_vehicle_with_cached_state(self.token, vehicle) File "/usr/local/lib/python3.12/site-packages/hyundai_kia_connect_api/KiaUvoApiCA.py", line 180, in update_vehicle_with_cached_state self._update_vehicle_properties_base(vehicle, state) File "/usr/local/lib/python3.12/site-packages/hyundai_kia_connect_api/KiaUvoApiCA.py", line 251, in _update_vehicle_properties_base tempIndex = get_hex_temp_into_index( ^^^^^^^^^^^^^^^^^^^^^^^^ File "/usr/local/lib/python3.12/site-packages/hyundai_kia_connect_api/utils.py", line 39, in get_hex_temp_into_index value = int(value, 16) ^^^^^^^^^^^^^^ ValueError: invalid literal for int() with base 16: '24.5'