### PR TITLE
fix(USA): fix USA Hyundai duration idle times

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
@@ -479,11 +479,12 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
         trips = []
         for trip in tripDetails:
             yyyymmdd_hhmmss = trip["startdate"]  # remember full date
-            drive_time = get_child_value(trip["mileagetime"], "value")
+            drive_time = int(get_child_value(trip["mileagetime"], "value"))
+            idle_time = int(get_child_value(trip["duration"], "value")) - drive_time
             processed_trip = TripInfo(
                 hhmmss=yyyymmdd_hhmmss,
-                drive_time=int(drive_time),
-                idle_time=int(get_child_value(trip["duration"], "value") - drive_time),
+                drive_time=int(drive_time / 60),  # convert seconds to minutes
+                idle_time=int(idle_time / 60),  # convert seconds to minutes
                 distance=int(trip["distance"]),
                 avg_speed=get_child_value(trip["avgspeed"], "value"),
                 max_speed=int(get_child_value(trip["maxspeed"], "value")),

--- a/hyundai_kia_connect_api/Vehicle.py
+++ b/hyundai_kia_connect_api/Vehicle.py
@@ -17,8 +17,8 @@ class TripInfo:
     """Trip Info"""
 
     hhmmss: str = None  # will not be filled by summary
-    drive_time: int = None
-    idle_time: int = None
+    drive_time: int = None  # minutes
+    idle_time: int = None  # minutes
     distance: int = None
     avg_speed: float = None
     max_speed: int = None


### PR DESCRIPTION
For Europe trip info duration and idle time are in minutes. For HyundaiBlueLinkAPIUSA.py the Bluelink API returns it in seconds. Now the seconds are converted to minutes for HyundaiBlueLinkAPIUSA.py.

[See this discussion](https://github.com/ZuinigeRijder/hyundai_kia_connect_monitor/discussions/68#discussioncomment-10714627).

The changes [have been tested here](https://github.com/ZuinigeRijder/hyundai_kia_connect_monitor/discussions/68#discussioncomment-10722153).

