### PR TITLE
fix(EU): update default of ScheduleChargingClimateRequestOptions::DepartureOptions::days to non-empty to avoid API error

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -1307,7 +1307,7 @@ class KiaUvoApiEU(ApiImplType1):
             if departure_options.enabled is None:
                 departure_options.enabled = False
             if departure_options.days is None:
-                departure_options.days = []
+                departure_options.days = [0]
             if departure_options.time is None:
                 departure_options.time = dt.time()
 


### PR DESCRIPTION
Server rejects schedule charge/climate request when day is empty