### PR TITLE
chore!: reduce number of exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+bin/
 env/
 build/
 develop-eggs/
@@ -84,6 +85,7 @@ celerybeat-schedule
 .env
 
 # virtualenv
+pyvenv.cfg
 .venv
 venv/
 ENV/

--- a/hyundai_kia_connect_api/__init__.py
+++ b/hyundai_kia_connect_api/__init__.py
@@ -2,17 +2,10 @@
 
 # flake8: noqa
 from .ApiImpl import (
-    ApiImpl,
     ClimateRequestOptions,
     WindowRequestOptions,
     ScheduleChargingClimateRequestOptions,
 )
-from .ApiImplType1 import ApiImplType1
-from .HyundaiBlueLinkAPIUSA import HyundaiBlueLinkAPIUSA
-from .KiaUvoApiCA import KiaUvoApiCA
-from .KiaUvoApiEU import KiaUvoApiEU
-from .KiaUvoAPIUSA import KiaUvoAPIUSA
-from .KiaUvoApiCN import KiaUvoApiCN
 
 from .Token import Token
 from .Vehicle import Vehicle


### PR DESCRIPTION
Confirmed that kia_uvo only needs the remaining imports. Kept WindowRequestOptions even if it is not used yet.

BREAKING CHANGE: Remove the API implementation from being exported since the user should use VehicleManager().

The goal is to make internal refactoring safer by reducing the risk for future breaking changes.

This make it possible to reduce code duplication in the future.

Add virtualenv items to .gitignore.