### PR TITLE
feat: Bluelink USA better distance accuracy using odometer, one-tenth of mile

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
@@ -462,7 +462,7 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
         tripStats = []
         tripDetails = get_child_value(state, "evTripDetails.tripdetails") or {}
 
-        # compute more digits for distance milage using odometer and overrule distance
+        # compute more digits for distance mileage using odometer and overrule distance
         previous_odometer = None
         for trip in reversed(tripDetails):
             odometer = get_child_value(trip, "odometer.value")

--- a/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
@@ -12,6 +12,8 @@ import certifi
 from requests.adapters import HTTPAdapter
 from urllib3.util.ssl_ import create_urllib3_context
 
+from hyundai_kia_connect_api.exceptions import APIError
+
 from .const import (
     DOMAIN,
     VEHICLE_LOCK_ACTION,
@@ -459,6 +461,31 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
         # fill vehicle.daily_stats
         tripStats = []
         tripDetails = get_child_value(state, "evTripDetails.tripdetails") or {}
+
+        # compute more digits for distance milage using odometer and overrule distance
+        previous_odometer = None
+        for trip in reversed(tripDetails):
+            odometer = get_child_value(trip, "odometer.value")
+            if previous_odometer and odometer:
+                delta_odometer = odometer - previous_odometer
+                if delta_odometer >= 0.0:
+                    trip["distance"] = delta_odometer
+            previous_odometer = odometer
+
+        # overrule odometer with more accuracy from last trip
+        if (
+            previous_odometer
+            and vehicle.odometer
+            and previous_odometer > vehicle.odometer
+        ):
+            _LOGGER.debug(
+                f"Overruling odometer: {previous_odometer:.1f} old: {vehicle.odometer:.1f}"  # noqa
+            )
+            vehicle.odometer = (
+                previous_odometer,
+                DISTANCE_UNITS[3],
+            )
+
         for trip in tripDetails:
             processedTrip = DailyDrivingStats(
                 date=dt.datetime.strptime(trip["startdate"], "%Y-%m-%d %H:%M:%S.%f"),
@@ -485,7 +512,7 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
                 hhmmss=yyyymmdd_hhmmss,
                 drive_time=int(drive_time / 60),  # convert seconds to minutes
                 idle_time=int(idle_time / 60),  # convert seconds to minutes
-                distance=int(trip["distance"]),
+                distance=float(trip["distance"]),
                 avg_speed=get_child_value(trip["avgspeed"], "value"),
                 max_speed=int(get_child_value(trip["maxspeed"], "value")),
             )
@@ -733,6 +760,8 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
         elif action == VEHICLE_LOCK_ACTION.UNLOCK:
             url = self.API_URL + "rcs/rdo/on"
             _LOGGER.debug(f"{DOMAIN} - Calling unlock")
+        else:
+            raise APIError(f"Invalid action value: {action}")
 
         headers = self._get_vehicle_headers(token, vehicle)
         headers["APPCLOUD-VIN"] = vehicle.VIN

--- a/hyundai_kia_connect_api/Vehicle.py
+++ b/hyundai_kia_connect_api/Vehicle.py
@@ -19,7 +19,7 @@ class TripInfo:
     hhmmss: str = None  # will not be filled by summary
     drive_time: int = None  # minutes
     idle_time: int = None  # minutes
-    distance: int = None
+    distance: float = None
     avg_speed: float = None
     max_speed: int = None
 
@@ -60,9 +60,7 @@ class DailyDrivingStats:
     onboard_electronics_consumption: int = None
     battery_care_consumption: int = None
     regenerated_energy: int = None
-    # distance is expressed in (I assume) whatever unit the vehicle is
-    # configured in. KMs (rounded) in my case
-    distance: int = None
+    distance: float = None
     distance_unit: str = DISTANCE_UNITS[1]  # set to kms by default
 
 


### PR DESCRIPTION
For Bluelink USA the distance in the Vehicle dailystats is in whole miles and not in one-tenth of miles. However, also the odometer in one-tenth of miles is send when getting the trip details. See [this discussion post](https://github.com/ZuinigeRijder/hyundai_kia_connect_monitor/discussions/68#discussioncomment-10914206).   

> This needs to be solved at HyundaiBlueLinkAPIUSA.py, not in hyundai_kia_connect_monitor. In principle this can be done, by comparing the previous odometer trip with the current. Problem will be the earliest trip, nothing to compare with, so fallback to distance.

> Compute the delta miles from "odometer - previous odometer" and if there is no previous odometer fallback to "distance".

Also changed the typing of distance to float in Vehicle.py. In Europe (and maybe other regions) distance is already as float, however the struct incorrectly stated it was an int.

A Bluelink USA user [has tested this and it works](https://github.com/ZuinigeRijder/hyundai_kia_connect_monitor/discussions/68#discussioncomment-11084361).

Note that I marked the PR as feat, because the distance send by the Bluelink API is in whole miles, so hyundai_kia_connect_api does it now better than the Hyundai (server) software. But feel free to change it into fix, if that suits you better.