### PR TITLE
feat(USA hyundai): Add EV charge rate support

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py
@@ -386,6 +386,9 @@ class HyundaiBlueLinkAPIUSA(ApiImpl):
         vehicle.ev_battery_is_plugged_in = get_child_value(
             state, "vehicleStatus.evStatus.batteryPlugin"
         )
+        vehicle.ev_charging_current = get_child_value(
+            state, "vehicleStatus.evStatus.batteryStndChrgPower"
+        )
         ChargeDict = get_child_value(
             state, "vehicleStatus.evStatus.reservChargeInfos.targetSOClist"
         )

--- a/hyundai_kia_connect_api/Vehicle.py
+++ b/hyundai_kia_connect_api/Vehicle.py
@@ -159,7 +159,7 @@ class Vehicle:
 
     ev_charge_limits_dc: typing.Union[int, None] = None
     ev_charge_limits_ac: typing.Union[int, None] = None
-    ev_charging_current: typing.Union[int, None] = None  # Europe feature only
+    ev_charging_current: typing.Union[int, None] = None  # Only supported in some regions
     ev_v2l_discharge_limit: typing.Union[int, None] = None
 
     # energy consumed and regenerated since the vehicle was paired with the account

--- a/hyundai_kia_connect_api/Vehicle.py
+++ b/hyundai_kia_connect_api/Vehicle.py
@@ -159,7 +159,9 @@ class Vehicle:
 
     ev_charge_limits_dc: typing.Union[int, None] = None
     ev_charge_limits_ac: typing.Union[int, None] = None
-    ev_charging_current: typing.Union[int, None] = None  # Only supported in some regions
+    ev_charging_current: typing.Union[int, None] = (
+        None  # Only supported in some regions
+    )
     ev_v2l_discharge_limit: typing.Union[int, None] = None
 
     # energy consumed and regenerated since the vehicle was paired with the account


### PR DESCRIPTION
Bluelink in America started supporting the EV charge rate in kW a couple weeks ago.

The JSON exposes two fields named batteryStndChrgPower and batteryDischrgPower whose values appear to be equivalent. I've used StndChrgPower to populate `vehicle.ev_charging_current`.