### PR TITLE
chore(USA): Rename *APIUSA to *ApiUSA

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
@@ -62,8 +62,8 @@ class cipherAdapter(HTTPAdapter):
         return super().proxy_manager_for(*args, **kwargs)
 
 
-class HyundaiBlueLinkAPIUSA(ApiImpl):
-    """HyundaiBlueLinkAPIUSA"""
+class HyundaiBlueLinkApiUSA(ApiImpl):
+    """HyundaiBlueLinkApiUSA"""
 
     # initialize with a timestamp which will allow the first fetch to occur
     last_loc_timestamp = dt.datetime.now(pytz.utc) - dt.timedelta(hours=3)

--- a/hyundai_kia_connect_api/KiaUvoApiUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiUSA.py
@@ -106,8 +106,8 @@ def request_with_logging(func):
     return request_with_logging_wrapper
 
 
-class KiaUvoAPIUSA(ApiImpl):
-    """KiaUvoAPIUSA"""
+class KiaUvoApiUSA(ApiImpl):
+    """KiaUvoApiUSA"""
 
     def __init__(self, region: int, brand: int, language) -> None:
         self.LANGUAGE: str = language

--- a/hyundai_kia_connect_api/VehicleManager.py
+++ b/hyundai_kia_connect_api/VehicleManager.py
@@ -14,8 +14,8 @@ from .ApiImpl import (
     WindowRequestOptions,
     ScheduleChargingClimateRequestOptions,
 )
-from .HyundaiBlueLinkAPIUSA import HyundaiBlueLinkAPIUSA
-from .KiaUvoAPIUSA import KiaUvoAPIUSA
+from .HyundaiBlueLinkApiUSA import HyundaiBlueLinkApiUSA
+from .KiaUvoApiUSA import KiaUvoApiUSA
 from .KiaUvoApiCA import KiaUvoApiCA
 from .KiaUvoApiEU import KiaUvoApiEU
 from .KiaUvoApiCN import KiaUvoApiCN
@@ -284,9 +284,9 @@ class VehicleManager:
         elif REGIONS[region] == REGION_USA and (
             BRANDS[brand] == BRAND_HYUNDAI or BRANDS[brand] == BRAND_GENESIS
         ):
-            return HyundaiBlueLinkAPIUSA(region, brand, language)
+            return HyundaiBlueLinkApiUSA(region, brand, language)
         elif REGIONS[region] == REGION_USA and BRANDS[brand] == BRAND_KIA:
-            return KiaUvoAPIUSA(region, brand, language)
+            return KiaUvoApiUSA(region, brand, language)
         elif REGIONS[region] == REGION_CHINA:
             return KiaUvoApiCN(region, brand, language)
         elif REGIONS[region] == REGION_AUSTRALIA:


### PR DESCRIPTION
The fact that the USA one had "API" ALL CAPS but all others had "Api" really triggered me. This should not be a breaking change because clients use VehiculeManager but there's still a risk.

exceptions.py also use API all caps but that would break clients so this is not changed.