### PR TITLE
fix: replace 'OFF' with None

### DIFF
--- a/hyundai_kia_connect_api/Vehicle.py
+++ b/hyundai_kia_connect_api/Vehicle.py
@@ -424,7 +424,7 @@ class Vehicle:
     def air_temperature(self, value):
         self._air_temperature_value = value[0]
         self._air_temperature_unit = value[1]
-        self._air_temperature = value[0]
+        self._air_temperature = value[0] if value[0] != "OFF" else None
 
     @property
     def ev_driving_range(self):


### PR DESCRIPTION
This stops exceptions from being raised in Home Assistant as reported at
https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/710#issuecomment-2470834826

This doesn't fix the original reported issue so not closing it.

Note that this happens because
https://github.com/Hyundai-Kia-Connect/kia_uvo/blob/585ff9d56d8617e40787d33f4440ec2e93660b5d/custom_components/kia_uvo/sensor.py#L120
looks at `Vehicule._air_temperature` directly and bypass the property `air_temperature`. It took me a while to realize that.