### PR TITLE
feat: EV charging speed in EU and fix for US

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
@@ -386,8 +386,8 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
         vehicle.ev_battery_is_plugged_in = get_child_value(
             state, "vehicleStatus.evStatus.batteryPlugin"
         )
-        vehicle.ev_charging_current = get_child_value(
-            state, "vehicleStatus.evStatus.batteryStndChrgPower"
+        vehicle.ev_charging_power = get_child_value(
+            state, "vehicleStatus.evStatus.batteryPower.batteryStndChrgPower"
         )
         ChargeDict = get_child_value(
             state, "vehicleStatus.evStatus.reservChargeInfos.targetSOClist"

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -520,6 +520,11 @@ class KiaUvoApiEU(ApiImplType1):
             vehicle.ev_charge_port_door_is_open = True
         elif ev_charge_port_door_is_open == 2:
             vehicle.ev_charge_port_door_is_open = False
+
+        vehicle.ev_charging_power = get_child_value(
+            state, "vehicleStatus.evStatus.batteryPower.batteryStndChrgPower"
+        )
+
         if (
             get_child_value(
                 state,

--- a/hyundai_kia_connect_api/Vehicle.py
+++ b/hyundai_kia_connect_api/Vehicle.py
@@ -156,7 +156,7 @@ class Vehicle:
     # EV fields (EV/PHEV)
 
     ev_charge_port_door_is_open: typing.Union[bool, None] = None
-    ev_charging_power: typing.Union[float, None] = None # Charging power in kW
+    ev_charging_power: typing.Union[float, None] = None  # Charging power in kW
 
     ev_charge_limits_dc: typing.Union[int, None] = None
     ev_charge_limits_ac: typing.Union[int, None] = None

--- a/hyundai_kia_connect_api/Vehicle.py
+++ b/hyundai_kia_connect_api/Vehicle.py
@@ -156,11 +156,12 @@ class Vehicle:
     # EV fields (EV/PHEV)
 
     ev_charge_port_door_is_open: typing.Union[bool, None] = None
+    ev_charging_power: typing.Union[float, None] = None # Charging power in kW
 
     ev_charge_limits_dc: typing.Union[int, None] = None
     ev_charge_limits_ac: typing.Union[int, None] = None
     ev_charging_current: typing.Union[int, None] = (
-        None  # Only supported in some regions
+        None  # Europe feature only, ac charging current limit
     )
     ev_v2l_discharge_limit: typing.Union[int, None] = None
 

--- a/hyundai_kia_connect_api/bluelink.py
+++ b/hyundai_kia_connect_api/bluelink.py
@@ -100,6 +100,7 @@ def print_vehicle(vehicle):
     print("  location_last_updated_at:", vehicle.location_last_updated_at)
     print("EV/PHEV")
     print("  charge_port_door_is_open:", vehicle.ev_charge_port_door_is_open)
+    print("  charging_power:", vehicle.ev_charging_power)
     print("  charge_limits_dc:", vehicle.ev_charge_limits_dc)
     print("  charge_limits_ac:", vehicle.ev_charge_limits_ac)
     print("  charging_current:", vehicle.ev_charging_current)
@@ -278,6 +279,7 @@ def vehicle_to_dict(vehicle):
         },
         "electric": {
             "charge_port_door_is_open": vehicle.ev_charge_port_door_is_open,
+            "charging_power": vehicle.ev_charging_power,
             "charge_limits_dc": vehicle.ev_charge_limits_dc,
             "charge_limits_ac": vehicle.ev_charge_limits_ac,
             "charging_current": vehicle.ev_charging_current,


### PR DESCRIPTION
ev_charging_current defines the the portion of electric current the vehicle takes from the charger
available options are 1, 2 and 3 which map to 100% and 90% and 60% in kia_uvo

It cannot be used for charging power, which is in (float) kW.

also fixing the json string according to the capture in https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/961