### PR TITLE
fix: seat heat/cool settings for USA vehicles

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
--   Hyundai / Kia Connect version:
--   Python version:
--   Operating System:
+- Hyundai / Kia Connect version:
+- Python version:
+- Operating System:
 
 ### Description
 

--- a/hyundai_kia_connect_api/KiaUvoApiUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiUSA.py
@@ -624,7 +624,7 @@ class KiaUvoApiUSA(ApiImpl):
         # See const.SEAT_STATUS for the list and descriptions of levels.
         #
         # The values were determined empirically, see https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/718
-        if level == 8:    # High heat
+        if level == 8:  # High heat
             return {
                 "heatVentType": 1,
                 "heatVentLevel": 4,
@@ -666,7 +666,7 @@ class KiaUvoApiUSA(ApiImpl):
                 "heatVentLevel": 4,
                 "heatVentStep": 1,
             }
-        else:             # Off
+        else:  # Off
             return {
                 "heatVentType": 0,
                 "heatVentLevel": 1,


### PR DESCRIPTION
This sets the `heatVentStep` to the appropriate value.  It also does
away with the math on `heatVentLevel`, which I found confusing.  It
now treats the options value more like an enum.

The values are based on the empirical data from
Hyundai-Kia-Connect/kia_uvo#718 and confirmed on my own vehicle.
