### PR TITLE
fix: add steeringWheelStep: 2

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiUSA.py
@@ -704,6 +704,7 @@ class KiaUvoApiUSA(ApiImpl):
                     "rearWindow": 1 if options.heating in [3, 4] else 0,
                     "sideMirror": 1 if options.heating == 4 else 0,
                     "steeringWheel": 1 if options.heating in [2, 4] else 0,
+                    "steeringWheelStep": 2 if options.heating in [2, 4] else 0,
                 },
                 "ignitionOnDuration": {
                     "unit": 4,

--- a/hyundai_kia_connect_api/KiaUvoApiUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiUSA.py
@@ -701,10 +701,10 @@ class KiaUvoApiUSA(ApiImpl):
                 "airCtrl": options.climate,
                 "defrost": options.defrost,
                 "heatingAccessory": {
-                    "rearWindow": 1 if options.heating in [3, 4] else 0,
-                    "sideMirror": 1 if options.heating == 4 else 0,
-                    "steeringWheel": 1 if options.heating in [2, 4] else 0,
-                    "steeringWheelStep": 2 if options.heating in [2, 4] else 0,
+                    "rearWindow": 1 if options.heating in [1, 2, 4] else 0,
+                    "sideMirror": 1 if options.heating in [1, 4] else 0,
+                    "steeringWheel": 1 if options.heating in [1, 3, 4] else 0,
+                    "steeringWheelStep": 2 if options.heating in [1, 3, 4] else 0,
                 },
                 "ignitionOnDuration": {
                     "unit": 4,


### PR DESCRIPTION
This is needed for vehicles with multiple heating levels on the
steering wheel.  This doesn't allow for customization of the level
(it's always on high), but it's better than not being set.

Tested to work on a 2024 Kia EV9, but I am unsure if it'll cause
problems on vehicles without multiple levels.
