### PR TITLE
fix: climate control functionality for EV vehicles in Canada

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -582,7 +582,7 @@ class KiaUvoApiCA(ApiImpl):
             )
         if vehicle.engine_type == ENGINE_TYPES.EV:
             payload = {
-                "hvacInfo": {
+                "remoteControl": {
                     "airCtrl": int(options.climate),
                     "defrost": options.defrost,
                     "heating1": options.heating,
@@ -590,6 +590,13 @@ class KiaUvoApiCA(ApiImpl):
                         "value": hex_set_temp,
                         "unit": 0,
                         "hvacTempType": 1,
+                    },
+                    "igniOnDuration": options.duration,
+                    "seatHeaterVentCMD": {
+                        "drvSeatOptCmd": options.front_left_seat,
+                        "astSeatOptCmd": options.front_right_seat,
+                        "rlSeatOptCmd": options.rear_left_seat,
+                        "rrSeatOptCmd": options.rear_right_seat,
                     },
                 },
                 "pin": token.pin,


### PR DESCRIPTION
Resolve issues with starting climate control due to contract changes and update the payload structure to include seat options for electric vehicles.



```
curl 'https://kiaconnect.ca/tods/api/evc/rfon' \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Accept-Language: en-US,en;q=0.9,ar-EG;q=0.8,ar;q=0.7' \
  -H 'Cache-Control: no-cache' \
  -H 'Connection: keep-alive' \
  -H 'Content-Type: application/json;charset=UTF-8' \
  -H 'Cookie: remMeCWP=your_email@example.com' \
  -H 'Origin: https://kiaconnect.ca' \
  -H 'Pragma: no-cache' \
  -H 'Referer: https://kiaconnect.ca/remote/' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36' \
  -H 'accessToken: your_access_token' \
  -H 'from: CWP' \
  -H 'language: 0' \
  -H 'offset: -4' \
  -H 'pAuth: your_pAuth' \
  -H 'sec-ch-ua: "Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' \
  -H 'vehicleId: $base64Id' \
  --data-raw '{"pin":"1234","remoteControl":{"airCtrl":1,"defrost":true,"airTemp":{"value":"0CH","unit":0,"hvacTempType":1},"heating1":4,"igniOnDuration":4,"seatHeaterVentCMD":{"drvSeatOptCmd":6,"astSeatOptCmd":6,"rlSeatOptCmd":0,"rrSeatOptCmd":0}}}'

curl 'https://kiaconnect.ca/tods/api/evc/rfoff' \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Accept-Language: en-US,en;q=0.9,ar-EG;q=0.8,ar;q=0.7' \
  -H 'Cache-Control: no-cache' \
  -H 'Connection: keep-alive' \
  -H 'Content-Type: application/json;charset=UTF-8' \
  -H 'Cookie: remMeCWP=your_email@example.com' \
  -H 'Origin: https://kiaconnect.ca' \
  -H 'Pragma: no-cache' \
  -H 'Referer: https://kiaconnect.ca/remote/' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36' \
  -H 'accessToken: your_access_token' \
  -H 'from: CWP' \
  -H 'language: 0' \
  -H 'offset: -4' \
  -H 'pAuth: your_pAuth' \
  -H 'sec-ch-ua: "Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' \
  -H 'vehicleId: $base64Id' \
  --data-raw '{"pin":"1234"}'
```