### PR TITLE
fix(CA): fixed the cloudflare 403 issue

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -6,7 +6,6 @@ import time
 import datetime as dt
 import json
 import logging
-
 import pytz
 import requests
 
@@ -89,7 +88,7 @@ class KiaUvoApiCA(ApiImpl):
             "host": self.BASE_URL,
             "origin": "https://" + self.BASE_URL,
             "referer": "https://" + self.BASE_URL + "/login",
-            "from": "SPA",
+            "from": "CWP",
             "language": "0",
             "offset": "0",
             "sec-fetch-dest": "empty",
@@ -102,7 +101,7 @@ class KiaUvoApiCA(ApiImpl):
     def sessions(self):
         if not self._sessions:
             self._sessions = requests.Session()
-            self._sessions.mount("https://" + self.BASE_URL, cipherAdapter())
+            #self._sessions.mount("https://" + self.BASE_URL)
         return self._sessions
 
     def _check_response_for_errors(self, response: dict) -> None:
@@ -128,16 +127,18 @@ class KiaUvoApiCA(ApiImpl):
             else:
                 raise APIError(f"Server returned: '{response['error']['errorDesc']}'")
 
+
+
     def login(self, username: str, password: str) -> Token:
         # Sign In with Email and Password and Get Authorization Code
-        url = self.API_URL + "lgn"
+        url = self.API_URL + "v2/login"
         data = {"loginId": username, "password": password}
         headers = self.API_HEADERS
         response = self.sessions.post(url, json=data, headers=headers)
         _LOGGER.debug(f"{DOMAIN} - Sign In Response {response.text}")
         response = response.json()
         self._check_response_for_errors(response)
-        response = response["result"]
+        response = response["result"]['token']
         access_token = response["accessToken"]
         refresh_token = response["refreshToken"]
         _LOGGER.debug(f"{DOMAIN} - Access Token Value {access_token}")

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -101,7 +101,7 @@ class KiaUvoApiCA(ApiImpl):
     def sessions(self):
         if not self._sessions:
             self._sessions = requests.Session()
-            #self._sessions.mount("https://" + self.BASE_URL)
+            # self._sessions.mount("https://" + self.BASE_URL)
         return self._sessions
 
     def _check_response_for_errors(self, response: dict) -> None:
@@ -127,8 +127,6 @@ class KiaUvoApiCA(ApiImpl):
             else:
                 raise APIError(f"Server returned: '{response['error']['errorDesc']}'")
 
-
-
     def login(self, username: str, password: str) -> Token:
         # Sign In with Email and Password and Get Authorization Code
         url = self.API_URL + "v2/login"
@@ -138,7 +136,7 @@ class KiaUvoApiCA(ApiImpl):
         _LOGGER.debug(f"{DOMAIN} - Sign In Response {response.text}")
         response = response.json()
         self._check_response_for_errors(response)
-        response = response["result"]['token']
+        response = response["result"]["token"]
         access_token = response["accessToken"]
         refresh_token = response["refreshToken"]
         _LOGGER.debug(f"{DOMAIN} - Access Token Value {access_token}")

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -37,8 +37,6 @@ from .utils import (
     parse_datetime,
 )
 
-import ssl
-import urllib3
 
 CIPHERS = "ALL:@SECLEVEL=0"
 

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -45,20 +45,6 @@ CIPHERS = "ALL:@SECLEVEL=0"
 _LOGGER = logging.getLogger(__name__)
 
 
-class cipherAdapter(requests.adapters.HTTPAdapter):
-    """
-    A HTTPAdapter that re-enables poor ciphers required by Hyundai.
-    """
-
-    def init_poolmanager(self, connections, maxsize, block=False):
-        context = ssl.create_default_context()
-        context.set_ciphers(CIPHERS)
-        context.options |= getattr(ssl, "OP_LEGACY_SERVER_CONNECT", 0x4)
-        self.poolmanager = urllib3.poolmanager.PoolManager(
-            ssl_version=ssl.PROTOCOL_TLS, ssl_context=context
-        )
-
-
 class KiaUvoApiCA(ApiImpl):
     """KiaUvoApiCA"""
 
@@ -101,7 +87,6 @@ class KiaUvoApiCA(ApiImpl):
     def sessions(self):
         if not self._sessions:
             self._sessions = requests.Session()
-            # self._sessions.mount("https://" + self.BASE_URL)
         return self._sessions
 
     def _check_response_for_errors(self, response: dict) -> None:


### PR DESCRIPTION
Updated the login API to v2 and changed the 'From' header from SPA to CWP based on captured traffic between the browser and the mybluelink.ca site. Dropped legacy cipher support. V2 login has a different structure for accesstoken and refresh token, therefore, updated the way to retrive the tokens. 

It seems to be working on my HAOS but might need more testing. It appears that Cloudflare believes part of the request contains a string that triggered its security solution.

Below SS were from the api calling mybluelink.ca

---

![image](https://github.com/user-attachments/assets/6520b5fd-f958-4130-8ba1-189a05dd3f9f)
