### PR TITLE
fix: CA new api token expire fix

### DIFF
--- a/hyundai_kia_connect_api/ApiImpl.py
+++ b/hyundai_kia_connect_api/ApiImpl.py
@@ -89,6 +89,11 @@ class ApiImpl:
         """Get cached vehicle data and update Vehicle instance with it"""
         pass
 
+    def test_token(self, token: Token) -> bool:
+        """Test if token is valid
+        Use any dummy request to test if token is still valid"""
+        return True
+
     def check_action_status(
         self,
         token: Token,

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -115,6 +115,7 @@ class KiaUvoApiCA(ApiImpl):
         url = self.API_URL + "v2/login"
         data = {"loginId": username, "password": password}
         headers = self.API_HEADERS
+        headers.pop("accessToken", None)
         response = self.sessions.post(url, json=data, headers=headers)
         _LOGGER.debug(f"{DOMAIN} - Sign In Response {response.text}")
         response = response.json()
@@ -145,7 +146,8 @@ class KiaUvoApiCA(ApiImpl):
         response = self.sessions.post(url, headers=headers)
         _LOGGER.debug(f"{DOMAIN} - Test Token Response {response.text}")
         response = response.json()
-        if response["responseHeader"]["responseCode"] == 1 and response["error"]["errorCode"] == "7403":
+        token_errors = ["7403", "7602"]
+        if response["responseHeader"]["responseCode"] == 1 and response["error"]["errorCode"] in token_errors:
             return False
         return True
 

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -135,10 +135,10 @@ class KiaUvoApiCA(ApiImpl):
             refresh_token=refresh_token,
             valid_until=valid_until,
         )
-    
+
     def test_token(self, token: Token) -> bool:
         # Use "get number of notifications" as a dummy request to test the token
-        # Use this api because it's likely checked more frequently than other APIs, less 
+        # Use this api because it's likely checked more frequently than other APIs, less
         # chance to get banned. And it's short and simple.
         url = self.API_URL + "ntcmsgcnt"
         headers = self.API_HEADERS
@@ -147,7 +147,10 @@ class KiaUvoApiCA(ApiImpl):
         _LOGGER.debug(f"{DOMAIN} - Test Token Response {response.text}")
         response = response.json()
         token_errors = ["7403", "7602"]
-        if response["responseHeader"]["responseCode"] == 1 and response["error"]["errorCode"] in token_errors:
+        if (
+            response["responseHeader"]["responseCode"] == 1
+            and response["error"]["errorCode"] in token_errors
+        ):
             return False
         return True
 

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -134,6 +134,20 @@ class KiaUvoApiCA(ApiImpl):
             refresh_token=refresh_token,
             valid_until=valid_until,
         )
+    
+    def test_token(self, token: Token) -> bool:
+        # Use "get number of notifications" as a dummy request to test the token
+        # Use this api because it's likely checked more frequently than other APIs, less 
+        # chance to get banned. And it's short and simple.
+        url = self.API_URL + "ntcmsgcnt"
+        headers = self.API_HEADERS
+        headers["accessToken"] = token.access_token
+        response = self.sessions.post(url, headers=headers)
+        _LOGGER.debug(f"{DOMAIN} - Test Token Response {response.text}")
+        response = response.json()
+        if response["responseHeader"]["responseCode"] == 1 and response["error"]["errorCode"] == "7403":
+            return False
+        return True
 
     def get_vehicles(self, token: Token) -> list[Vehicle]:
         url = self.API_URL + "vhcllst"

--- a/hyundai_kia_connect_api/VehicleManager.py
+++ b/hyundai_kia_connect_api/VehicleManager.py
@@ -134,7 +134,7 @@ class VehicleManager:
     def check_and_refresh_token(self) -> bool:
         if self.token is None:
             self.initialize()
-        if self.token.valid_until <= dt.datetime.now(pytz.utc):
+        if self.token.valid_until <= dt.datetime.now(pytz.utc) or self.api.test_token(self.token) is False:
             _LOGGER.debug(f"{DOMAIN} - Refresh token expired")
             self.token: Token = self.api.login(self.username, self.password)
             self.token.pin = self.pin

--- a/hyundai_kia_connect_api/VehicleManager.py
+++ b/hyundai_kia_connect_api/VehicleManager.py
@@ -134,7 +134,10 @@ class VehicleManager:
     def check_and_refresh_token(self) -> bool:
         if self.token is None:
             self.initialize()
-        if self.token.valid_until <= dt.datetime.now(pytz.utc) or self.api.test_token(self.token) is False:
+        if (
+            self.token.valid_until <= dt.datetime.now(pytz.utc)
+            or self.api.test_token(self.token) is False
+        ):
             _LOGGER.debug(f"{DOMAIN} - Refresh token expired")
             self.token: Token = self.api.login(self.username, self.password)
             self.token.pin = self.pin


### PR DESCRIPTION
close issue: https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1039
+ Test token before each request. Test by sending a dummy request (Get # of notifications)
+ If the token expires, it will log in again. 

```
2025-02-20 03:50:33.410 DEBUG (SyncWorker_2) [hyundai_kia_connect_api.KiaUvoApiCA] hyundai_kia_connect_api - Test Token Response {"error":{"errorCode":"7403","errorDesc":"Your authentication has expired. Please return to the login page and enter your credentials."},"responseHeader":{"responseCode":1}}
2025-02-20 03:50:33.411 DEBUG (SyncWorker_2) [hyundai_kia_connect_api.VehicleManager] hyundai_kia_connect_api - Refresh token expired
2025-02-20 03:50:33.809 DEBUG (SyncWorker_2) [hyundai_kia_connect_api.KiaUvoApiCA] hyundai_kia_connect_api - Sign In Response {"responseHeader":{"responseCode":0,"responseDesc":"Success"},"result":{"accountInformation":
...
```