### PR TITLE
fix: osm geocoded location 403 error

### DIFF
--- a/hyundai_kia_connect_api/ApiImpl.py
+++ b/hyundai_kia_connect_api/ApiImpl.py
@@ -124,10 +124,11 @@ class ApiImpl:
                 + "&format=json&addressdetails=1&zoom=18"
                 + email_parameter
             )
+            headers = {'user-agent': 'curl/7.81.0'}
             _LOGGER.debug(
                 f"{DOMAIN} - Running update geocode location with value: {url}"
             )
-            response = requests.get(url)
+            response = requests.get(url, headers=headers)
             _LOGGER.debug(f"{DOMAIN} - geocode location raw response: {response}")
             try:
                 response = response.json()


### PR DESCRIPTION
403 error due to missing user-agent when requesting geocode from osm api. 
Add curl agent the the problem is solved. 