### PR TITLE
fix: avoid unnecessary geocode lookups

### DIFF
--- a/hyundai_kia_connect_api/ApiImpl.py
+++ b/hyundai_kia_connect_api/ApiImpl.py
@@ -156,13 +156,10 @@ class ApiImpl:
                     )
                     self.previous_latitude = vehicle.location_latitude
                     self.previous_longitude = vehicle.location_longitude
-                    _LOGGER.debug(
-                        f"{DOMAIN} - geocode openstreetmap ({vehicle.location_latitude},{vehicle.location_longitude}) {vehicle.geocode}"  # noqa
-                    )
+                    _LOGGER.debug(f"{DOMAIN} - geocode openstreetmap")
             elif GEO_LOCATION_PROVIDERS[provider] == GOOGLE:
                 if API_KEY:
                     latlong = (vehicle.location_latitude, vehicle.location_longitude)
-                    _LOGGER.debug(f"{DOMAIN} - Running update geocode google")
                     try:
                         geolocator = GoogleV3(api_key=API_KEY)
                         locations = geolocator.reverse(latlong)
@@ -170,9 +167,7 @@ class ApiImpl:
                             vehicle.geocode = locations
                             self.previous_latitude = vehicle.location_latitude
                             self.previous_longitude = vehicle.location_longitude
-                        _LOGGER.debug(
-                            f"{DOMAIN} - geocode google ({vehicle.location_latitude},{vehicle.location_longitude}) {vehicle.geocode}"  # noqa
-                        )
+                            _LOGGER.debug(f"{DOMAIN} - geocode google")
                     except Exception as ex:  # pylint: disable=broad-except
                         _LOGGER.warning(f"{DOMAIN} - failed geocode Google: {ex}")
                         vehicle.geocode = None


### PR DESCRIPTION
I added support for Google address lookup to [hyundai_kia_connect_monitor](https://github.com/ZuinigeRijder/hyundai_kia_connect_monitor/releases/tag/R4.5.0). For Google 10000 address lookups are free per month. Although you will not easily exceed to this limit, maybe other software uses the same Google API key. So it is better to not ask for the address lookup if the coordinates are the same as already asked the previous time. Note that this also gives a speedup if you are using openstreetmap as address lookup (unnecessary API call). 