### PR TITLE
fix: obey ccs timezones

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -4,6 +4,8 @@ import datetime as dt
 import requests
 import logging
 from typing import Optional
+from datetime import timedelta, timezone
+
 
 from time import sleep
 
@@ -119,9 +121,14 @@ class ApiImplType1(ApiImpl):
         }
 
     def _update_vehicle_properties_ccs2(self, vehicle: Vehicle, state: dict) -> None:
+        if get_child_value(state, "Offset"):
+            offset = get_child_value(state, "Offset")
+            hours = int(offset)
+            minutes = int((offset - hours) * 60)
+            vehicle.timezone = timezone(timedelta(hours=hours, minutes=minutes))
         if get_child_value(state, "Date"):
             vehicle.last_updated_at = parse_datetime(
-                get_child_value(state, "Date"), self.data_timezone
+                get_child_value(state, "Date"), vehicle.timezone
             )
         else:
             vehicle.last_updated_at = dt.datetime.now(self.data_timezone)


### PR DESCRIPTION
This fixes a key bug that would impact Australia being a +10 offset. I would like eyes on this. Only touches ccs cars since I don't know if offset exists for non ccs cars or if they still live in UTC for data. If someone has a non ccs car would be great to check the data in the API for "offset".

@fuatakgun  could you check if your CCS car now reports offset? 