### PR TITLE
fix: Update start_climate for older US Hyundai vehicles

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
@@ -811,17 +811,19 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
         if vehicle.engine_type == ENGINE_TYPES.EV:
             data = {
                 "airCtrl": int(options.climate),
-                "igniOnDuration": options.duration,
                 "airTemp": {"value": str(options.set_temp), "unit": 1},
                 "defrost": options.defrost,
                 "heating1": int(options.heating),
-                "seatHeaterVentInfo": {
+            }
+            # Older vehicles do not support seat heater vent info or duration
+            if vehicle.generation == 3:
+                data["igniOnDuration"] = options.duration
+                data["seatHeaterVentInfo"] = {
                     "drvSeatHeatState": options.front_left_seat,
                     "astSeatHeatState": options.front_right_seat,
                     "rlSeatHeatState": options.rear_left_seat,
                     "rrSeatHeatState": options.rear_right_seat,
-                },
-            }
+                }
         else:
             data = {
                 "Ims": 0,


### PR DESCRIPTION
This should fix the issues in Hyundai-Kia-Connect/kia_uvo#1135. Wasn't sure of the best method to determine when to include the extra options so based it off of `vehicle.generation`. Happy to update if there's a better way to do this but I was able to test successfully with both a 2025 Ioniq 6 (generation 2) and a 2025 Ioniq 5 (generation 3).