### PR TITLE
fix: CA login by bumping the cloudscraper version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ python-dateutil
 pytz>=2021.3
 certifi>=2024.6.2
 geopy >= 2.2.0
+git+https://github.com/VeNoMouS/cloudscraper.git@v3.0.0#egg=cloudscraper
 cloudscraper>=1.2.60

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ python-dateutil
 pytz>=2021.3
 certifi>=2024.6.2
 geopy >= 2.2.0
-git+https://github.com/VeNoMouS/cloudscraper.git@v3.0.0#egg=cloudscraper
+git+https://github.com/VeNoMouS/cloudscraper.git@3.0.0#egg=cloudscraper
 cloudscraper>=1.2.60

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,4 +11,5 @@ twine==6.1.0
 watchdog==6.0.0
 wheel==0.45.1
 geopy>=2.2.0
+git+https://github.com/VeNoMouS/cloudscraper.git@v3.0.0#egg=cloudscraper
 cloudscraper>=1.2.60

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,5 +11,5 @@ twine==6.1.0
 watchdog==6.0.0
 wheel==0.45.1
 geopy>=2.2.0
-git+https://github.com/VeNoMouS/cloudscraper.git@v3.0.0#egg=cloudscraper
+git+https://github.com/VeNoMouS/cloudscraper.git@3.0.0#egg=cloudscraper
 cloudscraper>=1.2.60


### PR DESCRIPTION
The latest 3.0 version of cloudscraper released 2 weeks ago solves the Cloudflare blocking. 
However, it's not registered in Pypl yet. 
Trying to get the version through git. 
fix issue: #824 