### PR TITLE
fix: KiaUvoApiCA.py Removing cloudscraper

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -61,6 +61,7 @@ class KiaUvoApiCA(ApiImpl):
         self.old_vehicle_status = {}
         self.API_URL: str = "https://" + self.BASE_URL + "/tods/api/"
         self.API_HEADERS = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:141.0) Gecko/20100101 Firefox/141.0",
             "content-type": "application/json",
             "accept": "application/json",
             "accept-encoding": "gzip",

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -7,7 +7,7 @@ import datetime as dt
 import json
 import logging
 import pytz
-import cloudscraper
+import requests
 
 
 from dateutil.tz import tzoffset
@@ -61,7 +61,7 @@ class KiaUvoApiCA(ApiImpl):
         self.old_vehicle_status = {}
         self.API_URL: str = "https://" + self.BASE_URL + "/tods/api/"
         self.API_HEADERS = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:141.0) Gecko/20100101 Firefox/141.0",
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:141.1) Gecko/20100101 Firefox/141.1",
             "content-type": "application/json",
             "accept": "application/json",
             "accept-encoding": "gzip",
@@ -81,7 +81,7 @@ class KiaUvoApiCA(ApiImpl):
     @property
     def sessions(self):
         if not self._sessions:
-            self._sessions = cloudscraper.create_scraper()
+            self._sessions = requests.session()
         return self._sessions
 
     def _check_response_for_errors(self, response: dict) -> None:


### PR DESCRIPTION
Since it seems that HA is unable to correctly retrieve cloudscraper 3.0 from GitHub, the KiaUvoAPICA.py file was modified to use requests for the time being.