### PR TITLE
feat: Add a retry for requests

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -61,6 +61,7 @@ class KiaUvoApiCA(ApiImpl):
         self.old_vehicle_status = {}
         self.API_URL: str = "https://" + self.BASE_URL + "/tods/api/"
         self.API_HEADERS = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:141.0) Gecko/20100101 Firefox/141.0",
             "content-type": "application/json",
             "accept": "application/json",
             "accept-encoding": "gzip",

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -9,7 +9,6 @@ import logging
 import pytz
 import requests
 
-
 from dateutil.tz import tzoffset
 
 from .ApiImpl import ApiImpl, ClimateRequestOptions
@@ -38,6 +37,36 @@ from .utils import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class RetrySession(requests.Session):
+    def __init__(self, max_retries=3, delay=2, backoff=2):
+        super().__init__()
+        self.max_retries = max_retries
+        self.delay = delay
+        self.backoff = backoff
+
+    def post(self, url, **kwargs):
+        return self._request_with_retry('POST', url, **kwargs)
+
+    def _request_with_retry(self, method, url, **kwargs):
+        attempt = 0
+        current_delay = self.delay
+
+        while attempt < self.max_retries:
+            try:
+                _LOGGER.debug(f"{DOMAIN} - Try to request {attempt + 1}")
+                response = super().request(method, url, **kwargs)
+
+                return response
+            except requests.exceptions.RequestException as e:
+                _LOGGER.debug(f"{DOMAIN} - {method} Attempt {attempt + 1}: Connection error ({e}), retrying...")
+
+                time.sleep(current_delay)
+                current_delay *= self.backoff
+                attempt += 1
+
+        raise last_exception
 
 
 class KiaUvoApiCA(ApiImpl):
@@ -81,7 +110,7 @@ class KiaUvoApiCA(ApiImpl):
     @property
     def sessions(self):
         if not self._sessions:
-            self._sessions = requests.session()
+            self._sessions = RetrySession(max_retries=4, delay=2, backoff=2)
         return self._sessions
 
     def _check_response_for_errors(self, response: dict) -> None:

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -7,7 +7,7 @@ import datetime as dt
 import json
 import logging
 import pytz
-import cloudscraper
+import requests
 
 
 from dateutil.tz import tzoffset
@@ -61,7 +61,7 @@ class KiaUvoApiCA(ApiImpl):
         self.old_vehicle_status = {}
         self.API_URL: str = "https://" + self.BASE_URL + "/tods/api/"
         self.API_HEADERS = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:141.0) Gecko/20100101 Firefox/141.0",
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:141.1) Gecko/20100101 Firefox/141.1",
             "content-type": "application/json",
             "accept": "application/json",
             "accept-encoding": "gzip",
@@ -81,7 +81,7 @@ class KiaUvoApiCA(ApiImpl):
     @property
     def sessions(self):
         if not self._sessions:
-            self._sessions = cloudscraper.create_scraper()
+            self._sessions = requests.session()
         return self._sessions
 
     def _check_response_for_errors(self, response: dict) -> None:


### PR DESCRIPTION
From time to time, my login fails with error 104 (reset by peer).
I’m not sure if it’s something related to my network, but this only happens during the login process.
I want to check whether it’s worth pushing the change or keeping it on standby to see if others experience the same problem.
I added the class to the file for the reason I mentioned earlier.