### PR TITLE
fix: Use old login methods for hyundai in EU

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -112,7 +112,7 @@ class KiaUvoApiEU(ApiImplType1):
                 "RFtoRq/vDXJmRndoZaZQyfOot7OrIqGVFj96iY2WL3yyH5Z/pUvlUhqmCxD2t+D65SQ="
             )
             self.BASIC_AUTHORIZATION: str = "Basic NmQ0NzdjMzgtM2NhNC00Y2YzLTk1NTctMmExOTI5YTk0NjU0OktVeTQ5WHhQekxwTHVvSzB4aEJDNzdXNlZYaG10UVI5aVFobUlGampvWTRJcHhzVg=="  # noqa
-            self.LOGIN_FORM_HOST = "https://idpconnect-eu.hyundai.com"
+            self.LOGIN_FORM_HOST = "eu-account.hyundai.com"
             self.PUSH_TYPE = "GCM"
         elif BRANDS[self.brand] == BRAND_GENESIS:
             self.BASE_DOMAIN: str = "prd-eu-ccapi.genesis.com"
@@ -147,16 +147,17 @@ class KiaUvoApiEU(ApiImplType1):
                 + "&state=ccsp"
             )
         elif BRANDS[self.brand] == BRAND_HYUNDAI:
-            auth_client_id = "6d477c38-3ca4-4cf3-9557-2a1929a94654"
+            auth_client_id = "64621b96-0f0d-11ec-82a8-0242ac130003"
             self.LOGIN_FORM_URL: str = (
-                self.LOGIN_FORM_HOST
-                + "/auth/api/v2/user/oauth2/authorize?response_type=code&client_id="
+                "https://"
+                + self.LOGIN_FORM_HOST
+                + "/auth/realms/euhyundaiidm/protocol/openid-connect/auth?client_id="
                 + auth_client_id
-                + "&redirect_uri="
+                + "&scope=openid%20profile%20email%20phone&response_type=code&hkid_session_reset=true&redirect_uri="  # noqa
                 + self.USER_API_URL
-                + "oauth2/redirect&lang="
+                + "integration/redirect/login&ui_locales="
                 + self.LANGUAGE
-                + "&state=ccsp"
+                + "&state=$service_id:$user_id"
             )
         elif BRANDS[self.brand] == BRAND_GENESIS:
             auth_client_id = "3020afa2-30ff-412a-aa51-d28fbe901e10"
@@ -1091,43 +1092,57 @@ class KiaUvoApiEU(ApiImplType1):
     def _get_authorization_code_with_redirect_url(
         self, username, password, cookies
     ) -> str:
-        url = self.LOGIN_FORM_URL
-        headers = {"Content-type": "application/json"}
-        data = {"email": username, "password": password}
-        response = requests.get(url, headers=headers, cookies=cookies)
-        _LOGGER.debug(f"{DOMAIN} - Sign In Response: {response}")
+        if BRANDS[self.brand] == BRAND_HYUNDAI:
+            url = self.USER_API_URL + "signin"
+            headers = {"Content-type": "application/json"}
+            data = {"email": username, "password": password}
+            response = requests.post(
+                url, json=data, headers=headers, cookies=cookies
+            ).json()
+            _LOGGER.debug(f"{DOMAIN} - Sign In Response: {response}")
+            parsed_url = urlparse(response["redirectUrl"])
+            authorization_code = "".join(parse_qs(parsed_url.query)["code"])
+            return authorization_code
+        else:
+            url = self.LOGIN_FORM_URL
+            headers = {"Content-type": "application/json"}
+            data = {"email": username, "password": password}
+            response = requests.get(url, headers=headers, cookies=cookies)
+            _LOGGER.debug(f"{DOMAIN} - Sign In Response: {response}")
 
-        url_redirect = response.url
-        connector_session_key = re.search(
-            r"connector_session_key%3D([0-9a-fA-F-]{36})", url_redirect
-        ).group(1)
-        url = self.LOGIN_FORM_HOST + "/auth/account/signin"
-        headers = {
-            "content-type": "application/x-www-form-urlencoded",
-            "origin": self.LOGIN_FORM_HOST,
-        }
-        data = {
-            "client_id": self.CCSP_SERVICE_ID,
-            "encryptedPassword": "false",
-            "orgHmgSid": "",
-            "password": password,
-            "redirect_uri": "https://"
-            + self.BASE_DOMAIN
-            + ":8080/api/v1/user/oauth2/redirect",
-            "state": "ccsp",
-            "username": username,
-            "remember_me": "false",
-            "connector_session_key": connector_session_key,
-            "_csrf": "",
-        }
+            url_redirect = response.url
+            connector_session_key = re.search(
+                r"connector_session_key%3D([0-9a-fA-F-]{36})", url_redirect
+            ).group(1)
+            url = self.LOGIN_FORM_HOST + "/auth/account/signin"
+            headers = {
+                "content-type": "application/x-www-form-urlencoded",
+                "origin": self.LOGIN_FORM_HOST,
+            }
+            data = {
+                "client_id": self.CCSP_SERVICE_ID,
+                "encryptedPassword": "false",
+                "orgHmgSid": "",
+                "password": password,
+                "redirect_uri": "https://"
+                + self.BASE_DOMAIN
+                + ":8080/api/v1/user/oauth2/redirect",
+                "state": "ccsp",
+                "username": username,
+                "remember_me": "false",
+                "connector_session_key": connector_session_key,
+                "_csrf": "",
+            }
 
-        response = requests.post(url, headers=headers, data=data, allow_redirects=False)
-        location = response.headers["Location"]
-        code_location = re.search(
-            r"code=([0-9a-fA-F-]{36}\.[0-9a-fA-F-]{36}\.[0-9a-fA-F-]{36})", location
-        ).group(1)
+            response = requests.post(
+                url, headers=headers, data=data, allow_redirects=False
+            )
+            location = response.headers["Location"]
+            code_location = re.search(
+                r"code=([0-9a-fA-F-]{36}\.[0-9a-fA-F-]{36}\.[0-9a-fA-F-]{36})", location
+            ).group(1)
 
-        return code_location
+            return code_location
 
     def _get_authorization_code_with_form(self, username, password, cookies) -> str:
         url = self.USER_API_URL + "integrationinfo"
@@ -1228,18 +1243,40 @@ class KiaUvoApiEU(ApiImplType1):
         return authorization_code
 
     def _get_access_token(self, stamp, authorization_code):
-        url = self.LOGIN_FORM_HOST + "/auth/api/v2/user/oauth2/token"
-        data = {
-            "grant_type": "authorization_code",
-            "code": authorization_code,
-            "redirect_uri": "https://"
-            + self.BASE_DOMAIN
-            + ":8080/api/v1/user/oauth2/redirect",
-            "client_id": self.CCSP_SERVICE_ID,
-            "client_secret": "secret",
-        }
+        if BRANDS[self.brand] == BRAND_HYUNDAI:
+            # Get Access Token #
+            url = self.USER_API_URL + "oauth2/token"
+            headers = {
+                "Authorization": self.BASIC_AUTHORIZATION,
+                "Stamp": stamp,
+                "Content-type": "application/x-www-form-urlencoded",
+                "Host": self.BASE_URL,
+                "Connection": "close",
+                "Accept-Encoding": "gzip, deflate",
+                "User-Agent": USER_AGENT_OK_HTTP,
+            }
 
-        response = requests.post(url, data=data, allow_redirects=False)
+            data = (
+                "grant_type=authorization_code&redirect_uri=https%3A%2F%2F"
+                + self.BASE_DOMAIN
+                + "%3A8080%2Fapi%2Fv1%2Fuser%2Foauth2%2Fredirect&code="
+                + authorization_code
+            )
+            response = requests.post(url, data=data, headers=headers)
+        else:
+            url = self.LOGIN_FORM_HOST + "/auth/api/v2/user/oauth2/token"
+            data = {
+                "grant_type": "authorization_code",
+                "code": authorization_code,
+                "redirect_uri": "https://"
+                + self.BASE_DOMAIN
+                + ":8080/api/v1/user/oauth2/redirect",
+                "client_id": self.CCSP_SERVICE_ID,
+                "client_secret": "secret",
+            }
+
+            response = requests.post(url, data=data, allow_redirects=False)
+
         response = response.json()
 
         token_type = response["token_type"]


### PR DESCRIPTION
It looks like Hyundai rolled back authentification methods in EU to previous versions.

Therefore I added some condition to differentiate between Hyundai and Kia/Genesis during Authentication process

Potential fix for https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1231 and https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/855