### PR TITLE
fix: Partial patch for Kia Europe login

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -202,21 +202,23 @@ class KiaUvoApiEU(ApiImplType1):
                     username, password, cookies
                 )
             except Exception:
-                _LOGGER.debug(f"{DOMAIN} - get_authorization_code_with_redirect_url failed")
+                _LOGGER.debug(
+                    f"{DOMAIN} - get_authorization_code_with_redirect_url failed"
+                )
                 authorization_code = self._get_authorization_code_with_form(
                     username, password, cookies
                 )
-    
+
             if authorization_code is None:
                 raise AuthenticationError("Login Failed")
-    
+
             _, access_token, authorization_code, expires_in = self._get_access_token(
                 stamp, authorization_code
             )
             valid_until = dt.datetime.now(pytz.utc) + dt.timedelta(seconds=expires_in)
-    
+
             _, refresh_token = self._get_refresh_token(stamp, authorization_code)
-    
+
             return Token(
                 username=username,
                 password=password,


### PR DESCRIPTION
The stable use of `hyundai_kia_connect_api` and Kia Europe is currently only possible with a refresh_token.

This commit fixes `KiaUvoApiEU.py` so that the refresh_token can be used in the password field instead of the Kia password.

This only fixes part of the problem. The part about how to obtain the refresh_token currently still has to be done via a second method.

The test with `pytest` ran successfully. To do this, I set:
```
export KIA_EU_FUATAKGUN_USERNAME="m@m.com"
export KIA_EU_FUATAKGUN_PASSWORD="<REFRESH_TOKEN>"

$ pytest
==================================== test session starts =====================================
platform linux -- Python 3.12.3, pytest-8.4.1, pluggy-1.6.0
rootdir: ../hyundai_kia_connect_api
configfile: setup.cfg
collected 4 items                                                                            

tests/eu_check_response_for_errors_test.py ...                                         [ 75%]
tests/eu_login_test.py .                                                               [100%]

===================================== 4 passed in 1.64s ======================================

```

https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1277