### PR TITLE
fix: Exception For auth in Kia EU

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -71,6 +71,7 @@ def _check_response_for_errors(response: dict) -> None:
     """
 
     error_code_mapping = {
+        "7501": AuthenticationError,
         "4002": DeviceIDError,
         "4004": DuplicateRequestError,
         "4081": RequestTimeoutError,
@@ -102,6 +103,10 @@ def _check_response_for_errors(response: dict) -> None:
         else:
             _LOGGER.error(f"Unknown error in API response: {error_reason}")
             raise APIError(f"Unknown error in API response: {error_reason}")
+    elif "retCode" in response and "retMsg" in response:
+        retMSG = response["retMsg"]
+        if retMSG == "Received unexpected statusCode":
+            raise AuthenticationError(retMSG)
 
 
 class ApiImplType1(ApiImpl):

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -1359,6 +1359,8 @@ class KiaUvoApiEU(ApiImplType1):
             response = requests.post(url, data=data, allow_redirects=False)
 
         response = response.json()
+        _LOGGER.debug(f"{DOMAIN} - Get Access Token Response: {response}")
+        _check_response_for_errors(response)
 
         token_type = response["token_type"]
         access_token = token_type + " " + response["access_token"]


### PR DESCRIPTION
Throw and exception when kia EU login fails for wrong password.  This will get caught by HA and throw the correction exception that triggers re-auth flow. 