### PR TITLE
fix: Accommodate multiple sources for real-time charging power

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -330,6 +330,10 @@ class ApiImplType1(ApiImpl):
         vehicle.ev_battery_percentage = get_child_value(
             state, "Green.BatteryManagement.BatteryRemain.Ratio"
         )
+        if get_child_value(state, "Green.Electric.SmartGrid.RealTimePower"):
+            vehicle.ev_charging_power = get_child_value(
+                state, "Green.Electric.SmartGrid.RealTimePower"
+            )
         vehicle.ev_battery_remain = get_child_value(
             state, "Green.BatteryManagement.BatteryRemain.Value"
         )

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -430,7 +430,9 @@ class KiaUvoApiEU(ApiImplType1):
         elif ev_charge_port_door_is_open == 2:
             vehicle.ev_charge_port_door_is_open = False
 
-        if get_child_value(state, "vehicleStatus.evStatus.batteryPower.batteryStndChrgPower"):
+        if get_child_value(
+            state, "vehicleStatus.evStatus.batteryPower.batteryStndChrgPower"
+        ):
             vehicle.ev_charging_power = get_child_value(
                 state, "vehicleStatus.evStatus.batteryPower.batteryStndChrgPower"
             )

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -430,9 +430,10 @@ class KiaUvoApiEU(ApiImplType1):
         elif ev_charge_port_door_is_open == 2:
             vehicle.ev_charge_port_door_is_open = False
 
-        vehicle.ev_charging_power = get_child_value(
-            state, "vehicleStatus.evStatus.batteryPower.batteryStndChrgPower"
-        )
+        if get_child_value(state, "vehicleStatus.evStatus.batteryPower.batteryStndChrgPower"):
+            vehicle.ev_charging_power = get_child_value(
+                state, "vehicleStatus.evStatus.batteryPower.batteryStndChrgPower"
+            )
 
         if (
             get_child_value(


### PR DESCRIPTION
Following on from my issue post ([1305](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1305)) this PR enables the sensor for charging power to be brought in for more vehicles (confirmed working on 2024 Hyundai Kona EV). Shouldn't interfere with the preexisting code that was working for another user's Ioniq 5.