### PR TITLE
fix: USA - Cast vehicle generation to integer

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
@@ -743,7 +743,7 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
                 registration_date=entry["enrollmentDate"],
                 timezone=self.data_timezone,
                 enabled=entry.get("enrollmentStatus") != "CANCELLED",
-                generation=entry.get("vehicleGeneration", 2),
+                generation=int(entry.get("vehicleGeneration", "2")),
             )
             result.append(vehicle)
 


### PR DESCRIPTION
The generation check for climate start was not working properly because vehicle generation was stored as a string. Casting the generation to integer to make it work properly.