### PR TITLE
fix(EU): ev_charging_power for EU BEVs

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -433,8 +433,11 @@ class KiaUvoApiEU(ApiImplType1):
         elif ev_charge_port_door_is_open == 2:
             vehicle.ev_charge_port_door_is_open = False
 
-        if get_child_value(
-            state, "vehicleStatus.evStatus.batteryPower.batteryStndChrgPower"
+        if (
+            get_child_value(
+                state, "vehicleStatus.evStatus.batteryPower.batteryStndChrgPower"
+            )
+            is not None
         ):
             vehicle.ev_charging_power = get_child_value(
                 state, "vehicleStatus.evStatus.batteryPower.batteryStndChrgPower"


### PR DESCRIPTION
97e100b did introduce a bug, as the ev_charging_power will not be populated when the vehicle currently is not charging, e.g. power is 0.