### PR TITLE
fix: restore explicit timezone for Canadian responses

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -293,7 +293,7 @@ class KiaUvoApiCA(ApiImpl):
         last_updated_at = parse_datetime(
             get_child_value(state, "status.lastStatusDate"), dt.timezone.utc
         )
-        ref_date = dt.datetime.now()
+        ref_date = dt.datetime.now(tz=dt.timezone.utc)
         tz = detect_timezone_for_date(last_updated_at, ref_date, CA_TIMEZONES)
         if tz:
             _LOGGER.debug(f"{DOMAIN} - Set vehicle.timezone to {tz} (guessed)")


### PR DESCRIPTION
Fixes a regression introduced with a previous Canadian timezone fix, `datetime.now()` requires an explicit timezone parameter to prevent:

      File "hyundai_kia_connect_api/utils.py", line 107, in detect_timezone_for_date
        delta = (ref_date - date.replace(tzinfo=tz)).total_seconds()
                 ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
    TypeError: can't subtract offset-naive and offset-aware datetimes

Link: https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1316#issuecomment-3341841390
Fixes: 753076d62607 (#896)