### PR TITLE
feat: make Google geocode support optional, warn on missing API key

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 beautifulsoup4>=4.10.0
 requests
 certifi>=2024.6.2
-geopy >= 2.2.0

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,9 @@ setup(
     ],
     description="Python Boilerplate contains all the boilerplate you need to create a Python package.",
     install_requires=requirements,
+    extras_require={
+        "google": ["geopy>=2.2.0"],
+    },
     license="MIT license",
     long_description=long_description,
     include_package_data=True,


### PR DESCRIPTION
Geocoding via Google is optional and requires extra configuration. Mark the related geopy library as optional, other projects that require Google geocoding support can enable it with a dependency like:

    pip install 'hyundai_kia_connect_api[google]'

Warn when `geocode_provider` is Google and `geocode_api_key` is missing.