### PR TITLE
fix: improve error handling and coord parsing in KiaUvoApiEU

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -801,9 +801,9 @@ class KiaUvoApiEU(ApiImplType1):
             ).json()
             _LOGGER.debug(f"{DOMAIN} - _get_location response: {response}")
             _check_response_for_errors(response)
-            return response["resMsg"]["gpsDetail"]
-        except Exception:
-            _LOGGER.warning(f"{DOMAIN} - _get_location failed")
+            return response["resMsg"]["coord"]
+        except Exception as e:
+            _LOGGER.error(f"{DOMAIN} - _get_location failed: {e}", exc_info=True)
             return None
 
     def _get_forced_vehicle_state(self, token: Token, vehicle: Vehicle) -> dict:


### PR DESCRIPTION
## Summary
- Fixed geolocation bug by correcting the response field from `gpsDetail` to `coord`
- Improved error handling with detailed exception logging
- Enhanced visibility by upgrading log level from warning to error

## Changes
- Changed `response["resMsg"]["gpsDetail"]` to `response["resMsg"]["coord"]` in `_get_location` method
- Added detailed exception logging with `exc_info=True` for better debugging
- Upgraded log level from `warning` to `error` for failed location requests