### PR TITLE
fix: ev_charging_power for BEVs with power in Green.Electric.SmartGrid

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -337,7 +337,7 @@ class ApiImplType1(ApiImpl):
         vehicle.ev_battery_percentage = get_child_value(
             state, "Green.BatteryManagement.BatteryRemain.Ratio"
         )
-        if get_child_value(state, "Green.Electric.SmartGrid.RealTimePower"):
+        if get_child_value(state, "Green.Electric.SmartGrid.RealTimePower") is not None:
             vehicle.ev_charging_power = get_child_value(
                 state, "Green.Electric.SmartGrid.RealTimePower"
             )


### PR DESCRIPTION
[PR 903](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/pull/903/commits/74992962ef2cf47dc16d696e30229ff52a23d3e9) fixed the logic with zero values for ev_charging_power in KiaUvoApiEU.py, but not the identical issue in ApiImplType1.py. This PR just applies the same fix to the latter file.