### PR TITLE
feat: Add remote commands to Brazilian Hyundai BlueLink API

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
@@ -453,9 +453,7 @@ class HyundaiBlueLinkApiBR(ApiImpl):
         headers = self._get_authenticated_headers(token)
         headers["Authorization"] = control_token
         headers["ccsp-device-id"] = device_id
-        headers["ccuCCS2ProtocolSupport"] = str(
-            vehicle.ccu_ccs2_protocol_support or 0
-        )
+        headers["ccuCCS2ProtocolSupport"] = str(vehicle.ccu_ccs2_protocol_support or 0)
 
         payload = {"deviceId": device_id, "action": action.value}
         _LOGGER.debug(f"{DOMAIN} - Lock action request: %s", payload)
@@ -546,9 +544,7 @@ class HyundaiBlueLinkApiBR(ApiImpl):
         headers = self._get_authenticated_headers(token)
         headers["Authorization"] = control_token
         headers["ccsp-device-id"] = device_id
-        headers["ccuCCS2ProtocolSupport"] = str(
-            vehicle.ccu_ccs2_protocol_support or 0
-        )
+        headers["ccuCCS2ProtocolSupport"] = str(vehicle.ccu_ccs2_protocol_support or 0)
 
         payload = {"action": action, "deviceId": device_id}
         _LOGGER.debug(f"{DOMAIN} - Window action request: {payload}")
@@ -574,9 +570,7 @@ class HyundaiBlueLinkApiBR(ApiImpl):
         headers = self._get_authenticated_headers(token)
         headers["Authorization"] = control_token
         headers["ccsp-device-id"] = device_id
-        headers["ccuCCS2ProtocolSupport"] = str(
-            vehicle.ccu_ccs2_protocol_support or 0
-        )
+        headers["ccuCCS2ProtocolSupport"] = str(vehicle.ccu_ccs2_protocol_support or 0)
 
         _LOGGER.debug(f"{DOMAIN} - Hazard lights request")
 
@@ -639,9 +633,7 @@ class HyundaiBlueLinkApiBR(ApiImpl):
         headers = self._get_authenticated_headers(token)
         headers["Authorization"] = control_token
         headers["ccsp-device-id"] = device_id
-        headers["ccuCCS2ProtocolSupport"] = str(
-            vehicle.ccu_ccs2_protocol_support or 0
-        )
+        headers["ccuCCS2ProtocolSupport"] = str(vehicle.ccu_ccs2_protocol_support or 0)
 
         payload = {
             "action": "start",
@@ -682,9 +674,7 @@ class HyundaiBlueLinkApiBR(ApiImpl):
         headers = self._get_authenticated_headers(token)
         headers["Authorization"] = control_token
         headers["ccsp-device-id"] = device_id
-        headers["ccuCCS2ProtocolSupport"] = str(
-            vehicle.ccu_ccs2_protocol_support or 0
-        )
+        headers["ccuCCS2ProtocolSupport"] = str(vehicle.ccu_ccs2_protocol_support or 0)
 
         payload = {"action": "stop", "deviceId": device_id}
 


### PR DESCRIPTION
## Description

Adds remote command capabilities to the Brazilian Hyundai BlueLink API implementation (region 8, merged in PR #915).

## Changes

### New Methods - Remote Commands

**Authentication:**
- `_ensure_control_token()` - Manages PIN-based control tokens for remote commands (600s validity)

**Vehicle Control:**
- `lock_action()` - Lock/unlock doors via `POST /api/v2/spa/vehicles/{vehicleId}/control/door`
- `start_climate()` - Start climate with temperature/seat/defrost options via `POST /api/v2/spa/vehicles/{vehicleId}/control/engine`
- `stop_climate()` - Stop climate via same endpoint
- `set_windows_state()` - Open/close windows via `POST /api/v2/spa/vehicles/{vehicleId}/control/window`
- `start_hazard_lights()` - Activate hazard lights via `POST /api/v2/spa/vehicles/{vehicleId}/control/light`

**Status Tracking:**
- `check_action_status()` - Check command execution status via `GET /api/v1/spa/notifications/{vehicleId}/records`
  - Supports synchronous (with timeout) and asynchronous modes
- `get_notification_history()` - Get notification history via `GET /api/v1/spa/notifications/{vehicleId}/history`

### New Utilities (utils.py)

- `get_index_into_hex_temp()` - Convert Celsius temperature to hex format (e.g., 21°C → "15H")
  - Required by Brazilian API for climate control

### API Implementation Details

**Control Token Flow:**
1. Call `PUT /api/v1/user/pin` with PIN and deviceId
2. Receive controlToken (valid for 600s)
3. Use Bearer controlToken for all remote commands

**Brazilian API Specifics:**
- Window control affects all windows simultaneously (not individual control)
- Hazard lights endpoint activates lights only (no horn)
- Climate endpoint uses hex-encoded temperature values

## Testing

Tested on Hyundai Creta 2026 (ICE):
- Lock/unlock operations
- Climate start with temperature 21°C, duration 10min, seat heating
- Climate stop
- Window open/close
- Hazard lights
- Command status tracking

## Notes

- No changes to existing read-only functionality
- EV-specific features (charging control) not implemented - requires EV vehicle for testing
- Brazilian API uses `/api/v2/` for remote commands vs `/api/v1/` for data retrieval