### PR TITLE
fix: Change python 3.10 typing construct to one compatible with 3.9

### DIFF
--- a/hyundai_kia_connect_api/utils.py
+++ b/hyundai_kia_connect_api/utils.py
@@ -3,6 +3,7 @@
 
 import datetime
 import re
+from typing import Optional
 
 
 def get_child_value(data, key):
@@ -98,7 +99,7 @@ def detect_timezone_for_date(
     date: datetime.datetime,
     ref_date: datetime.datetime,
     timezones: list[datetime.timezone],
-) -> datetime.timezone | None:
+) -> Optional[datetime.timezone]:
     """
     Guess an appropriate timezone given a date with an unknown timezone and a
     nearby reference time in any valid timezone.


### PR DESCRIPTION
See [this issue](https://github.com/ZuinigeRijder/hyundai_kia_connect_monitor/issues/85).
And [this discussion](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/discussions/928)

Till recently hyundai_kia_connect_api was compatible with python 3.9. But one construct has been added, which forces one to update to python 3.10 or later. Some people cannot easily upgrade to python 3.10 or later. 

I think for such a small feature, we should avoid complains and avoiding a forced upgrade to python 3.10. Of course, I can imagine that in the future there are reasons to have constructs of python 3.10 or later. I also understand that there is no guarantee that python 3.9 will keep working in the future, but for now it is better to also allow python 3.9.