### PR TITLE
fix(EU): connection with Genesis (EU)

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -40,9 +40,6 @@ from .const import (
     TEMPERATURE_UNITS,
     VALET_MODE_ACTION,
 )
-from .exceptions import (
-    AuthenticationError,
-)
 from .utils import (
     get_child_value,
     get_hex_temp_into_index,
@@ -198,7 +195,6 @@ class KiaUvoApiEU(ApiImplType1):
             device_id=device_id,
             valid_until=valid_until,
         )
-
 
     def update_vehicle_with_cached_state(self, token: Token, vehicle: Vehicle) -> None:
         url = self.SPA_API_URL + "vehicles/" + vehicle.id


### PR DESCRIPTION
This is rebased https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/pull/879

Basically, now it uses same approach as KIA (by providing refresh_token instead of password).

Tested using simple:

```python
from hyundai_kia_connect_api import *
vm = VehicleManager(region=1, brand=3, username="email@gmail.com", password="refresh_token", pin="")
vm.check_and_refresh_token()
vm.update_all_vehicles_with_cached_state()
print(vm.vehicles)
``` 

Still haven't figured out best way to extract Genesis token. 