### PR TITLE
fix: ensure vehicles list is initialized after token check

### DIFF
--- a/hyundai_kia_connect_api/VehicleManager.py
+++ b/hyundai_kia_connect_api/VehicleManager.py
@@ -78,11 +78,16 @@ class VehicleManager:
 
         self.token: Token = None
         self.vehicles: dict = {}
+        self.vehicles_valid = False
 
     def initialize(self) -> None:
         self.token: Token = self.api.login(self.username, self.password)
         self.token.pin = self.pin
+        self.initialize_vehicles()
+
+    def initialize_vehicles(self):
         vehicles = self.api.get_vehicles(self.token)
+        self.vehicles_valid = True
         for vehicle in vehicles:
             self.vehicles[vehicle.id] = vehicle
 
@@ -146,6 +151,8 @@ class VehicleManager:
     def check_and_refresh_token(self) -> bool:
         if self.token is None:
             self.initialize()
+        elif not self.vehicles_valid:
+            self.initialize_vehicles()
         if (
             self.token.valid_until - timedelta(seconds=10)
             <= dt.datetime.now(dt.timezone.utc)


### PR DESCRIPTION
Until having once fetched successfully the list of vehicles, re-try to do so on each token validation/renewal again.
Else the `check_and_refresh_token` raises an exception the same way again as on (partial) `initialize`.

Note: as the login may be expensive afaik (logins limit in us?), I rejected the idea to dismiss the token already having retrieved before and stay with a partially initialized instance until next `check_and_refresh_token` call

#939