### PR TITLE
fix: Sanitize oversized ICE values from Hyundai API

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -120,15 +120,15 @@ class ApiImplType1(ApiImpl):
     def _sanitize_ice_value(self, state: dict) -> None:
         """
         Sanitize oversized ICE (Internal Combustion Engine) values in DTE data.
-        
+
         Hyundai's API sometimes returns corrupted ICE values that are too large
         (beyond 64-bit integer limits), which can cause issues when:
         - Serializing to JSON for JavaScript consumers
         - Storing in databases with 64-bit integer limits
         - Processing in other systems
-        
+
         This function replaces invalid ICE values with None and logs a warning.
-        
+
         Args:
             state: The vehicle state dictionary (modified in place)
         """
@@ -137,7 +137,7 @@ class ApiImplType1(ApiImpl):
             fuel_system = state.get("Drivetrain", {}).get("FuelSystem", {})
             dte = fuel_system.get("DTE", {})
             ice_value = dte.get("ICE")
-            
+
             if ice_value is not None:
                 # Check if the value is a number and unreasonably large
                 # A reasonable ICE range should be < 1,000,000 km/miles
@@ -147,7 +147,7 @@ class ApiImplType1(ApiImpl):
                     # (2^53 - 1 = 9,007,199,254,740,991) to prevent JSON issues
                     max_safe_integer = 9007199254740991
                     max_reasonable_range = 1000000
-                    
+
                     if ice_value > max_safe_integer or ice_value > max_reasonable_range:
                         _LOGGER.warning(
                             f"{DOMAIN} - Invalid ICE value detected ({ice_value}), "


### PR DESCRIPTION
# Fix: Sanitize oversized ICE values from Hyundai API

## Problem

Hyundai's API sometimes returns corrupted ICE (Internal Combustion Engine) values in the DTE (Distance To Empty) data that exceed 64-bit integer limits. The value `36893488145271620000` causes critical failures in Home Assistant and other downstream systems.

### Impact

The oversized ICE value causes multiple failures:

1. **JSON Serialization Errors** - Home Assistant cannot serialize state to JSON:
   ```
   TypeError: Integer exceeds 64-bit range
   File "/usr/src/homeassistant/homeassistant/core.py", line 1922, in as_dict_json
       return json_bytes(self._as_dict)
   ```

2. **WebSocket API Failures** - All WebSocket requests fail when trying to serialize states:
   ```
   ERROR (MainThread) [aiohttp.server] Error handling request
   File "/usr/src/homeassistant/homeassistant/components/api/__init__.py", line 228, in get
       body=b"".join((b"[", b",".join(states), b"]"))
   TypeError: Integer exceeds 64-bit range
   ```

3. **Recorder Warnings** - Home Assistant recorder cannot store state:
   ```
   WARNING (Recorder) [homeassistant.components.recorder.table_managers.state_attributes] 
   State is not JSON serializable: ... ICE=36893488145271620000 ... Integer exceeds 64-bit range
   ```

### Root Cause

The corrupted value comes directly from Hyundai's API in the CCS2 protocol response:
```json
"Drivetrain": {
  "FuelSystem": {
    "DTE": {
      "Total": 83,
      "Unit": 1,
      "ICE": 36893488145271620000  // ← Corrupted value from API
    }
  }
}
```

This value (`36893488145271620000`) exceeds:
- JavaScript's `Number.MAX_SAFE_INTEGER` (9,007,199,254,740,991)
- 64-bit signed integer maximum (9,223,372,036,854,775,807)
- Any reasonable vehicle range value

## Solution

This PR adds sanitization to detect and replace invalid ICE values before storing them in `vehicle.data`, preventing downstream serialization issues.

### Changes

1. **Added `_sanitize_ice_value()` method** that:
   - Detects oversized ICE values (> 1,000,000 or > JavaScript's MAX_SAFE_INTEGER)
   - Replaces invalid values with `None`
   - Logs a warning about corrupted data from Hyundai's API
   - Handles missing/malformed data structures gracefully

2. **Applied sanitization** before storing state in `vehicle.data` (line 549-551 in `ApiImplType1.py`)

### Testing

- ✅ Test script confirms corrupted values are sanitized to `None`
- ✅ Valid ICE values are preserved
- ✅ JSON serialization works correctly after sanitization

### Example Logs (Before Fix)

```
2025-11-30 12:27:37.838 ERROR (MainThread) [homeassistant.components.websocket_api.messages] 
Unable to serialize to JSON. Bad data found at $.event.a.sensor.kona_hev_data.a.vehicle_data.Drivetrain.FuelSystem.DTE.ICE=36893488145271620000

2025-11-30 12:27:45.098 WARNING (Recorder) [homeassistant.components.recorder.table_managers.state_attributes] 
State is not JSON serializable: ... ICE=36893488145271620000 ... Integer exceeds 64-bit range

2025-11-30 12:28:28.608 ERROR (MainThread) [aiohttp.server] Error handling request
TypeError: Integer exceeds 64-bit range
```

### Expected Behavior (After Fix)

- Invalid ICE values are replaced with `None` before storage
- Warning logged: `"Invalid ICE value detected (36893488145271620000), too large to be valid. Replacing with None."`
- No JSON serialization errors
- Home Assistant WebSocket API and recorder work normally

## Technical Details

- **Affected Field**: `Drivetrain.FuelSystem.DTE.ICE`
- **Validation Threshold**: Values > 1,000,000 km/miles or > JavaScript's MAX_SAFE_INTEGER
- **Replacement Value**: `None` (instead of corrupted integer)
- **Impact**: Prevents JSON serialization failures in Home Assistant and other consumers

## Related

This fix addresses issues reported in Home Assistant integrations using this library, specifically:
- WebSocket API failures
- Recorder storage failures  
- JSON serialization errors when accessing vehicle state