### PR TITLE
fix: remove un-used token

### DIFF
--- a/hyundai_kia_connect_api/ApiImpl.py
+++ b/hyundai_kia_connect_api/ApiImpl.py
@@ -88,7 +88,6 @@ class ApiImpl:
         self,
         username: str,
         password: str,
-        token: Token | None = None,
         otp_handler: ty.Callable[[dict], dict] | None = None,
     ) -> Token:
         """Login into cloud endpoints and return Token"""

--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
@@ -156,7 +156,6 @@ class HyundaiBlueLinkApiBR(ApiImpl):
         self,
         username: str,
         password: str,
-        token: Token | None = None,
         otp_handler: ty.Callable[[dict], dict] | None = None,
     ) -> Token:
         """Login to Brazilian Hyundai API."""

--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
@@ -128,7 +128,6 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
         self,
         username: str,
         password: str,
-        token: Token | None = None,
         otp_handler: ty.Callable[[dict], dict] | None = None,
     ) -> Token:
         # Sign In with Email and Password and Get Authorization Code

--- a/hyundai_kia_connect_api/KiaUvoApiAU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiAU.py
@@ -86,7 +86,6 @@ class KiaUvoApiAU(ApiImplType1):
         self,
         username: str,
         password: str,
-        token: Token | None = None,
         otp_handler: ty.Callable[[dict], dict] | None = None,
     ) -> Token:
         stamp = self._get_stamp()

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -193,7 +193,6 @@ class KiaUvoApiCA(ApiImpl):
         self,
         username: str,
         password: str,
-        token: Token | None = None,
         otp_handler: ty.Callable[[dict], dict] | None = None,
     ) -> Token:
         # Sign In with Email and Password and Get Authorization Code

--- a/hyundai_kia_connect_api/KiaUvoApiCN.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCN.py
@@ -158,7 +158,6 @@ class KiaUvoApiCN(ApiImplType1):
         self,
         username: str,
         password: str,
-        token: Token | None = None,
         otp_handler: ty.Callable[[dict], dict] | None = None,
     ) -> Token:
         device_id = self._get_device_id()

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -181,7 +181,6 @@ class KiaUvoApiEU(ApiImplType1):
         self,
         username: str,
         password: str,
-        token: Token | None = None,
         otp_handler: ty.Callable[[dict], dict] | None = None,
     ) -> Token:
         stamp = self._get_stamp()

--- a/hyundai_kia_connect_api/KiaUvoApiIN.py
+++ b/hyundai_kia_connect_api/KiaUvoApiIN.py
@@ -126,7 +126,6 @@ class KiaUvoApiIN(ApiImplType1):
         self,
         username: str,
         password: str,
-        token: Token | None = None,
         otp_handler: ty.Callable[[dict], dict] | None = None,
     ) -> Token:
         stamp = self._get_stamp()

--- a/hyundai_kia_connect_api/VehicleManager.py
+++ b/hyundai_kia_connect_api/VehicleManager.py
@@ -87,7 +87,6 @@ class VehicleManager:
         self.token: Token = self.api.login(
             self.username,
             self.password,
-            token=self.token,
             otp_handler=self.otp_handler,
         )
         self.token.pin = self.pin


### PR DESCRIPTION
The API files are stateless.  As such removing the token.   USA Kia file isn't stateless like other regions so needs to be fixed. 
#972 