### PR TITLE
fix(EU): Handle different return keys in _get_location

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -813,7 +813,8 @@ class KiaUvoApiEU(ApiImplType1):
             ).json()
             _LOGGER.debug(f"{DOMAIN} - _get_location response: {response}")
             _check_response_for_errors(response)
-            return response["resMsg"]["coord"]
+            res_msg = response.get("resMsg", {})
+            return res_msg.get("coord") or res_msg.get("gpsDetail")
         except Exception as e:
             _LOGGER.error(f"{DOMAIN} - _get_location failed: {e}", exc_info=True)
             return None


### PR DESCRIPTION
It seems that the API could also return the old gpsDetail instead of coords - this handles both potential returns

closes #993 