### PR TITLE
fix(EU): fix correct location key

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -813,7 +813,7 @@ class KiaUvoApiEU(ApiImplType1):
             ).json()
             _LOGGER.debug(f"{DOMAIN} - _get_location response: {response}")
             _check_response_for_errors(response)
-            return response["resMsg"]["gpsDetail"]["coord"]
+            return response["resMsg"]["gpsDetail"]
         except Exception as e:
             _LOGGER.error(f"{DOMAIN} - _get_location failed: {e}", exc_info=True)
             return None


### PR DESCRIPTION
fixes #1003 

sorry, i misinterpreted the key structure, this corrects it according to: 

```json
{'retCode': 'S', 'resCode': '0000', 'resMsg': {'gpsDetail': {'coord': {'lat': xx.xxxxx, 'lon': yy.yyyyy, 'alt': 0, 'type': 0}, 'head': 0, 'speed': {'value': 0, 'unit': 0}, 'accuracy': {'hdop': 0, 'pdop': 0}, 'time': '20260111172656'}, 'drvDistance': {'rangeByFuel': {'evModeRange': {'value': 165, 'unit': 1}, 'totalAvailableRange': {'value': 165, 'unit': 1}}, 'type': 2}}, 'msgId': '...msgid...'}
```

wanted to forcepush the pr #1003 but you were quick!