### PR TITLE
fix(CA): Skip Canadian timezone detection for fresh UTC timestamps 

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -851,14 +851,15 @@ class KiaUvoApiCA(ApiImpl):
 
     def get_location(self, token: Token, vehicle: Vehicle) -> dict:
         url = self.API_URL + "fndmcr"
-        headers = self.API_HEADERS
+        headers = self.API_HEADERS.copy()
         headers["accessToken"] = token.access_token
         headers["vehicleId"] = vehicle.id
+        headers["from"] = "SPA"
+        headers["Referer"] = f"https://{self.BASE_URL}/remote/"
         try:
             headers["pAuth"] = self._get_pin_token(token, vehicle)
-
             response = self.sessions.post(
-                url, headers=headers, data=json.dumps({"pin": token.pin})
+                url, headers=headers, json={"pin": token.pin}
             )
             response = response.json()
             _LOGGER.debug(f"{DOMAIN} - Get Vehicle Location {response}")
@@ -871,16 +872,14 @@ class KiaUvoApiCA(ApiImpl):
 
     def _get_pin_token(self, token: Token, vehicle: Vehicle) -> None:
         url = self.API_URL + "vrfypin"
-        headers = self.API_HEADERS
+        headers = self.API_HEADERS.copy()
         headers["accessToken"] = token.access_token
         headers["vehicleId"] = vehicle.id
-
         response = self.sessions.post(
-            url, headers=headers, data=json.dumps({"pin": token.pin})
+            url, headers=headers, json={"pin": token.pin}
         )
         _LOGGER.debug(f"{DOMAIN} - Received Pin validation response {response.json()}")
         result = response.json()["result"]
-
         return result["pAuth"]
 
     def lock_action(self, token: Token, vehicle: Vehicle, action) -> str:

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -860,15 +860,14 @@ class KiaUvoApiCA(ApiImpl):
 
     def get_location(self, token: Token, vehicle: Vehicle) -> dict:
         url = self.API_URL + "fndmcr"
-        headers = self.API_HEADERS
+        headers = self.API_HEADERS.copy()
         headers["accessToken"] = token.access_token
         headers["vehicleId"] = vehicle.id
+        headers["from"] = "SPA"
+        headers["Referer"] = f"https://{self.BASE_URL}/remote/"
         try:
             headers["pAuth"] = self._get_pin_token(token, vehicle)
-
-            response = self.sessions.post(
-                url, headers=headers, data=json.dumps({"pin": token.pin})
-            )
+            response = self.sessions.post(url, headers=headers, json={"pin": token.pin})
             response = response.json()
             _LOGGER.debug(f"{DOMAIN} - Get Vehicle Location {response}")
             if response["responseHeader"]["responseCode"] != 0:
@@ -880,16 +879,12 @@ class KiaUvoApiCA(ApiImpl):
 
     def _get_pin_token(self, token: Token, vehicle: Vehicle) -> None:
         url = self.API_URL + "vrfypin"
-        headers = self.API_HEADERS
+        headers = self.API_HEADERS.copy()
         headers["accessToken"] = token.access_token
         headers["vehicleId"] = vehicle.id
-
-        response = self.sessions.post(
-            url, headers=headers, data=json.dumps({"pin": token.pin})
-        )
+        response = self.sessions.post(url, headers=headers, json={"pin": token.pin})
         _LOGGER.debug(f"{DOMAIN} - Received Pin validation response {response.json()}")
         result = response.json()["result"]
-
         return result["pAuth"]
 
     def lock_action(self, token: Token, vehicle: Vehicle, action) -> str:

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -461,15 +461,24 @@ class KiaUvoApiCA(ApiImpl):
             get_child_value(state, "status.lastStatusDate"), dt.timezone.utc
         )
         ref_date = dt.datetime.now(tz=dt.timezone.utc)
-        tz = detect_timezone_for_date(last_updated_at, ref_date, CA_TIMEZONES)
-        if tz:
-            _LOGGER.debug(f"{DOMAIN} - Set vehicle.timezone to {tz} (guessed)")
-            vehicle.timezone = tz
-        else:
-            delta = (ref_date - last_updated_at).total_seconds() / 3600
-            _LOGGER.warning(
-                f"{DOMAIN} - could not guess Canadian timezone! delta is {delta} hours"
+        raw_delta_seconds = (ref_date - last_updated_at).total_seconds()
+        if abs(raw_delta_seconds) < 20 * 60:
+            # Timestamp is already in UTC (e.g. fresh forced-refresh response);
+            # reinterpreting it as a Canadian local time would always fail — skip silently.
+            _LOGGER.debug(
+                f"{DOMAIN} - lastStatusDate delta is {raw_delta_seconds:.1f}s; "
+                "skipping Canadian timezone guess (timestamp appears to be UTC)"
             )
+        else:
+            tz = detect_timezone_for_date(last_updated_at, ref_date, CA_TIMEZONES)
+            if tz:
+                _LOGGER.debug(f"{DOMAIN} - Set vehicle.timezone to {tz} (guessed)")
+                vehicle.timezone = tz
+            else:
+                _LOGGER.warning(
+                    f"{DOMAIN} - could not guess Canadian timezone! "
+                    f"delta is {raw_delta_seconds / 3600} hours"
+                )
 
         self._update_vehicle_properties_base(vehicle, state)
 
@@ -851,14 +860,15 @@ class KiaUvoApiCA(ApiImpl):
 
     def get_location(self, token: Token, vehicle: Vehicle) -> dict:
         url = self.API_URL + "fndmcr"
-        headers = self.API_HEADERS.copy()
+        headers = self.API_HEADERS
         headers["accessToken"] = token.access_token
         headers["vehicleId"] = vehicle.id
-        headers["from"] = "SPA"
-        headers["Referer"] = f"https://{self.BASE_URL}/remote/"
         try:
             headers["pAuth"] = self._get_pin_token(token, vehicle)
-            response = self.sessions.post(url, headers=headers, json={"pin": token.pin})
+
+            response = self.sessions.post(
+                url, headers=headers, data=json.dumps({"pin": token.pin})
+            )
             response = response.json()
             _LOGGER.debug(f"{DOMAIN} - Get Vehicle Location {response}")
             if response["responseHeader"]["responseCode"] != 0:
@@ -870,12 +880,16 @@ class KiaUvoApiCA(ApiImpl):
 
     def _get_pin_token(self, token: Token, vehicle: Vehicle) -> None:
         url = self.API_URL + "vrfypin"
-        headers = self.API_HEADERS.copy()
+        headers = self.API_HEADERS
         headers["accessToken"] = token.access_token
         headers["vehicleId"] = vehicle.id
-        response = self.sessions.post(url, headers=headers, json={"pin": token.pin})
+
+        response = self.sessions.post(
+            url, headers=headers, data=json.dumps({"pin": token.pin})
+        )
         _LOGGER.debug(f"{DOMAIN} - Received Pin validation response {response.json()}")
         result = response.json()["result"]
+
         return result["pAuth"]
 
     def lock_action(self, token: Token, vehicle: Vehicle, action) -> str:

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -858,9 +858,7 @@ class KiaUvoApiCA(ApiImpl):
         headers["Referer"] = f"https://{self.BASE_URL}/remote/"
         try:
             headers["pAuth"] = self._get_pin_token(token, vehicle)
-            response = self.sessions.post(
-                url, headers=headers, json={"pin": token.pin}
-            )
+            response = self.sessions.post(url, headers=headers, json={"pin": token.pin})
             response = response.json()
             _LOGGER.debug(f"{DOMAIN} - Get Vehicle Location {response}")
             if response["responseHeader"]["responseCode"] != 0:
@@ -875,9 +873,7 @@ class KiaUvoApiCA(ApiImpl):
         headers = self.API_HEADERS.copy()
         headers["accessToken"] = token.access_token
         headers["vehicleId"] = vehicle.id
-        response = self.sessions.post(
-            url, headers=headers, json={"pin": token.pin}
-        )
+        response = self.sessions.post(url, headers=headers, json={"pin": token.pin})
         _LOGGER.debug(f"{DOMAIN} - Received Pin validation response {response.json()}")
         result = response.json()["result"]
         return result["pAuth"]


### PR DESCRIPTION
## Skip Canadian timezone detection for fresh UTC timestamps

> ⚡ This change was vibe coded.

### Problem

After a forced vehicle state refresh, the API returns `lastStatusDate` as a UTC timestamp. The previous code would unconditionally pass this to `detect_timezone_for_date()`, which tries to reinterpret the timestamp as a Canadian local time. Since the delta between a fresh UTC timestamp and the current UTC time is near zero, the timezone guessing would always fail — producing a noisy warning log even when everything was working correctly.

### Solution

Add a guard check before attempting Canadian timezone detection: if the absolute delta between `lastStatusDate` and the current UTC time is less than 20 minutes, the timestamp is assumed to already be in UTC and the guessing step is skipped silently.

This avoids false-positive warnings on fresh forced-refresh responses while preserving the existing timezone detection logic for cached/stale timestamps where guessing is meaningful.

### Changes

- `force_refresh_vehicle_state`: compute `raw_delta_seconds` upfront and skip `detect_timezone_for_date()` when `abs(raw_delta_seconds) < 20 * 60`
- Log a debug message (instead of a warning) when the skip occurs, explaining the reason
- Warning log for failed timezone detection now uses the pre-computed `raw_delta_seconds` variable for consistency

### Testing

- Forced refresh with a live vehicle should no longer produce a spurious timezone warning in logs
- Cached state updates with stale timestamps should continue to have timezone detection applied as before