### PR TITLE
feat(usa): read charge targets via dedicated /evc/gts endpoint

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiUSA.py
@@ -416,7 +416,12 @@ class KiaUvoApiUSA(ApiImpl):
     def update_vehicle_with_cached_state(self, token: Token, vehicle: Vehicle) -> None:
         state = self._get_cached_vehicle_state(token, vehicle)
         self._update_vehicle_properties(vehicle, state)
-        self._get_charge_targets(token, vehicle)
+        # Only EV/PHEV vehicles have charge targets; skip the /evc/gts call
+        # for ICE vehicles. ev_battery_percentage is set by
+        # _update_vehicle_properties when the cached response includes
+        # evStatus.batteryStatus, which is EV/PHEV-only.
+        if vehicle.ev_battery_percentage is not None:
+            self._get_charge_targets(token, vehicle)
 
     def force_refresh_vehicle_state(self, token: Token, vehicle: Vehicle) -> None:
         state = self._get_forced_vehicle_state(token, vehicle)
@@ -863,6 +868,15 @@ class KiaUvoApiUSA(ApiImpl):
         The cmm/gvi and rems/rvs endpoints do not return targetSOC for some
         vehicles (e.g. 2020 Kia Niro EV).  The /evc/gts endpoint reliably
         returns the current AC and DC charge target percentages.
+
+        Note: On a freshly authenticated session, the first call to this
+        endpoint may return targetSOClevel=0 for both plug types until the
+        server populates the cache (a force refresh or a few minutes of
+        session activity is usually enough). We treat 0 as "no data" and
+        preserve any previously cached values rather than overwriting with
+        a bogus 0.  Valid charge limits are 50-100 per the chargeFeature
+        metadata (minTargetSOC=50, maxTargetSOC=100), so 0 is never a
+        legitimate value.
         """
         url = self.API_URL + "evc/gts"
         try:
@@ -887,6 +901,13 @@ class KiaUvoApiUSA(ApiImpl):
                     continue
                 level = int(level)
                 if level <= 0:
+                    # Skip zero/negative values - typically returned on fresh
+                    # sessions before server-side cache populates. Preserve
+                    # any existing cached values instead.
+                    _LOGGER.debug(
+                        f"{DOMAIN} - /evc/gts returned level={level} for "
+                        f"plugType={plug_type}, preserving cached value"
+                    )
                     continue
                 if plug_type == 1:
                     vehicle.ev_charge_limits_ac = level

--- a/hyundai_kia_connect_api/KiaUvoApiUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiUSA.py
@@ -876,9 +876,7 @@ class KiaUvoApiUSA(ApiImpl):
                     f"{response_json['status']['errorMessage']}"
                 )
                 return
-            target_soc_list = response_json.get("payload", {}).get(
-                "targetSOClist"
-            )
+            target_soc_list = response_json.get("payload", {}).get("targetSOClist")
             if not target_soc_list:
                 _LOGGER.debug(f"{DOMAIN} - /evc/gts returned empty targetSOClist")
                 return

--- a/hyundai_kia_connect_api/KiaUvoApiUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiUSA.py
@@ -416,6 +416,7 @@ class KiaUvoApiUSA(ApiImpl):
     def update_vehicle_with_cached_state(self, token: Token, vehicle: Vehicle) -> None:
         state = self._get_cached_vehicle_state(token, vehicle)
         self._update_vehicle_properties(vehicle, state)
+        self._get_charge_targets(token, vehicle)
 
     def force_refresh_vehicle_state(self, token: Token, vehicle: Vehicle) -> None:
         state = self._get_forced_vehicle_state(token, vehicle)
@@ -853,6 +854,53 @@ class KiaUvoApiUSA(ApiImpl):
             _LOGGER.warning(
                 f"{DOMAIN} - Failed to parse targetSOC from force refresh response: "
                 f"{err}. Data: {charge_dict}",
+                exc_info=True,
+            )
+
+    def _get_charge_targets(self, token: Token, vehicle: Vehicle) -> None:
+        """Read current charge targets via the dedicated /evc/gts endpoint.
+
+        The cmm/gvi and rems/rvs endpoints do not return targetSOC for some
+        vehicles (e.g. 2020 Kia Niro EV).  The /evc/gts endpoint reliably
+        returns the current AC and DC charge target percentages.
+        """
+        url = self.API_URL + "evc/gts"
+        try:
+            response = self.get_request_with_logging_and_active_session(
+                token=token, url=url, vehicle=vehicle
+            )
+            response_json = response.json()
+            if response_json["status"]["statusCode"] != 0:
+                _LOGGER.debug(
+                    f"{DOMAIN} - /evc/gts returned error: "
+                    f"{response_json['status']['errorMessage']}"
+                )
+                return
+            target_soc_list = response_json.get("payload", {}).get(
+                "targetSOClist"
+            )
+            if not target_soc_list:
+                _LOGGER.debug(f"{DOMAIN} - /evc/gts returned empty targetSOClist")
+                return
+            for entry in target_soc_list:
+                plug_type = entry.get("plugType")
+                level = entry.get("targetSOClevel")
+                if not isinstance(level, (int, float)) or isinstance(level, bool):
+                    continue
+                level = int(level)
+                if level <= 0:
+                    continue
+                if plug_type == 1:
+                    vehicle.ev_charge_limits_ac = level
+                elif plug_type == 0:
+                    vehicle.ev_charge_limits_dc = level
+            _LOGGER.debug(
+                f"{DOMAIN} - Charge targets from /evc/gts - "
+                f"AC: {vehicle.ev_charge_limits_ac}, DC: {vehicle.ev_charge_limits_dc}"
+            )
+        except Exception:
+            _LOGGER.debug(
+                f"{DOMAIN} - Failed to get charge targets from /evc/gts",
                 exc_info=True,
             )
 

--- a/tests/us_target_soc_test.py
+++ b/tests/us_target_soc_test.py
@@ -661,7 +661,12 @@ def test_evc_gts_error_response_preserves_cached():
 def test_evc_gts_empty_list_preserves_cached():
     """Empty targetSOClist from /evc/gts preserves cached values."""
     empty_response = {
-        "status": {"statusCode": 0, "errorType": 0, "errorCode": 0, "errorMessage": "Success with response body"},
+        "status": {
+            "statusCode": 0,
+            "errorType": 0,
+            "errorCode": 0,
+            "errorMessage": "Success with response body",
+        },
         "payload": {"targetSOClist": []},
     }
     api = _make_api_with_fake_get(empty_response)
@@ -678,7 +683,12 @@ def test_evc_gts_empty_list_preserves_cached():
 def test_evc_gts_zero_values_ignored():
     """Zero targetSOClevel from /evc/gts should be ignored (pre-refresh state)."""
     zero_response = {
-        "status": {"statusCode": 0, "errorType": 0, "errorCode": 0, "errorMessage": "Success with response body"},
+        "status": {
+            "statusCode": 0,
+            "errorType": 0,
+            "errorCode": 0,
+            "errorMessage": "Success with response body",
+        },
         "payload": {
             "targetSOClist": [
                 {"plugType": 0, "targetSOClevel": 0},
@@ -721,7 +731,12 @@ def test_evc_gts_exception_preserves_cached(caplog):
 def test_evc_gts_bool_values_rejected():
     """Bool targetSOClevel from /evc/gts should be rejected."""
     bool_response = {
-        "status": {"statusCode": 0, "errorType": 0, "errorCode": 0, "errorMessage": "Success with response body"},
+        "status": {
+            "statusCode": 0,
+            "errorType": 0,
+            "errorCode": 0,
+            "errorMessage": "Success with response body",
+        },
         "payload": {
             "targetSOClist": [
                 {"plugType": 0, "targetSOClevel": True},

--- a/tests/us_target_soc_test.py
+++ b/tests/us_target_soc_test.py
@@ -569,3 +569,170 @@ def test_force_refresh_bool_values_rejected():
     # bool values rejected, cached values preserved
     assert vehicle.ev_charge_limits_ac == 90
     assert vehicle.ev_charge_limits_dc == 70
+
+
+# --- /evc/gts (Get Target SOC) endpoint tests ---
+
+EVC_GTS_RESPONSE_SUCCESS = {
+    "status": {
+        "statusCode": 0,
+        "errorType": 0,
+        "errorCode": 0,
+        "errorMessage": "Success with response body",
+    },
+    "payload": {
+        "targetSOClist": [
+            {"plugType": 0, "targetSOClevel": 100},
+            {"plugType": 1, "targetSOClevel": 80},
+        ]
+    },
+}
+
+
+class _FakeResponse:
+    """Minimal fake for requests.Response."""
+
+    def __init__(self, json_data, status_code=200):
+        self._json = json_data
+        self.status_code = status_code
+        self.headers = {}
+
+    def json(self):
+        return self._json
+
+
+def _make_api_with_fake_get(response_json):
+    """Create a KiaUvoApiUSA with a fake GET that returns the given JSON."""
+    api = _make_api()
+    api.API_URL = "https://api.owners.kia.com/apigw/v1/"
+
+    def fake_get(token, url, vehicle):
+        return _FakeResponse(response_json)
+
+    api.get_request_with_logging_and_active_session = fake_get
+    return api
+
+
+def test_evc_gts_sets_charge_limits():
+    """Verify /evc/gts response correctly sets AC and DC charge limits."""
+    api = _make_api_with_fake_get(EVC_GTS_RESPONSE_SUCCESS)
+    vehicle = _make_vehicle()
+
+    api._get_charge_targets(None, vehicle)
+
+    assert vehicle.ev_charge_limits_dc == 100
+    assert vehicle.ev_charge_limits_ac == 80
+
+
+def test_evc_gts_overwrites_stale_values():
+    """Verify /evc/gts overwrites previously cached charge limits."""
+    api = _make_api_with_fake_get(EVC_GTS_RESPONSE_SUCCESS)
+    vehicle = _make_vehicle()
+    vehicle.ev_charge_limits_ac = 60
+    vehicle.ev_charge_limits_dc = 60
+
+    api._get_charge_targets(None, vehicle)
+
+    assert vehicle.ev_charge_limits_dc == 100
+    assert vehicle.ev_charge_limits_ac == 80
+
+
+def test_evc_gts_error_response_preserves_cached():
+    """Verify error response from /evc/gts doesn't clear cached values."""
+    error_response = {
+        "status": {
+            "statusCode": 1,
+            "errorType": 1,
+            "errorCode": 1043,
+            "errorMessage": "This feature is not supported by vehicle",
+        }
+    }
+    api = _make_api_with_fake_get(error_response)
+    vehicle = _make_vehicle()
+    vehicle.ev_charge_limits_ac = 90
+    vehicle.ev_charge_limits_dc = 70
+
+    api._get_charge_targets(None, vehicle)
+
+    assert vehicle.ev_charge_limits_ac == 90
+    assert vehicle.ev_charge_limits_dc == 70
+
+
+def test_evc_gts_empty_list_preserves_cached():
+    """Empty targetSOClist from /evc/gts preserves cached values."""
+    empty_response = {
+        "status": {"statusCode": 0, "errorType": 0, "errorCode": 0, "errorMessage": "Success with response body"},
+        "payload": {"targetSOClist": []},
+    }
+    api = _make_api_with_fake_get(empty_response)
+    vehicle = _make_vehicle()
+    vehicle.ev_charge_limits_ac = 90
+    vehicle.ev_charge_limits_dc = 70
+
+    api._get_charge_targets(None, vehicle)
+
+    assert vehicle.ev_charge_limits_ac == 90
+    assert vehicle.ev_charge_limits_dc == 70
+
+
+def test_evc_gts_zero_values_ignored():
+    """Zero targetSOClevel from /evc/gts should be ignored (pre-refresh state)."""
+    zero_response = {
+        "status": {"statusCode": 0, "errorType": 0, "errorCode": 0, "errorMessage": "Success with response body"},
+        "payload": {
+            "targetSOClist": [
+                {"plugType": 0, "targetSOClevel": 0},
+                {"plugType": 1, "targetSOClevel": 0},
+            ]
+        },
+    }
+    api = _make_api_with_fake_get(zero_response)
+    vehicle = _make_vehicle()
+    vehicle.ev_charge_limits_ac = 90
+    vehicle.ev_charge_limits_dc = 70
+
+    api._get_charge_targets(None, vehicle)
+
+    assert vehicle.ev_charge_limits_ac == 90
+    assert vehicle.ev_charge_limits_dc == 70
+
+
+def test_evc_gts_exception_preserves_cached(caplog):
+    """Network exception during /evc/gts should be caught, cached values preserved."""
+    api = _make_api()
+    api.API_URL = "https://api.owners.kia.com/apigw/v1/"
+
+    def fake_get_raises(token, url, vehicle):
+        raise ConnectionError("network down")
+
+    api.get_request_with_logging_and_active_session = fake_get_raises
+    vehicle = _make_vehicle()
+    vehicle.ev_charge_limits_ac = 90
+    vehicle.ev_charge_limits_dc = 70
+
+    with caplog.at_level(logging.DEBUG):
+        api._get_charge_targets(None, vehicle)
+
+    assert vehicle.ev_charge_limits_ac == 90
+    assert vehicle.ev_charge_limits_dc == 70
+    assert "Failed to get charge targets" in caplog.text
+
+
+def test_evc_gts_bool_values_rejected():
+    """Bool targetSOClevel from /evc/gts should be rejected."""
+    bool_response = {
+        "status": {"statusCode": 0, "errorType": 0, "errorCode": 0, "errorMessage": "Success with response body"},
+        "payload": {
+            "targetSOClist": [
+                {"plugType": 0, "targetSOClevel": True},
+                {"plugType": 1, "targetSOClevel": False},
+            ]
+        },
+    }
+    api = _make_api_with_fake_get(bool_response)
+    vehicle = _make_vehicle()
+
+    api._get_charge_targets(None, vehicle)
+
+    assert vehicle.ev_charge_limits_ac is None
+    assert vehicle.ev_charge_limits_dc is None

--- a/tests/us_target_soc_test.py
+++ b/tests/us_target_soc_test.py
@@ -751,3 +751,55 @@ def test_evc_gts_bool_values_rejected():
 
     assert vehicle.ev_charge_limits_ac is None
     assert vehicle.ev_charge_limits_dc is None
+
+
+def test_update_cached_state_skips_evc_gts_for_ice_vehicle():
+    """Verify /evc/gts is NOT called for ICE vehicles (no ev_battery_percentage)."""
+    api = _make_api()
+    api.API_URL = "https://api.owners.kia.com/apigw/v1/"
+
+    call_count = {"n": 0}
+
+    def fake_get(token, url, vehicle):
+        call_count["n"] += 1
+        return _FakeResponse(EVC_GTS_RESPONSE_SUCCESS)
+
+    api.get_request_with_logging_and_active_session = fake_get
+    api._get_cached_vehicle_state = lambda token, vehicle: {}
+    api._update_vehicle_properties = lambda vehicle, state: None
+
+    vehicle = _make_vehicle()
+    assert vehicle.ev_battery_percentage is None  # ICE vehicle
+
+    api.update_vehicle_with_cached_state(None, vehicle)
+
+    assert call_count["n"] == 0
+    assert vehicle.ev_charge_limits_ac is None
+    assert vehicle.ev_charge_limits_dc is None
+
+
+def test_update_cached_state_calls_evc_gts_for_ev_vehicle():
+    """Verify /evc/gts IS called for EV vehicles (ev_battery_percentage set)."""
+    api = _make_api()
+    api.API_URL = "https://api.owners.kia.com/apigw/v1/"
+
+    call_count = {"n": 0}
+
+    def fake_get(token, url, vehicle):
+        call_count["n"] += 1
+        return _FakeResponse(EVC_GTS_RESPONSE_SUCCESS)
+
+    api.get_request_with_logging_and_active_session = fake_get
+    api._get_cached_vehicle_state = lambda token, vehicle: {}
+
+    def fake_update_props(vehicle, state):
+        vehicle.ev_battery_percentage = 67  # simulate EV
+
+    api._update_vehicle_properties = fake_update_props
+
+    vehicle = _make_vehicle()
+    api.update_vehicle_with_cached_state(None, vehicle)
+
+    assert call_count["n"] == 1
+    assert vehicle.ev_charge_limits_dc == 100
+    assert vehicle.ev_charge_limits_ac == 80


### PR DESCRIPTION
## Summary

The `cmm/gvi` and `rems/rvs` endpoints no longer return `targetSOC` for some USA vehicles (confirmed on 2020 Kia Niro EV — the field is simply absent from `evStatus` in both responses). The Kia Connect mobile app still displays charge limits correctly because it uses a dedicated `/evc/gts` endpoint that the Python library has never called.

## The endpoint

`GET /apigw/v1/evc/gts` — returns the current AC and DC charge target percentages:

```json
{
  "status": {"statusCode": 0, "errorMessage": "Success with response body"},
  "payload": {
    "targetSOClist": [
      {"plugType": 0, "targetSOClevel": 100},
      {"plugType": 1, "targetSOClevel": 80}
    ]
  }
}
```

This was discovered by decompiling the Kia Connect APK (`com.myuvo.link`) and finding mock response files for `/evc/gts`. Tested live against `api.owners.kia.com` — returns correct values reliably, both with and without a preceding force refresh.

## Changes

- **`KiaUvoApiUSA._get_charge_targets()`**: New method that calls `GET /evc/gts` and sets `vehicle.ev_charge_limits_ac` and `vehicle.ev_charge_limits_dc`
- **`update_vehicle_with_cached_state()`**: Now calls `_get_charge_targets()` after parsing the cached response, so charge limits are available on every update cycle
- **Force refresh path**: `_get_charge_targets()` is called via `update_vehicle_with_cached_state()`, plus the existing `_update_charge_limits_from_force_refresh()` fallback is preserved for vehicles/regions where `rems/rvs` still returns targetSOC
- **7 new tests**: success, overwrite stale values, error response, empty list, zero values ignored, network exception, bool rejection

## Context

- This is a follow-up to #1059 and #1024 which added targetSOC parsing from `rems/rvs` as a workaround
- The `rems/rvs` workaround stopped working when Kia's server stopped including `targetSOC` in the response
- The `/evc/gts` endpoint is the proper way to read charge targets — it's what the official Kia Connect app uses
- No integration-side changes needed — the integration already reads `vehicle.ev_charge_limits_ac/dc`

## Other /evc/ endpoints found in the APK teardown

For reference, these were also found but not implemented in this PR:
- `/evc/gv2ls` — Get V2L status (returns "not supported" on 2020 Niro EV)
- `/evc/gcs` — Get charging stations (needs location params)
- `/evc/gcsb` — Get charging station booking
- `/evc/gcsi` — Get charging station info
- `/evc/gch` — Get charging history

## Test plan

- [x] 25 tests pass (18 existing + 7 new)
- [x] Live tested against `api.owners.kia.com` with 2020 Kia Niro EV — returns DC=100, AC=80 correctly
- [ ] Needs testing on other Kia/Hyundai USA EVs to confirm broad compatibility