### PR TITLE
fix: remove debug logging of tokens and cookies

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -1091,8 +1091,8 @@ class ApiImplType1(ApiImpl):
         data = {"deviceId": token.device_id, "pin": token.pin}
         response = requests.put(url, json=data, headers=headers)
         response = response.json()
-        _LOGGER.debug(f"{DOMAIN} - Get Control Token Response {response}")
         if response.get("controlToken") is None:
+            _LOGGER.debug(f"{DOMAIN} - Get Control Token Response {response}")
             raise APIError("PIN verification failed, ensure PIN is entered correctly.")
         control_token = "Bearer " + response["controlToken"]
         control_token_expire_at = math.floor(

--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
@@ -99,7 +99,6 @@ class HyundaiBlueLinkApiBR(ApiImpl):
         response = self.session.get(url, params=params)
         response.raise_for_status()
         cookies = response.cookies.get_dict()
-        _LOGGER.debug(f"{DOMAIN} - Got cookies: {cookies}")
         return cookies
 
     def _get_authorization_code(

--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
@@ -136,7 +136,6 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
         data = {"username": username, "password": password}
 
         response = self.sessions.post(url, json=data, headers=self.API_HEADERS)
-        _LOGGER.debug(f"{DOMAIN} - Sign In Response {response.text}")
         response = response.json()
         if response.get("access_token") is None:
             raise AuthenticationError(

--- a/hyundai_kia_connect_api/KiaUvoApiAU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiAU.py
@@ -857,7 +857,6 @@ class KiaUvoApiAU(ApiImplType1):
         _LOGGER.debug(f"{DOMAIN} - Get cookies request: {url}")
         session = requests.Session()
         _ = session.get(url)
-        _LOGGER.debug(f"{DOMAIN} - Get cookies response: {session.cookies.get_dict()}")
         return session.cookies.get_dict()
 
     def _get_authorization_code_with_redirect_url(

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -209,7 +209,6 @@ class KiaUvoApiCA(ApiImpl):
 
         headers["Deviceid"] = device_id
         response = self.sessions.post(url, json=data, headers=headers)
-        _LOGGER.debug(f"{DOMAIN} - Sign In Response {response.text}")
         response_json = response.json()
 
         # Check if OTP is required (error code 7110)

--- a/hyundai_kia_connect_api/KiaUvoApiCN.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCN.py
@@ -1040,7 +1040,6 @@ class KiaUvoApiCN(ApiImplType1):
         _LOGGER.debug(f"{DOMAIN} - Get cookies request: {url}")
         session = requests.Session()
         _ = session.get(url)
-        _LOGGER.debug(f"{DOMAIN} - Get cookies response: {session.cookies.get_dict()}")
         return session.cookies.get_dict()
         # return session
 
@@ -1060,7 +1059,6 @@ class KiaUvoApiCN(ApiImplType1):
         response = requests.post(
             url, json=data, headers=headers, cookies=cookies
         ).json()
-        _LOGGER.debug(f"{DOMAIN} - Sign In Response: {response}")
         parsed_url = urlparse(response["redirectUrl"])
         authorization_code = "".join(parse_qs(parsed_url.query)["code"])
         return authorization_code
@@ -1084,15 +1082,12 @@ class KiaUvoApiCN(ApiImplType1):
             + "%3A443%2Fapi%2Fv1%2Fuser%2Foauth2%2Fredirect&code="
             + authorization_code
         )
-        _LOGGER.debug(f"{DOMAIN} - Get Access Token Data: {headers}{data}")
         response = requests.post(url, data=data, headers=headers)
         response = response.json()
-        _LOGGER.debug(f"{DOMAIN} - Get Access Token Response: {response}")
 
         token_type = response["token_type"]
         access_token = token_type + " " + response["access_token"]
         authorization_code = response["refresh_token"]
-        _LOGGER.debug(f"{DOMAIN} - Access Token Value {access_token}")
         return token_type, access_token, authorization_code
 
     def _get_refresh_token(self, authorization_code):
@@ -1111,10 +1106,8 @@ class KiaUvoApiCN(ApiImplType1):
             "grant_type=refresh_token&redirect_uri=https%3A%2F%2Fwww.getpostman.com%2Foauth2%2Fcallback&refresh_token="  # noqa
             + authorization_code
         )
-        _LOGGER.debug(f"{DOMAIN} - Get Refresh Token Data: {data}")
         response = requests.post(url, data=data, headers=headers)
         response = response.json()
-        _LOGGER.debug(f"{DOMAIN} - Get Refresh Token Response: {response}")
         token_type = response["token_type"]
         refresh_token = token_type + " " + response["access_token"]
         return token_type, refresh_token
@@ -1130,10 +1123,8 @@ class KiaUvoApiCN(ApiImplType1):
         }
 
         data = {"deviceId": token.device_id, "pin": token.pin}
-        _LOGGER.debug(f"{DOMAIN} - Get Control Token Data: {data}")
         response = requests.put(url, json=data, headers=headers)
         response = response.json()
-        _LOGGER.debug(f"{DOMAIN} - Get Control Token Response {response}")
         control_token = "Bearer " + response["controlToken"]
         control_token_expire_at = math.floor(
             dt.datetime.now().timestamp() + response["expiresTime"]

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -1126,9 +1126,7 @@ class KiaUvoApiEU(ApiImplType1):
         _LOGGER.debug(f"{DOMAIN} - Get cookies request: {url}")
         session = requests.Session()
         _ = session.get(url)
-        _LOGGER.debug(f"{DOMAIN} - Get cookies response: {session.cookies.get_dict()}")
         return session.cookies.get_dict()
-        # return session
 
     def _get_authorization_code_with_redirect_url(
         self, username, password, cookies

--- a/hyundai_kia_connect_api/KiaUvoApiIN.py
+++ b/hyundai_kia_connect_api/KiaUvoApiIN.py
@@ -969,9 +969,7 @@ class KiaUvoApiIN(ApiImplType1):
         _LOGGER.debug(f"{DOMAIN} - Get cookies request: {url}")
         session = requests.Session()
         _ = session.get(url)
-        _LOGGER.debug(f"{DOMAIN} - Get cookies response: {session.cookies.get_dict()}")
         return session.cookies.get_dict()
-        # return session
 
     def _get_authorization_code_with_redirect_url(
         self, username, password, cookies
@@ -1006,10 +1004,8 @@ class KiaUvoApiIN(ApiImplType1):
             + "%3A8080%2Fapi%2Fv1%2Fuser%2Foauth2%2Fredirect&code="
             + authorization_code
         )
-        _LOGGER.debug(f"{DOMAIN} - Get Access Token Data: {headers}{data}")
         response = requests.post(url, data=data, headers=headers)
         response = response.json()
-        _LOGGER.debug(f"{DOMAIN} - Get Access Token Response: {response}")
 
         token_type = response["token_type"]
         access_token = token_type + " " + response["access_token"]
@@ -1052,10 +1048,8 @@ class KiaUvoApiIN(ApiImplType1):
             "grant_type=refresh_token&redirect_uri=https%3A%2F%2Fwww.getpostman.com%2Foauth2%2Fcallback&refresh_token="  # noqa
             + authorization_code
         )
-        _LOGGER.debug(f"{DOMAIN} - Get Refresh Token Data: {data}")
         response = requests.post(url, data=data, headers=headers)
         response = response.json()
-        _LOGGER.debug(f"{DOMAIN} - Get Refresh Token Response: {response}")
         token_type = response["token_type"]
         refresh_token = token_type + " " + response["access_token"]
         return token_type, refresh_token
@@ -1071,10 +1065,8 @@ class KiaUvoApiIN(ApiImplType1):
         }
 
         data = {"deviceId": token.device_id, "pin": token.pin}
-        _LOGGER.debug(f"{DOMAIN} - Get Control Token Data: {data}")
         response = requests.put(url, json=data, headers=headers)
         response = response.json()
-        _LOGGER.debug(f"{DOMAIN} - Get Control Token Response {response}")
         control_token = "Bearer " + response["controlToken"]
         control_token_expire_at = math.floor(
             dt.datetime.now().timestamp() + response["expiresTime"]


### PR DESCRIPTION
Access tokens are typically short-lived. Refresh tokens are more
dangerous to leak, they are like passwords that are valid for a long
time. Remove any logging that could possibly leak these.

