### PR TITLE
feat(usa): populate engine_type and use it to gate /evc/gts

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiUSA.py
@@ -21,6 +21,7 @@ from .Vehicle import Vehicle
 from .const import (
     DISTANCE_UNITS,
     DOMAIN,
+    ENGINE_TYPES,
     LOGIN_TOKEN_LIFETIME,
     ORDER_STATUS,
     TEMPERATURE_UNITS,
@@ -363,10 +364,21 @@ class KiaUvoApiUSA(ApiImpl):
                 name=entry["nickName"],
                 model=entry["modelName"],
                 key=entry["vehicleKey"],
+                engine_type=self._engine_type_from_fuel_type(entry.get("fuelType")),
                 timezone=self.data_timezone,
             )
             result.append(vehicle)
         return result
+
+    @staticmethod
+    def _engine_type_from_fuel_type(fuel_type) -> ty.Optional[ENGINE_TYPES]:
+        # Only fuelType=4 (EV) is confirmed against a live Kia USA account
+        # (2020 Niro EV). Mappings for ICE/PHEV/HEV are unknown, so leave
+        # engine_type as None for those and let _update_vehicle_properties
+        # refine it from the cached state's evStatus presence.
+        if fuel_type == 4:
+            return ENGINE_TYPES.EV
+        return None
 
     def refresh_vehicles(
         self, token: Token, vehicles: ty.Union[list[Vehicle], Vehicle]
@@ -417,10 +429,10 @@ class KiaUvoApiUSA(ApiImpl):
         state = self._get_cached_vehicle_state(token, vehicle)
         self._update_vehicle_properties(vehicle, state)
         # Only EV/PHEV vehicles have charge targets; skip the /evc/gts call
-        # for ICE vehicles. ev_battery_percentage is set by
-        # _update_vehicle_properties when the cached response includes
-        # evStatus.batteryStatus, which is EV/PHEV-only.
-        if vehicle.ev_battery_percentage is not None:
+        # for ICE vehicles. engine_type is set in get_vehicles from the
+        # fuelType hint and refined in _update_vehicle_properties from the
+        # cached state (evStatus presence => EV/PHEV, gasModeRange => PHEV).
+        if vehicle.engine_type in (ENGINE_TYPES.EV, ENGINE_TYPES.PHEV):
             self._get_charge_targets(token, vehicle)
 
     def force_refresh_vehicle_state(self, token: Token, vehicle: Vehicle) -> None:
@@ -748,6 +760,27 @@ class KiaUvoApiUSA(ApiImpl):
         vehicle.dtc_descriptions = get_child_value(
             state, "lastVehicleInfo.activeDTC.dtcCategory"
         )
+
+        if vehicle.engine_type is None:
+            # fuelType in ownr/gvl only reliably maps 4 -> EV; for anything
+            # else we infer from the cached state. Presence of an evStatus
+            # block means a high-voltage battery (EV or PHEV); absence
+            # means ICE. PHEVs additionally report a gasModeRange block,
+            # which pure EVs never do.
+            ev_status = get_child_value(
+                state, "lastVehicleInfo.vehicleStatusRpt.vehicleStatus.evStatus"
+            )
+            if ev_status:
+                gas_mode_range = get_child_value(
+                    state,
+                    "lastVehicleInfo.vehicleStatusRpt.vehicleStatus.evStatus.drvDistance.0.rangeByFuel.gasModeRange.value",  # noqa
+                )
+                if gas_mode_range is not None:
+                    vehicle.engine_type = ENGINE_TYPES.PHEV
+                else:
+                    vehicle.engine_type = ENGINE_TYPES.EV
+            else:
+                vehicle.engine_type = ENGINE_TYPES.ICE
 
         vehicle.data = state
 

--- a/tests/us_target_soc_test.py
+++ b/tests/us_target_soc_test.py
@@ -12,6 +12,7 @@ preserved across subsequent cached updates.
 import datetime as dt
 import logging
 
+from hyundai_kia_connect_api.const import ENGINE_TYPES
 from hyundai_kia_connect_api.KiaUvoApiUSA import KiaUvoApiUSA
 from hyundai_kia_connect_api.Vehicle import Vehicle
 
@@ -754,32 +755,7 @@ def test_evc_gts_bool_values_rejected():
 
 
 def test_update_cached_state_skips_evc_gts_for_ice_vehicle():
-    """Verify /evc/gts is NOT called for ICE vehicles (no ev_battery_percentage)."""
-    api = _make_api()
-    api.API_URL = "https://api.owners.kia.com/apigw/v1/"
-
-    call_count = {"n": 0}
-
-    def fake_get(token, url, vehicle):
-        call_count["n"] += 1
-        return _FakeResponse(EVC_GTS_RESPONSE_SUCCESS)
-
-    api.get_request_with_logging_and_active_session = fake_get
-    api._get_cached_vehicle_state = lambda token, vehicle: {}
-    api._update_vehicle_properties = lambda vehicle, state: None
-
-    vehicle = _make_vehicle()
-    assert vehicle.ev_battery_percentage is None  # ICE vehicle
-
-    api.update_vehicle_with_cached_state(None, vehicle)
-
-    assert call_count["n"] == 0
-    assert vehicle.ev_charge_limits_ac is None
-    assert vehicle.ev_charge_limits_dc is None
-
-
-def test_update_cached_state_calls_evc_gts_for_ev_vehicle():
-    """Verify /evc/gts IS called for EV vehicles (ev_battery_percentage set)."""
+    """Verify /evc/gts is NOT called for ICE vehicles (engine_type=ICE)."""
     api = _make_api()
     api.API_URL = "https://api.owners.kia.com/apigw/v1/"
 
@@ -793,7 +769,34 @@ def test_update_cached_state_calls_evc_gts_for_ev_vehicle():
     api._get_cached_vehicle_state = lambda token, vehicle: {}
 
     def fake_update_props(vehicle, state):
-        vehicle.ev_battery_percentage = 67  # simulate EV
+        vehicle.engine_type = ENGINE_TYPES.ICE
+
+    api._update_vehicle_properties = fake_update_props
+
+    vehicle = _make_vehicle()
+    api.update_vehicle_with_cached_state(None, vehicle)
+
+    assert call_count["n"] == 0
+    assert vehicle.ev_charge_limits_ac is None
+    assert vehicle.ev_charge_limits_dc is None
+
+
+def test_update_cached_state_calls_evc_gts_for_ev_vehicle():
+    """Verify /evc/gts IS called for EV vehicles (engine_type=EV)."""
+    api = _make_api()
+    api.API_URL = "https://api.owners.kia.com/apigw/v1/"
+
+    call_count = {"n": 0}
+
+    def fake_get(token, url, vehicle):
+        call_count["n"] += 1
+        return _FakeResponse(EVC_GTS_RESPONSE_SUCCESS)
+
+    api.get_request_with_logging_and_active_session = fake_get
+    api._get_cached_vehicle_state = lambda token, vehicle: {}
+
+    def fake_update_props(vehicle, state):
+        vehicle.engine_type = ENGINE_TYPES.EV
 
     api._update_vehicle_properties = fake_update_props
 
@@ -803,3 +806,109 @@ def test_update_cached_state_calls_evc_gts_for_ev_vehicle():
     assert call_count["n"] == 1
     assert vehicle.ev_charge_limits_dc == 100
     assert vehicle.ev_charge_limits_ac == 80
+
+
+def test_update_cached_state_calls_evc_gts_for_phev_vehicle():
+    """Verify /evc/gts IS called for PHEV vehicles (engine_type=PHEV)."""
+    api = _make_api()
+    api.API_URL = "https://api.owners.kia.com/apigw/v1/"
+
+    call_count = {"n": 0}
+
+    def fake_get(token, url, vehicle):
+        call_count["n"] += 1
+        return _FakeResponse(EVC_GTS_RESPONSE_SUCCESS)
+
+    api.get_request_with_logging_and_active_session = fake_get
+    api._get_cached_vehicle_state = lambda token, vehicle: {}
+
+    def fake_update_props(vehicle, state):
+        vehicle.engine_type = ENGINE_TYPES.PHEV
+
+    api._update_vehicle_properties = fake_update_props
+
+    vehicle = _make_vehicle()
+    api.update_vehicle_with_cached_state(None, vehicle)
+
+    assert call_count["n"] == 1
+
+
+def test_engine_type_from_fuel_type_ev():
+    """fuelType=4 in ownr/gvl maps to ENGINE_TYPES.EV."""
+    assert KiaUvoApiUSA._engine_type_from_fuel_type(4) == ENGINE_TYPES.EV
+
+
+def test_engine_type_from_fuel_type_unknown():
+    """Unknown fuelType values return None (refined later from cached state)."""
+    assert KiaUvoApiUSA._engine_type_from_fuel_type(1) is None
+    assert KiaUvoApiUSA._engine_type_from_fuel_type(None) is None
+    assert KiaUvoApiUSA._engine_type_from_fuel_type("4") is None
+
+
+def test_update_vehicle_properties_infers_ev_from_ev_status():
+    """Presence of evStatus without gasModeRange => ENGINE_TYPES.EV."""
+    api = _make_api()
+    vehicle = _make_vehicle()
+    api._update_vehicle_properties(vehicle, CACHED_RESPONSE_PAYLOAD)
+    assert vehicle.engine_type == ENGINE_TYPES.EV
+
+
+def test_update_vehicle_properties_infers_ice_without_ev_status():
+    """Missing evStatus => ENGINE_TYPES.ICE."""
+    api = _make_api()
+    vehicle = _make_vehicle()
+    ice_state = {
+        "lastVehicleInfo": {
+            "vehicleStatusRpt": {
+                "vehicleStatus": {
+                    "syncDate": {"utc": "20260131002545"},
+                },
+            },
+        },
+    }
+    api._update_vehicle_properties(vehicle, ice_state)
+    assert vehicle.engine_type == ENGINE_TYPES.ICE
+
+
+def test_update_vehicle_properties_infers_phev_from_gas_mode_range():
+    """evStatus + gasModeRange => ENGINE_TYPES.PHEV."""
+    api = _make_api()
+    vehicle = _make_vehicle()
+    phev_state = {
+        "lastVehicleInfo": {
+            "vehicleStatusRpt": {
+                "vehicleStatus": {
+                    "syncDate": {"utc": "20260131002545"},
+                    "evStatus": {
+                        "batteryStatus": 55,
+                        "drvDistance": [
+                            {
+                                "rangeByFuel": {
+                                    "gasModeRange": {"value": 300, "unit": 3},
+                                    "evModeRange": {"value": 20, "unit": 3},
+                                },
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+    }
+    api._update_vehicle_properties(vehicle, phev_state)
+    assert vehicle.engine_type == ENGINE_TYPES.PHEV
+
+
+def test_update_vehicle_properties_preserves_preset_engine_type():
+    """If engine_type is already set (e.g. from get_vehicles), don't overwrite."""
+    api = _make_api()
+    vehicle = _make_vehicle()
+    vehicle.engine_type = ENGINE_TYPES.EV
+    ice_looking_state = {
+        "lastVehicleInfo": {
+            "vehicleStatusRpt": {
+                "vehicleStatus": {"syncDate": {"utc": "20260131002545"}},
+            },
+        },
+    }
+    api._update_vehicle_properties(vehicle, ice_looking_state)
+    assert vehicle.engine_type == ENGINE_TYPES.EV


### PR DESCRIPTION
## Summary

Follow-up to #1080 per @cdnninja's review suggestion. `KiaUvoApiUSA` was the
only region-specific implementation that never populated `Vehicle.engine_type`,
so #1080 had to gate the new `/evc/gts` call on `ev_battery_percentage is not
None` as a proxy. This PR populates `engine_type` properly and switches the
gate to use it.

## Changes

1. **`get_vehicles()`** now maps `ownr/gvl`'s `fuelType` field. Only
   `fuelType=4` is confirmed from a live account (2020 Niro EV), so that's the
   only value mapped to `ENGINE_TYPES.EV`; anything else is left as `None` and
   refined in step 2.
2. **`_update_vehicle_properties()`** refines `engine_type` from the cached
   `cmm/gvi` state when it is still `None`:
   - `evStatus` present + `drvDistance.rangeByFuel.gasModeRange` → `PHEV`
   - `evStatus` present, no `gasModeRange` → `EV`
   - no `evStatus` → `ICE`
3. **Gate in `update_vehicle_with_cached_state()`** switched from
   `ev_battery_percentage is not None` to
   `engine_type in (ENGINE_TYPES.EV, ENGINE_TYPES.PHEV)`.

## Testing caveat

> ⚠️ **I only have access to a 2020 Kia Niro EV account**, so I cannot
> verify the ICE, PHEV, or HEV code paths against real API responses.
> Those paths are exercised by unit tests based on the expected cached
> response shape, but the `fuelType` integer values for non-EV Kia USA
> vehicles are unknown to me — that's why only `fuelType=4` is mapped
> explicitly and everything else falls through to the cached-state
> inference.

If anyone with an ICE / PHEV / HEV Kia USA account sees issues I'm happy
to adjust.

## Tests

9 new tests in `tests/us_target_soc_test.py`:

- `test_engine_type_from_fuel_type_ev` — `fuelType=4` → `EV`
- `test_engine_type_from_fuel_type_unknown` — other values → `None`
- `test_update_vehicle_properties_infers_ev_from_ev_status`
- `test_update_vehicle_properties_infers_ice_without_ev_status`
- `test_update_vehicle_properties_infers_phev_from_gas_mode_range`
- `test_update_vehicle_properties_preserves_preset_engine_type`
- `test_update_cached_state_calls_evc_gts_for_phev_vehicle`
- (plus the two existing gate tests rewritten to use `engine_type`)

Full suite: **96 passed, 8 skipped**, `ruff check` clean.