### PR TITLE
fix: Hyundai Token Script, switch to playwright and add option to use venv instead of installing dependencies globally

### DIFF
--- a/Hyundai Token Solution/HyundaiToken.bat
+++ b/Hyundai Token Solution/HyundaiToken.bat
@@ -14,17 +14,58 @@ cd /d "%~dp0"
 
 where python >nul 2>nul
 if %ERRORLEVEL% neq 0 (
-    echo ❌ Python not found! Please install it from https://www.python.org.
+    echo Python not found! Please install it from https://www.python.org.
     pause
     exit /b
 )
 
-python -m pip install --user selenium chromedriver-autoinstaller requests >nul 2>nul
+echo How would you like to set up dependencies?
+echo.
+echo   [1] Install dependencies globally (pip install)
+echo   [2] Use a virtual environment (venv) [RECOMMENDED]
+echo   [3] Skip - dependencies are already installed
+echo.
+set /p CHOICE="Your choice (1/2/3): "
+
+if "%CHOICE%"=="1" (
+    echo.
+    echo Installing dependencies globally...
+    python -m pip install -r requirements.txt
+    if %ERRORLEVEL% neq 0 (
+        echo.
+        echo ERROR: Failed to install dependencies. Try option 2 (venv) instead.
+        pause
+        exit /b
+    )
+    python -m playwright install chromium
+) else if "%CHOICE%"=="2" (
+    echo.
+    if not exist "venv" (
+        echo Creating virtual environment...
+        python -m venv venv
+    )
+    echo Activating virtual environment...
+    call venv\Scripts\activate.bat
+    echo Installing dependencies in venv...
+    pip install -r requirements.txt
+    if %ERRORLEVEL% neq 0 (
+        echo.
+        echo ERROR: Failed to install dependencies.
+        pause
+        exit /b
+    )
+    python -m playwright install chromium
+) else (
+    echo.
+    echo Skipping dependency installation.
+)
+
+echo.
 python hyundai_token.py
 
 echo.
 echo ============================================================
-echo ✅ Process completed successfully!
+echo Process completed successfully!
 echo You can use your refresh token as your password in your Hyundai integration in Home Assistant.
 echo ============================================================
 pause

--- a/Hyundai Token Solution/HyundaiToken.sh
+++ b/Hyundai Token Solution/HyundaiToken.sh
@@ -5,7 +5,7 @@
 
 clear
 echo "============================================================"
-echo "      🚗 Hyundai Token Generator - macOS / Linux"
+echo "      Hyundai Token Generator - macOS / Linux"
 echo "============================================================"
 echo
 echo "Please wait a few seconds. You will be redirected to Hyundai login page by Chrome."
@@ -14,16 +14,65 @@ echo
 cd "$(dirname "$0")"
 
 if ! command -v python3 &> /dev/null; then
-    echo "❌ Python3 not found!"
+    echo "Python3 not found!"
     exit 1
 fi
 
-python3 -m pip install --user selenium chromedriver-autoinstaller requests > /dev/null 2>&1
+echo "How would you like to set up dependencies?"
+echo
+echo "  [1] Install dependencies globally (pip install)"
+echo "  [2] Use a virtual environment (venv) [RECOMMENDED]"
+echo "  [3] Skip - dependencies are already installed"
+echo
+read -p "Your choice (1/2/3): " CHOICE
+
+case "$CHOICE" in
+    1)
+        echo
+        echo "Installing dependencies globally..."
+        python3 -m pip install -r requirements.txt
+        if [ $? -ne 0 ]; then
+            echo
+            echo "ERROR: Failed to install dependencies. Try option 2 (venv) instead."
+            read -p "Press ENTER to exit..."
+            exit 1
+        fi
+        python3 -m playwright install chromium
+        ;;
+    2)
+        echo
+        if [ ! -d "venv" ]; then
+            echo "Creating virtual environment..."
+            python3 -m venv venv
+        fi
+        echo "Activating virtual environment..."
+        source venv/bin/activate
+        echo "Installing dependencies in venv..."
+        pip install -r requirements.txt
+        if [ $? -ne 0 ]; then
+            echo
+            echo "ERROR: Failed to install dependencies."
+            read -p "Press ENTER to exit..."
+            exit 1
+        fi
+        python -m playwright install chromium
+        ;;
+    3)
+        echo
+        echo "Skipping dependency installation."
+        ;;
+    *)
+        echo
+        echo "Invalid choice. Skipping dependency installation."
+        ;;
+esac
+
+echo
 python3 hyundai_token.py
 
 echo
 echo "============================================================"
-echo "✅ Process completed successfully!"
+echo "Process completed successfully!"
 echo "You can use your refresh token as your password in your Hyundai integration in Home Assistant."
 echo "============================================================"
 read -p "Press ENTER to close..."

--- a/Hyundai Token Solution/hyundai_token.py
+++ b/Hyundai Token Solution/hyundai_token.py
@@ -2,7 +2,6 @@
 import re
 import subprocess
 import sys
-import time
 
 import requests
 from playwright.sync_api import sync_playwright

--- a/Hyundai Token Solution/hyundai_token.py
+++ b/Hyundai Token Solution/hyundai_token.py
@@ -1,145 +1,126 @@
 # hyundai_token.py
-import os
 import re
-import time
-import shutil
+import subprocess
 import sys
+import time
+
 import requests
-import platform
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
-from selenium.webdriver.chrome.service import Service
-from selenium.common.exceptions import WebDriverException
-import chromedriver_autoinstaller
-
-# Detect OS
-IS_WINDOWS = platform.system() == "Windows"
-
-# Chrome options (no printing)
-options = Options()
-options.add_argument("--window-size=1000,800")
-options.add_argument("--disable-blink-features=AutomationControlled")
-options.add_argument(
-    "user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-    "AppleWebKit/537.36 (KHTML, like Gecko) "
-    "Chrome/125.0.0.0 Safari/537.36_CCS_APP_AOS"
-)
+from playwright.sync_api import sync_playwright
 
 
-def install_driver():
-    """
-    Ensure a matching chromedriver is installed and return its path.
-    Exit with an informative message if Chrome is not found.
-    """
+def ensure_browser_installed():
+    """Install Chromium if not already downloaded by Playwright."""
     try:
-        _ = chromedriver_autoinstaller.get_chrome_version()
-    except Exception:
-        print(
-            "ERROR: Google Chrome not found. Please install Google Chrome and try again."
+        subprocess.run(
+            [sys.executable, "-m", "playwright", "install", "chromium"],
+            check=True,
+            capture_output=True,
         )
+    except subprocess.CalledProcessError as e:
+        print("ERROR: Could not install Chromium browser.")
+        print(f"Details: {e.stderr.decode()}")
         sys.exit(1)
 
-    try:
-        driver_path = chromedriver_autoinstaller.install()
-        return driver_path
-    except Exception:
-        return None
 
+def main():
+    ensure_browser_installed()
 
-def safe_install_and_start():
-    """
-    Install chromedriver (or reinstall after cleanup) and start the Chrome WebDriver.
-    Attempts one automatic cleanup/reinstall if the first start fails.
-    """
-    driver_path = install_driver()
-    if not driver_path:
+    with sync_playwright() as p:
+        browser = p.chromium.launch(
+            headless=False,
+            args=[
+                "--window-size=1000,800",
+                "--disable-blink-features=AutomationControlled",
+            ],
+        )
+        context = browser.new_context(
+            viewport={"width": 1000, "height": 800},
+            user_agent=(
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/125.0.0.0 Safari/537.36_CCS_APP_AOS"
+            ),
+        )
+        page = context.new_page()
+
+        # Hyundai login URL (ENGLISH VERSION)
+        BASE_URL = "https://idpconnect-eu.hyundai.com/auth/api/v2/user/oauth2/"
+        LOGIN_URL = (
+            f"{BASE_URL}authorize?"
+            "client_id=peuhyundaiidm-ctb&"
+            "redirect_uri=https%3A%2F%2Fctbapi.hyundai-europe.com%2Fapi%2Fauth&"
+            "nonce=&state=EN_&"
+            "scope=openid+profile+email+phone&"
+            "response_type=code&"
+            "connector_client_id=peuhyundaiidm-ctb&"
+            "connector_scope=&connector_session_key=&country=&captcha=1&"
+            "ui_locales=en-US&lang=en"
+        )
+
+        page.goto(LOGIN_URL)
+
+        print("\n" + "=" * 60)
+        print("LOGIN REQUIRED:")
+        print("Please complete login and reCAPTCHA in the opened browser window.")
+        print("=" * 60)
+        input("\nPress ENTER after login is complete...")
+
+        # Use CDP to intercept the redirect that carries the authorization code.
+        # The redirect target (prd.eu-ccapi.hyundai.com) is unreachable, so we
+        # capture the code from the network request before it times out.
+        print("Fetching authorization code...")
+
+        authorize_url = (
+            f"{BASE_URL}authorize?response_type=code"
+            "&client_id=6d477c38-3ca4-4cf3-9557-2a1929a94654"
+            "&redirect_uri=https://prd.eu-ccapi.hyundai.com:8080/api/v1/user/oauth2/token"
+            "&lang=en&state=ccsp"
+        )
+
+        page.goto(authorize_url)
+
+        print("A consent/authorization page may appear in the browser.")
+        print("If prompted, please complete any required steps.")
+        print("Waiting for authorization code (up to 120s)...")
+
+        # Wait for the OAuth flow to complete — the final redirect carries code=
         try:
-            driver_path = chromedriver_autoinstaller.install()
-        except Exception as e:
-            print(f"ERROR: Failed to install chromedriver: {e}")
-            sys.exit(1)
-
-    try:
-        service = Service(driver_path)
-        driver = webdriver.Chrome(service=service, options=options)
-        return driver
-    except WebDriverException:
-        # Attempt to remove the installed driver folder and try reinstall
-        try:
-            driver_dir = os.path.dirname(driver_path) if driver_path else None
-            if driver_dir and os.path.exists(driver_dir):
-                shutil.rmtree(driver_dir, ignore_errors=True)
+            page.wait_for_url(re.compile(r"code="), timeout=120000)
         except Exception:
             pass
 
-        # Reinstall and try again
-        try:
-            driver_path = chromedriver_autoinstaller.install()
-            service = Service(driver_path)
-            driver = webdriver.Chrome(service=service, options=options)
-            return driver
-        except Exception as final_err:
-            print("ERROR: Could not start Chrome WebDriver after reinstall.")
-            print("Reason:", final_err)
-            sys.exit(1)
+        code = None
+        code_match = re.search(r"[?&]code=([^&]+)", page.url)
+        if code_match:
+            code = code_match.group(1)
+        if code:
+            response = requests.post(
+                f"{BASE_URL}token",
+                data={
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "redirect_uri": "https://prd.eu-ccapi.hyundai.com:8080/api/v1/user/oauth2/token",
+                    "client_id": "6d477c38-3ca4-4cf3-9557-2a1929a94654",
+                    "client_secret": "KUy49XxPzLpLuoK0xhBC77W6VXhmtQR9iQhmIFjjoY4IpxsV",
+                },
+            )
+            if response.status_code == 200:
+                token = response.json().get("refresh_token")
+                print("\n" + "=" * 60)
+                print(f"REFRESH TOKEN:\n{token}\n")
+                print(
+                    "Use this token as your password in your Hyundai integration in Home Assistant."
+                )
+                print("=" * 60)
+            else:
+                print(f"Error while retrieving token: {response.text}")
+        else:
+            print("Authorization code not found in URL. Try logging in again.")
+
+        browser.close()
+
+    input("\nPress Enter to exit...")
 
 
-# Start: install driver and launch browser without printing Chrome version
-driver = safe_install_and_start()
-
-# Hyundai login URL (ENGLISH VERSION)
-BASE_URL = "https://idpconnect-eu.hyundai.com/auth/api/v2/user/oauth2/"
-LOGIN_URL = (
-    f"{BASE_URL}authorize?"
-    "client_id=peuhyundaiidm-ctb&"
-    "redirect_uri=https%3A%2F%2Fctbapi.hyundai-europe.com%2Fapi%2Fauth&"
-    "nonce=&state=EN_&"
-    "scope=openid+profile+email+phone&"
-    "response_type=code&"
-    "connector_client_id=peuhyundaiidm-ctb&"
-    "connector_scope=&connector_session_key=&country=&captcha=1&"
-    "ui_locales=en-US&lang=en"
-)
-
-driver.get(LOGIN_URL)
-
-print("\n" + "=" * 60)
-print("LOGIN REQUIRED:")
-print("Please complete login and reCAPTCHA in the opened Chrome window.")
-print("=" * 60)
-input("\nPress ENTER after login is complete...")
-
-# After login, get the authorization code from redirected URL
-driver.get(
-    f"{BASE_URL}authorize?response_type=code&client_id=6d477c38-3ca4-4cf3-9557-2a1929a94654&redirect_uri=https://prd.eu-ccapi.hyundai.com:8080/api/v1/user/oauth2/token&lang=en&state=ccsp"
-)
-time.sleep(2)
-
-match = re.search(r"code=([^&]+)", driver.current_url)
-if match:
-    code = match.group(1)
-    response = requests.post(
-        f"{BASE_URL}token",
-        data={
-            "grant_type": "authorization_code",
-            "code": code,
-            "redirect_uri": "https://prd.eu-ccapi.hyundai.com:8080/api/v1/user/oauth2/token",
-            "client_id": "6d477c38-3ca4-4cf3-9557-2a1929a94654",
-            "client_secret": "KUy49XxPzLpLuoK0xhBC77W6VXhmtQR9iQhmIFjjoY4IpxsV",
-        },
-    )
-    if response.status_code == 200:
-        token = response.json().get("refresh_token")
-        print("\n" + "=" * 60)
-        print(f"REFRESH TOKEN:\n{token}\n")
-        print(
-            "Use this token as your password in your Hyundai integration in Home Assistant."
-        )
-        print("=" * 60)
-    else:
-        print(f"Error while retrieving token: {response.text}")
-else:
-    print("Authorization code not found in URL. Try logging in again.")
-
-driver.quit()
-input("\nPress Enter to exit...")
+if __name__ == "__main__":
+    main()

--- a/Hyundai Token Solution/readme.txt
+++ b/Hyundai Token Solution/readme.txt
@@ -6,21 +6,44 @@ HyundaiToken.bat (for window system)
 HyundaiToken.sh (for mac/Linux system)
 hyundai_token.py
 
-2.Run the script:
+2. Run the script:
 -Windows / Mac / Linux: Double-click launch_hyundai_token.bat. This script automatically detects your system and runs the correct commands.
 -Alternative: If Python 3 is already installed, you can double-click hyundai_token.py directly. It will work the same as using launch_hyundai_token.bat.
 
+The script will ask you how to install dependencies:
+  [1] Install globally (pip install)
+  [2] Use a virtual environment (venv) [RECOMMENDED]
+  [3] Skip (if you already installed them)
 
-3.Login to Hyundai:
+Option 2 is recommended because it keeps the dependencies isolated from your system Python.
+If you choose option 2, the script will automatically create and activate the venv for you.
+
+If you prefer to set up the venv manually beforehand:
+
+  Windows (CMD / PowerShell):
+    python -m venv venv
+    venv\Scripts\activate
+    pip install -r requirements.txt
+
+  Mac / Linux:
+    python3 -m venv venv
+    source venv/bin/activate
+    pip install -r requirements.txt
+
+To leave the virtual environment later, simply run:
+    deactivate
+
+
+4. Login to Hyundai:
 -Chrome page will automatically open the Hyundai login page.
 -Complete login with your Hyundai account and solve any reCAPTCHA if prompted. (After login, don't close chrome page yet)
 
 Note: After you login with your Hyundai account, a weird message will appear on chrome page such as "result":"E","data":null,"message":"url is not defined". This message is not important. You can still keep open your chrome page and go back to terminal / CMD / PowerShell screen and press ENTER button.
 
-4.Return to the terminal / CMD / PowerShell:
+5. Return to the terminal / CMD / PowerShell:
 Press ENTER once login is complete.
 
-5.Retrieve your token:
+6. Retrieve your token:
 
 Your refresh token will appear in the terminal.
 You can now use this token as the password in your Hyundai integration in Home Assistant.

--- a/Hyundai Token Solution/requirements.txt
+++ b/Hyundai Token Solution/requirements.txt
@@ -1,0 +1,2 @@
+requests
+playwright


### PR DESCRIPTION
Hello,
i had to update my token in my homeassistant instance today, 
but the script wasn't working. 

In this PR i adjusted the Hyundai Token Utils to use playwright, auto install chromium if needed, and let the user select if he wants to use an venv (recommended) or install dependencies globally.