### PR TITLE
fix:  for #1090 stale location for eu

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -245,6 +245,11 @@ class KiaUvoApiEU(ApiImplType1):
             state = response["resMsg"]["state"]["Vehicle"]
             self._update_vehicle_properties_ccs2(vehicle, state)
 
+        # The status response embeds a stale cached location.
+        # Override it with the more current /location/park endpoint.
+        # this is not a force endpoint so car will not wake up
+        self._set_cached_location_park(token, vehicle)
+
         if (
             vehicle.engine_type == ENGINE_TYPES.EV
             or vehicle.engine_type == ENGINE_TYPES.PHEV
@@ -801,8 +806,31 @@ class KiaUvoApiEU(ApiImplType1):
             response = response["resMsg"]["state"]["Vehicle"]
         return response
 
-    def _get_location(self, token: Token, vehicle: Vehicle) -> dict:
+    def _set_cached_location_park(self, token: Token, vehicle: Vehicle) -> None:
         url = self.SPA_API_URL + "vehicles/" + vehicle.id + "/location/park"
+        
+        try:
+            response = requests.get(
+                url, headers=self._get_authenticated_headers(token)
+            ).json()
+            _LOGGER.debug(f"{DOMAIN} - _get_location response: {response}")
+            _check_response_for_errors(response)
+            
+            location = response["resMsg"]
+            if location and get_child_value(location, "coord.lat"):
+                vehicle.location = (
+                    get_child_value(location, "coord.lat"),
+                    get_child_value(location, "coord.lon"),
+                    parse_datetime(
+                        get_child_value(location, "time"), self.data_timezone
+                    ),
+                )
+        except Exception:
+            _LOGGER.debug(f"{DOMAIN} - _get_location failed")
+            return None
+
+    def _get_location(self, token: Token, vehicle: Vehicle) -> dict:
+        url = self.SPA_API_URL + "vehicles/" + vehicle.id + "/location"
 
         try:
             response = requests.get(
@@ -813,7 +841,7 @@ class KiaUvoApiEU(ApiImplType1):
             ).json()
             _LOGGER.debug(f"{DOMAIN} - _get_location response: {response}")
             _check_response_for_errors(response)
-            return response["resMsg"]
+            return response["resMsg"]["gpsDetail"]
         except Exception as e:
             _LOGGER.error(f"{DOMAIN} - _get_location failed: {e}", exc_info=True)
             return None

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -808,14 +808,14 @@ class KiaUvoApiEU(ApiImplType1):
 
     def _set_cached_location_park(self, token: Token, vehicle: Vehicle) -> None:
         url = self.SPA_API_URL + "vehicles/" + vehicle.id + "/location/park"
-        
+
         try:
             response = requests.get(
                 url, headers=self._get_authenticated_headers(token)
             ).json()
             _LOGGER.debug(f"{DOMAIN} - _get_location response: {response}")
             _check_response_for_errors(response)
-            
+
             location = response["resMsg"]
             if location and get_child_value(location, "coord.lat"):
                 vehicle.location = (


### PR DESCRIPTION
+ add new method to set the cached location from non forced "/park" endpoint for ccs2 and non ccs2 cars.
+ revert last change in _get_location(..) to use the forced endpoint "/location" again.