### PR TITLE
fix: After forced refresh, also call refresh from server cache

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -296,6 +296,9 @@ class KiaUvoApiEU(ApiImplType1):
                 )
             else:
                 self._update_vehicle_drive_info(vehicle, state)
+        # Forced update response is incomplete (SOC levels aren't included). Instead update
+        # from cached state.
+        self.update_vehicle_with_cached_state(token, vehicle)
 
     def _update_vehicle_properties(self, vehicle: Vehicle, state: dict) -> None:
         if get_child_value(state, "vehicleStatus.time"):


### PR DESCRIPTION
Tested on EU Hyundai Ioniq 5 (2025) and Kia EV3 (2025).

This fixes the underlying issue seen in Hyundai-Kia-Connect/kia_uvo#1617

The response to force_refresh does not include the SOC of my cars, and it makes the call fail and the SOC entity unavailable.

This fix makes a refresh from cache call after the force refresh call to get the correct values.

Related to:
- https://github.com/Hyundai-Kia-Connect/kia_uvo/pull/1629