### PR TITLE
fix: correct CCS2 stationary (AC) and fast (DC) charging estimates

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -471,7 +471,7 @@ class ApiImplType1(ApiImpl):
             "m",
         )
         vehicle.ev_estimated_fast_charge_duration = (
-            get_child_value(state, "Green.ChargingInformation.EstimatedTime.Standard"),
+            get_child_value(state, "Green.ChargingInformation.EstimatedTime.Quick"),
             "m",
         )
         vehicle.ev_estimated_portable_charge_duration = (
@@ -479,7 +479,7 @@ class ApiImplType1(ApiImpl):
             "m",
         )
         vehicle.ev_estimated_station_charge_duration = (
-            get_child_value(state, "Green.ChargingInformation.EstimatedTime.Quick"),
+            get_child_value(state, "Green.ChargingInformation.EstimatedTime.Standard"),
             "m",
         )
         vehicle.ev_charge_limits_ac = get_child_value(


### PR DESCRIPTION
Confirmed with a Kona EV 2026 (EU) with the following response:

    "EstimatedTime": {
      "ICCB": 970,
      "Standard": 240,
      "Quick": 28
    },