### PR TITLE
feat: add UnsupportedControlError for resCode 4005

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -40,6 +40,7 @@ from .exceptions import (
     InvalidAPIResponseError,
     RateLimitingError,
     DeviceIDError,
+    UnsupportedControlError,
 )
 
 USER_AGENT_OK_HTTP: str = "okhttp/3.12.0"
@@ -71,6 +72,7 @@ def _check_response_for_errors(response: dict) -> None:
         "7501": AuthenticationError,
         "4002": DeviceIDError,
         "4004": DuplicateRequestError,
+        "4005": UnsupportedControlError,
         "4081": RequestTimeoutError,
         "5031": ServiceTemporaryUnavailable,
         "5091": RateLimitingError,

--- a/hyundai_kia_connect_api/KiaUvoApiCN.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCN.py
@@ -39,6 +39,7 @@ from .exceptions import (
     RateLimitingError,
     RequestTimeoutError,
     ServiceTemporaryUnavailable,
+    UnsupportedControlError,
 )
 from .Token import Token
 from .utils import (
@@ -83,6 +84,7 @@ def _check_response_for_errors(response: dict) -> None:
 
     error_code_mapping = {
         "4004": DuplicateRequestError,
+        "4005": UnsupportedControlError,
         "4081": RequestTimeoutError,
         "5031": ServiceTemporaryUnavailable,
         "5091": RateLimitingError,

--- a/hyundai_kia_connect_api/exceptions.py
+++ b/hyundai_kia_connect_api/exceptions.py
@@ -85,6 +85,15 @@ class DuplicateRequestError(APIError):
     pass
 
 
+class UnsupportedControlError(APIError):
+    """
+    Raised when the vehicle does not support the requested control action.
+    API returns resCode 4005 for unsupported actions (e.g. stop_climate on HEV).
+    """
+
+    pass
+
+
 class RequestTimeoutError(APIError):
     """
     Raised when (supposedly) the server fails to establish a connection with the car.


### PR DESCRIPTION
  ## Summary

   - Add `UnsupportedControlError` exception class to `exceptions.py` for API resCode 4005 ("Unsupported control request - Vehicle is not Supported")
   - Map `"4005": UnsupportedControlError` in `error_code_mapping` for both EU (`ApiImplType1`) and CN (`KiaUvoApiCN`) API implementations
   - This error occurs when a vehicle doesn't support a particular remote control action (e.g., `stop_climate` on HEV vehicles)

   ## Problem

   Hybrid vehicles (HEV, not PHEV/EV) may have read-only status data (e.g., `air_control_is_on`) but don't support certain remote control actions (e.g., `stop_climate`). The API returns resCode 4005, which was previously unmapped and surfaced as a generic `APIError` with the raw server message.

   ## Test plan

   - [ ] Verify `UnsupportedControlError` is importable and is a subclass of `APIError`
   - [ ] Verify error code mapping includes `"4005": UnsupportedControlError` in both `ApiImplType1` and `KiaUvoApiCN`
   - [ ] Test with HEV vehicle: call `stop_climate` → should raise `UnsupportedControlError` instead of generic `APIError`