### PR TITLE
test: add test coverage for check_action_status polling loop

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -154,7 +154,7 @@ class ApiImplType1(ApiImpl):
                             "This appears to be corrupted data from Hyundai's API."
                         )
                         dte["ICE"] = None
-        except (KeyError, TypeError, AttributeError):
+        except (KeyError, TypeError, AttributeError):  # fmt: skip
             # If the structure doesn't exist or is malformed, silently continue
             # This is defensive programming in case the API structure changes
             pass
@@ -756,16 +756,9 @@ class ApiImplType1(ApiImpl):
             end_time = dt.datetime.now() + dt.timedelta(seconds=timeout)
             while end_time > dt.datetime.now():
                 # recursive call with Synchronous set to False
-                try:
-                    state = self.check_action_status(
-                        token, vehicle, action_id, synchronous=False
-                    )
-                except DuplicateRequestError:
-                    _LOGGER.debug(
-                        "Duplicate request while checking action status, "
-                        "treating as pending"
-                    )
-                    state = ORDER_STATUS.PENDING
+                state = self.check_action_status(
+                    token, vehicle, action_id, synchronous=False
+                )
                 if state == ORDER_STATUS.PENDING:
                     # state pending: recheck regularly
                     # (until we get a final state or exceed the timeout)

--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -756,9 +756,16 @@ class ApiImplType1(ApiImpl):
             end_time = dt.datetime.now() + dt.timedelta(seconds=timeout)
             while end_time > dt.datetime.now():
                 # recursive call with Synchronous set to False
-                state = self.check_action_status(
-                    token, vehicle, action_id, synchronous=False
-                )
+                try:
+                    state = self.check_action_status(
+                        token, vehicle, action_id, synchronous=False
+                    )
+                except DuplicateRequestError:
+                    _LOGGER.debug(
+                        "Duplicate request while checking action status, "
+                        "treating as pending"
+                    )
+                    state = ORDER_STATUS.PENDING
                 if state == ORDER_STATUS.PENDING:
                     # state pending: recheck regularly
                     # (until we get a final state or exceed the timeout)

--- a/hyundai_kia_connect_api/KiaUvoApiCN.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCN.py
@@ -1150,16 +1150,9 @@ class KiaUvoApiCN(ApiImplType1):
             end_time = dt.datetime.now() + dt.timedelta(seconds=timeout)
             while end_time > dt.datetime.now():
                 # recursive call with Synchronous set to False
-                try:
-                    state = self.check_action_status(
-                        token, vehicle, action_id, synchronous=False
-                    )
-                except DuplicateRequestError:
-                    _LOGGER.debug(
-                        "Duplicate request while checking action status, "
-                        "treating as pending"
-                    )
-                    state = ORDER_STATUS.PENDING
+                state = self.check_action_status(
+                    token, vehicle, action_id, synchronous=False
+                )
                 if state == ORDER_STATUS.PENDING:
                     # state pending: recheck regularly
                     # (until we get a final state or exceed the timeout)

--- a/hyundai_kia_connect_api/KiaUvoApiCN.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCN.py
@@ -1150,9 +1150,16 @@ class KiaUvoApiCN(ApiImplType1):
             end_time = dt.datetime.now() + dt.timedelta(seconds=timeout)
             while end_time > dt.datetime.now():
                 # recursive call with Synchronous set to False
-                state = self.check_action_status(
-                    token, vehicle, action_id, synchronous=False
-                )
+                try:
+                    state = self.check_action_status(
+                        token, vehicle, action_id, synchronous=False
+                    )
+                except DuplicateRequestError:
+                    _LOGGER.debug(
+                        "Duplicate request while checking action status, "
+                        "treating as pending"
+                    )
+                    state = ORDER_STATUS.PENDING
                 if state == ORDER_STATUS.PENDING:
                     # state pending: recheck regularly
                     # (until we get a final state or exceed the timeout)

--- a/tests/test_check_action_status.py
+++ b/tests/test_check_action_status.py
@@ -1,0 +1,263 @@
+"""Test check_action_status polling loop handles DuplicateRequestError correctly.
+
+Validates:
+1. Before fix: check_action_status(synchronous=True) crashes with
+   DuplicateRequestError when the API returns resCode 4004 during polling.
+2. After fix: DuplicateRequestError during polling is treated as PENDING,
+   and the loop continues polling until a final state is reached.
+3. Non-synchronous mode still raises DuplicateRequestError (not caught there).
+4. Normal polling still works (SUCCESS, FAILED, TIMEOUT states).
+"""
+
+import datetime as dt
+from time import sleep
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from hyundai_kia_connect_api.ApiImplType1 import ApiImplType1, _check_response_for_errors
+from hyundai_kia_connect_api.KiaUvoApiCN import KiaUvoApiCN
+from hyundai_kia_connect_api.Vehicle import Vehicle
+from hyundai_kia_connect_api.Token import Token
+from hyundai_kia_connect_api.const import (
+    BRAND_KIA,
+    BRAND_HYUNDAI,
+    REGION_EUROPE,
+    REGION_CANADA,
+    REGION_CHINA,
+)
+from hyundai_kia_connect_api.exceptions import (
+    DuplicateRequestError,
+    APIError,
+    InvalidAPIResponseError,
+)
+from hyundai_kia_connect_api.VehicleManager import VehicleManager
+
+
+# --- Helpers ---
+
+def _make_eu_api():
+    """Create an EU API instance for testing."""
+    return VehicleManager.get_implementation_by_region_brand(1, 1, "en")
+
+
+def _make_cn_api():
+    """Create a CN API instance for testing."""
+    return VehicleManager.get_implementation_by_region_brand(4, 1, "en")
+
+
+def _make_token():
+    """Create a valid token for testing."""
+    return Token(
+        username="test",
+        password="test",
+        valid_until=dt.datetime.now(dt.timezone.utc) + dt.timedelta(hours=1),
+    )
+
+
+def _make_vehicle():
+    """Create a test vehicle."""
+    v = Vehicle(id="test-vehicle-id")
+    v.ccu_ccs2_protocol_support = False
+    return v
+
+
+def _success_response(action_id="action-123"):
+    """API response for a successful action status."""
+    return {
+        "retCode": "S",
+        "resCode": "0000",
+        "resMsg": "success",
+        "msgId": action_id,
+    }
+
+
+def _pending_response():
+    """API response where action result is still None (pending)."""
+    return {
+        "retCode": "S",
+        "resCode": "0000",
+        "resMsg": [
+            {"recordId": "action-123", "result": None},
+        ],
+    }
+
+
+def _final_response(action_id="action-123", result="success"):
+    """API response with a final action result."""
+    return {
+        "retCode": "S",
+        "resCode": "0000",
+        "resMsg": [
+            {"recordId": action_id, "result": result},
+        ],
+    }
+
+
+def _duplicate_request_response():
+    """API response with resCode 4004 — DuplicateRequestError."""
+    return {
+        "retCode": "F",
+        "resCode": "4004",
+        "resMsg": "Duplicate request",
+    }
+
+
+# --- Tests: _check_response_for_errors still raises DuplicateRequestError ---
+
+class TestCheckResponseForErrors:
+    """Verify that _check_response_for_errors raises DuplicateRequestError for 4004."""
+
+    def test_raises_duplicate_request_error(self):
+        with pytest.raises(DuplicateRequestError):
+            _check_response_for_errors(_duplicate_request_response())
+
+    def test_success_response_passes(self):
+        # Should not raise
+        _check_response_for_errors(_success_response())
+
+
+# --- Tests: check_action_status non-synchronous mode ---
+
+class TestCheckActionStatusNonSynchronous:
+    """Non-synchronous mode should still raise DuplicateRequestError."""
+
+    @patch("hyundai_kia_connect_api.ApiImplType1.requests.get")
+    def test_non_sync_raises_duplicate_request_error(self, mock_get):
+        """When the API returns 4004, non-synchronous check should raise."""
+        mock_get.return_value.json.return_value = _duplicate_request_response()
+        api = _make_eu_api()
+        token = _make_token()
+        vehicle = _make_vehicle()
+
+        with pytest.raises(DuplicateRequestError):
+            api.check_action_status(token, vehicle, "action-123", synchronous=False)
+
+
+# --- Tests: check_action_status synchronous loop ---
+
+
+class TestCheckActionStatusSynchronousEU:
+    """Test the synchronous polling loop in ApiImplType1 (EU)."""
+
+    @patch("hyundai_kia_connect_api.ApiImplType1.requests.get")
+    @patch("hyundai_kia_connect_api.ApiImplType1.sleep", return_value=None)
+    def test_polling_treats_duplicate_request_as_pending(self, mock_sleep, mock_get):
+        """DuplicateRequestError during polling is treated as PENDING.
+
+        When the API returns resCode 4004 during a status check, it means
+        there's still a pending request. The polling loop should treat this
+        as PENDING and continue polling instead of crashing.
+        """
+        # First two calls return 4004 (pending), third returns success
+        mock_get.return_value.json.side_effect = [
+            _duplicate_request_response(),
+            _duplicate_request_response(),
+            _final_response("action-123", "success"),
+        ]
+        api = _make_eu_api()
+        token = _make_token()
+        vehicle = _make_vehicle()
+
+        from hyundai_kia_connect_api.const import ORDER_STATUS
+
+        result = api.check_action_status(
+            token, vehicle, "action-123", synchronous=True, timeout=60
+        )
+        assert result == ORDER_STATUS.SUCCESS
+        # Should have slept between polls (once per PENDING/4004 response)
+        assert mock_sleep.call_count >= 2
+
+    @patch("hyundai_kia_connect_api.ApiImplType1.requests.get")
+    @patch("hyundai_kia_connect_api.ApiImplType1.sleep", return_value=None)
+    def test_normal_polling_success(self, mock_sleep, mock_get):
+        """Normal polling: action goes from PENDING to SUCCESS."""
+        mock_get.return_value.json.side_effect = [
+            _pending_response(),
+            _pending_response(),
+            _final_response("action-123", "success"),
+        ]
+        api = _make_eu_api()
+        token = _make_token()
+        vehicle = _make_vehicle()
+
+        from hyundai_kia_connect_api.const import ORDER_STATUS
+
+        result = api.check_action_status(
+            token, vehicle, "action-123", synchronous=True, timeout=60
+        )
+        assert result == ORDER_STATUS.SUCCESS
+
+    @patch("hyundai_kia_connect_api.ApiImplType1.requests.get")
+    @patch("hyundai_kia_connect_api.ApiImplType1.sleep", return_value=None)
+    def test_normal_polling_failed(self, mock_sleep, mock_get):
+        """Normal polling: action goes from PENDING to FAILED."""
+        mock_get.return_value.json.side_effect = [
+            _pending_response(),
+            _final_response("action-123", "fail"),
+        ]
+        api = _make_eu_api()
+        token = _make_token()
+        vehicle = _make_vehicle()
+
+        from hyundai_kia_connect_api.const import ORDER_STATUS
+
+        result = api.check_action_status(
+            token, vehicle, "action-123", synchronous=True, timeout=60
+        )
+        assert result == ORDER_STATUS.FAILED
+
+    @patch("hyundai_kia_connect_api.ApiImplType1.requests.get")
+    @patch("hyundai_kia_connect_api.ApiImplType1.sleep", return_value=None)
+    def test_timeout_returns_timeout_status(self, mock_sleep, mock_get):
+        """When polling exceeds timeout, returns ORDER_STATUS.TIMEOUT.
+
+        We simulate a timeout by making every poll return PENDING,
+        then mocking the while-loop condition to exit after one iteration.
+        """
+        mock_get.return_value.json.return_value = _pending_response()
+        api = _make_eu_api()
+        token = _make_token()
+        vehicle = _make_vehicle()
+
+        from hyundai_kia_connect_api.const import ORDER_STATUS
+
+        # Patch dt.datetime.now in the ApiImplType1 module to simulate timeout.
+        # The check_action_status method uses: end_time = dt.datetime.now() + dt.timedelta(...)
+        # and: while end_time > dt.datetime.now():
+        # We need: first call to set end_time, second to enter the loop,
+        # third to exit the loop (time exceeded).
+        now = dt.datetime.now(tz=dt.timezone.utc)
+        later = now + dt.timedelta(hours=1)
+
+        with patch("hyundai_kia_connect_api.ApiImplType1.dt") as mock_dt:
+            mock_dt.datetime.now.side_effect = [now, now, later]
+            mock_dt.timedelta = dt.timedelta
+
+            result = api.check_action_status(
+                token, vehicle, "action-123", synchronous=True, timeout=15
+            )
+        assert result == ORDER_STATUS.TIMEOUT
+
+
+class TestCheckActionStatusSynchronousCN:
+    """Test the synchronous polling loop in KiaUvoApiCN (CN)."""
+
+    @patch("hyundai_kia_connect_api.KiaUvoApiCN.requests.get")
+    @patch("hyundai_kia_connect_api.KiaUvoApiCN.sleep", return_value=None)
+    def test_polling_treats_duplicate_request_as_pending(self, mock_sleep, mock_get):
+        """DuplicateRequestError during CN polling is treated as PENDING."""
+        mock_get.return_value.json.side_effect = [
+            _duplicate_request_response(),
+            _final_response("action-123", "success"),
+        ]
+        api = _make_cn_api()
+        token = _make_token()
+        vehicle = _make_vehicle()
+
+        from hyundai_kia_connect_api.const import ORDER_STATUS
+
+        result = api.check_action_status(
+            token, vehicle, "action-123", synchronous=True, timeout=60
+        )
+        assert result == ORDER_STATUS.SUCCESS

--- a/tests/test_check_action_status.py
+++ b/tests/test_check_action_status.py
@@ -1,12 +1,9 @@
-"""Test check_action_status polling loop handles DuplicateRequestError correctly.
+"""Test check_action_status polling loop behavior.
 
 Validates:
-1. Before fix: check_action_status(synchronous=True) crashes with
-   DuplicateRequestError when the API returns resCode 4004 during polling.
-2. After fix: DuplicateRequestError during polling is treated as PENDING,
-   and the loop continues polling until a final state is reached.
-3. Non-synchronous mode still raises DuplicateRequestError (not caught there).
-4. Normal polling still works (SUCCESS, FAILED, TIMEOUT states).
+1. _check_response_for_errors maps resCode 4004 to DuplicateRequestError
+2. Non-synchronous mode propagates DuplicateRequestError (not caught there)
+3. Normal polling works correctly (SUCCESS, FAILED, TIMEOUT states)
 """
 
 import datetime as dt
@@ -134,34 +131,6 @@ class TestCheckActionStatusSynchronousEU:
 
     @patch("hyundai_kia_connect_api.ApiImplType1.requests.get")
     @patch("hyundai_kia_connect_api.ApiImplType1.sleep", return_value=None)
-    def test_polling_treats_duplicate_request_as_pending(self, mock_sleep, mock_get):
-        """DuplicateRequestError during polling is treated as PENDING.
-
-        When the API returns resCode 4004 during a status check, it means
-        there's still a pending request. The polling loop should treat this
-        as PENDING and continue polling instead of crashing.
-        """
-        # First two calls return 4004 (pending), third returns success
-        mock_get.return_value.json.side_effect = [
-            _duplicate_request_response(),
-            _duplicate_request_response(),
-            _final_response("action-123", "success"),
-        ]
-        api = _make_eu_api()
-        token = _make_token()
-        vehicle = _make_vehicle()
-
-        from hyundai_kia_connect_api.const import ORDER_STATUS
-
-        result = api.check_action_status(
-            token, vehicle, "action-123", synchronous=True, timeout=60
-        )
-        assert result == ORDER_STATUS.SUCCESS
-        # Should have slept between polls (once per PENDING/4004 response)
-        assert mock_sleep.call_count >= 2
-
-    @patch("hyundai_kia_connect_api.ApiImplType1.requests.get")
-    @patch("hyundai_kia_connect_api.ApiImplType1.sleep", return_value=None)
     def test_normal_polling_success(self, mock_sleep, mock_get):
         """Normal polling: action goes from PENDING to SUCCESS."""
         mock_get.return_value.json.side_effect = [
@@ -230,26 +199,3 @@ class TestCheckActionStatusSynchronousEU:
                 token, vehicle, "action-123", synchronous=True, timeout=15
             )
         assert result == ORDER_STATUS.TIMEOUT
-
-
-class TestCheckActionStatusSynchronousCN:
-    """Test the synchronous polling loop in KiaUvoApiCN (CN)."""
-
-    @patch("hyundai_kia_connect_api.KiaUvoApiCN.requests.get")
-    @patch("hyundai_kia_connect_api.KiaUvoApiCN.sleep", return_value=None)
-    def test_polling_treats_duplicate_request_as_pending(self, mock_sleep, mock_get):
-        """DuplicateRequestError during CN polling is treated as PENDING."""
-        mock_get.return_value.json.side_effect = [
-            _duplicate_request_response(),
-            _final_response("action-123", "success"),
-        ]
-        api = _make_cn_api()
-        token = _make_token()
-        vehicle = _make_vehicle()
-
-        from hyundai_kia_connect_api.const import ORDER_STATUS
-
-        result = api.check_action_status(
-            token, vehicle, "action-123", synchronous=True, timeout=60
-        )
-        assert result == ORDER_STATUS.SUCCESS

--- a/tests/test_check_action_status.py
+++ b/tests/test_check_action_status.py
@@ -10,31 +10,21 @@ Validates:
 """
 
 import datetime as dt
-from time import sleep
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 
-from hyundai_kia_connect_api.ApiImplType1 import ApiImplType1, _check_response_for_errors
-from hyundai_kia_connect_api.KiaUvoApiCN import KiaUvoApiCN
+from hyundai_kia_connect_api.ApiImplType1 import _check_response_for_errors
 from hyundai_kia_connect_api.Vehicle import Vehicle
 from hyundai_kia_connect_api.Token import Token
-from hyundai_kia_connect_api.const import (
-    BRAND_KIA,
-    BRAND_HYUNDAI,
-    REGION_EUROPE,
-    REGION_CANADA,
-    REGION_CHINA,
-)
 from hyundai_kia_connect_api.exceptions import (
     DuplicateRequestError,
-    APIError,
-    InvalidAPIResponseError,
 )
 from hyundai_kia_connect_api.VehicleManager import VehicleManager
 
 
 # --- Helpers ---
+
 
 def _make_eu_api():
     """Create an EU API instance for testing."""
@@ -105,6 +95,7 @@ def _duplicate_request_response():
 
 # --- Tests: _check_response_for_errors still raises DuplicateRequestError ---
 
+
 class TestCheckResponseForErrors:
     """Verify that _check_response_for_errors raises DuplicateRequestError for 4004."""
 
@@ -118,6 +109,7 @@ class TestCheckResponseForErrors:
 
 
 # --- Tests: check_action_status non-synchronous mode ---
+
 
 class TestCheckActionStatusNonSynchronous:
     """Non-synchronous mode should still raise DuplicateRequestError."""


### PR DESCRIPTION
## Summary

Add test coverage for `check_action_status(synchronous=True)` polling behavior, which previously had zero tests.

**Affected regions**: EU (ApiImplType1) and CN (KiaUvoApiCN)

## Background

Original PR attempted to catch `DuplicateRequestError` in the polling loop based on the assumption that `resCode 4004` could appear on the status check endpoint. However, real EU API logs show that `resCode 4004` only appears on the **command submission** endpoint (`POST /ccs2/control/door`), never on the **status check** endpoint (`GET /notifications/{vehicle_id}/records`). The status endpoint consistently returns `resCode '0000'` even while a command is pending.

Per maintainer feedback, the defensive `try/except DuplicateRequestError` in the polling loop has been removed — it addresses a scenario that hasn't been observed in practice.

## Tests Added

- `TestCheckResponseForErrors` — verifies 4004 maps to `DuplicateRequestError` and success responses pass through
- `TestCheckActionStatusNonSynchronous` — verifies non-sync mode propagates `DuplicateRequestError`
- `TestCheckActionStatusSynchronousEU` — verifies normal polling (PENDING→SUCCESS, PENDING→FAILED, timeout)

## What This Does NOT Change

- `DuplicateRequestError` exception and its 4004 mapping in `_check_response_for_errors` remain — they correctly handle 4004 on the command submission path
- Non-synchronous `check_action_status` still raises `DuplicateRequestError`
- The polling loop behavior is unchanged from the base branch