### PR TITLE
fix: handle empty response body in start_charge and stop_charge (USA)

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
@@ -9,10 +9,6 @@ import time
 import certifi
 import requests
 from requests.adapters import HTTPAdapter
-
-# pylint:disable=logging-fstring-interpolation,deprecated-method,invalid-name,broad-exception-caught,unused-argument,missing-function-docstring
-
-
 from urllib3.util.ssl_ import create_urllib3_context
 
 from hyundai_kia_connect_api.exceptions import APIError, AuthenticationError

--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
@@ -9,6 +9,16 @@ import time
 import certifi
 import requests
 from requests.adapters import HTTPAdapter
+
+# pylint:disable=logging-fstring-interpolation,deprecated-method,invalid-name,broad-exception-caught,unused-argument,missing-function-docstring
+
+import datetime as dt
+import logging
+import time
+
+import certifi
+import requests
+from requests.adapters import HTTPAdapter
 from urllib3.util.ssl_ import create_urllib3_context
 
 from hyundai_kia_connect_api.exceptions import APIError, AuthenticationError
@@ -949,6 +959,12 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
         _LOGGER.debug(f"{DOMAIN} - Start charging headers: {headers}")
 
         response = self.sessions.post(url, headers=headers)
+        if not response.text:
+            _LOGGER.debug(
+                f"{DOMAIN} - Start charge response: empty body with status "
+                f"{response.status_code}, treating as success"
+            )
+            return
         response_json = response.json()
         _check_response_for_errors(response_json)
         _LOGGER.debug(
@@ -967,6 +983,12 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
         _LOGGER.debug(f"{DOMAIN} - Stop charging headers: {headers}")
 
         response = self.sessions.post(url, headers=headers)
+        if not response.text:
+            _LOGGER.debug(
+                f"{DOMAIN} - Stop charge response: empty body with status "
+                f"{response.status_code}, treating as success"
+            )
+            return
         response_json = response.json()
         _check_response_for_errors(response_json)
         _LOGGER.debug(

--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
@@ -12,13 +12,7 @@ from requests.adapters import HTTPAdapter
 
 # pylint:disable=logging-fstring-interpolation,deprecated-method,invalid-name,broad-exception-caught,unused-argument,missing-function-docstring
 
-import datetime as dt
-import logging
-import time
 
-import certifi
-import requests
-from requests.adapters import HTTPAdapter
 from urllib3.util.ssl_ import create_urllib3_context
 
 from hyundai_kia_connect_api.exceptions import APIError, AuthenticationError

--- a/tests/us_charge_command_test.py
+++ b/tests/us_charge_command_test.py
@@ -1,0 +1,197 @@
+"""Tests for start_charge and stop_charge commands in HyundaiBlueLinkApiUSA.
+
+Covers the fix for JSONDecodeError when Hyundai's API returns an empty
+response body (HTTP 200 OK, no body) for charge commands on newer vehicles
+such as the 2026 Hyundai Ioniq 9.
+"""
+
+import datetime as dt
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hyundai_kia_connect_api.const import ENGINE_TYPES
+from hyundai_kia_connect_api.HyundaiBlueLinkApiUSA import HyundaiBlueLinkApiUSA
+from hyundai_kia_connect_api.Token import Token
+from hyundai_kia_connect_api.Vehicle import Vehicle
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _FakeResponse:
+    """Minimal fake for requests.Response."""
+
+    def __init__(self, text="", status_code=200):
+        self.text = text
+        self.status_code = status_code
+
+    def json(self):
+        import json
+        return json.loads(self.text)
+
+
+def _make_vehicle(engine_type=ENGINE_TYPES.EV):
+    v = Vehicle(
+        id="test-id",
+        name="Ioniq 9",
+        model="IONIQ 9",
+        key="test-key",
+        timezone=dt.timezone(dt.timedelta(hours=-5)),
+    )
+    v.engine_type = engine_type
+    return v
+
+
+def _make_token():
+    return MagicMock(spec=Token)
+
+
+def _make_api():
+    """Create a HyundaiBlueLinkApiUSA without calling __init__."""
+    api = object.__new__(HyundaiBlueLinkApiUSA)
+    api.API_URL = "https://api.telematics.hyundaiusa.com/ac/v2/"
+    api.sessions = MagicMock()
+    return api
+
+
+# ---------------------------------------------------------------------------
+# start_charge tests
+# ---------------------------------------------------------------------------
+
+class TestStartCharge:
+
+    def test_start_charge_normal_json_response(self):
+        """start_charge succeeds when API returns valid JSON."""
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(
+            text='{"status": "success"}', status_code=200
+        )
+        vehicle = _make_vehicle()
+        token = _make_token()
+
+        api.start_charge(token, vehicle)
+        api.sessions.post.assert_called_once()
+
+    def test_start_charge_empty_body_no_exception(self):
+        """start_charge must NOT raise JSONDecodeError when API returns empty body.
+
+        Regression test for: Expecting value: line 1 column 1 (char 0)
+        Observed on 2026 Hyundai Ioniq 9 (USA) — command succeeds on vehicle
+        but API returns HTTP 200 with no response body.
+        """
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(text="", status_code=200)
+        vehicle = _make_vehicle()
+        token = _make_token()
+
+        api.start_charge(token, vehicle)
+        api.sessions.post.assert_called_once()
+
+    def test_start_charge_empty_body_logs_debug(self, caplog):
+        """start_charge logs a debug message when response body is empty."""
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(text="", status_code=200)
+        vehicle = _make_vehicle()
+        token = _make_token()
+
+        with caplog.at_level(logging.DEBUG):
+            api.start_charge(token, vehicle)
+
+        assert "empty body" in caplog.text.lower() or "treating as success" in caplog.text.lower()
+
+    def test_start_charge_skipped_for_non_ev(self):
+        """start_charge is a no-op for non-EV vehicles."""
+        api = _make_api()
+        vehicle = _make_vehicle(engine_type=ENGINE_TYPES.ICE)
+        token = _make_token()
+
+        api.start_charge(token, vehicle)
+        api.sessions.post.assert_not_called()
+
+    def test_start_charge_calls_correct_url(self):
+        """start_charge POSTs to the evc/charge/start endpoint."""
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(
+            text='{"status": "success"}', status_code=200
+        )
+        vehicle = _make_vehicle()
+        token = _make_token()
+
+        with patch.object(api, "_get_vehicle_headers", return_value={}):
+            api.start_charge(token, vehicle)
+
+        call_url = api.sessions.post.call_args[0][0]
+        assert "evc/charge/start" in call_url
+
+
+# ---------------------------------------------------------------------------
+# stop_charge tests
+# ---------------------------------------------------------------------------
+
+class TestStopCharge:
+
+    def test_stop_charge_normal_json_response(self):
+        """stop_charge succeeds when API returns valid JSON."""
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(
+            text='{"status": "success"}', status_code=200
+        )
+        vehicle = _make_vehicle()
+        token = _make_token()
+
+        api.stop_charge(token, vehicle)
+        api.sessions.post.assert_called_once()
+
+    def test_stop_charge_empty_body_no_exception(self):
+        """stop_charge must NOT raise JSONDecodeError when API returns empty body.
+
+        Regression test for: Expecting value: line 1 column 1 (char 0)
+        Observed on 2026 Hyundai Ioniq 9 (USA) — command succeeds on vehicle
+        but API returns HTTP 200 with no response body.
+        """
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(text="", status_code=200)
+        vehicle = _make_vehicle()
+        token = _make_token()
+
+        api.stop_charge(token, vehicle)
+        api.sessions.post.assert_called_once()
+
+    def test_stop_charge_empty_body_logs_debug(self, caplog):
+        """stop_charge logs a debug message when response body is empty."""
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(text="", status_code=200)
+        vehicle = _make_vehicle()
+        token = _make_token()
+
+        with caplog.at_level(logging.DEBUG):
+            api.stop_charge(token, vehicle)
+
+        assert "empty body" in caplog.text.lower() or "treating as success" in caplog.text.lower()
+
+    def test_stop_charge_skipped_for_non_ev(self):
+        """stop_charge is a no-op for non-EV vehicles."""
+        api = _make_api()
+        vehicle = _make_vehicle(engine_type=ENGINE_TYPES.ICE)
+        token = _make_token()
+
+        api.stop_charge(token, vehicle)
+        api.sessions.post.assert_not_called()
+
+    def test_stop_charge_calls_correct_url(self):
+        """stop_charge POSTs to the evc/charge/stop endpoint."""
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(
+            text='{"status": "success"}', status_code=200
+        )
+        vehicle = _make_vehicle()
+        token = _make_token()
+
+        with patch.object(api, "_get_vehicle_headers", return_value={}):
+            api.stop_charge(token, vehicle)
+
+        call_url = api.sessions.post.call_args[0][0]
+        assert "evc/charge/stop" in call_url

--- a/tests/us_charge_command_test.py
+++ b/tests/us_charge_command_test.py
@@ -9,7 +9,6 @@ import datetime as dt
 import logging
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 from hyundai_kia_connect_api.const import ENGINE_TYPES
 from hyundai_kia_connect_api.HyundaiBlueLinkApiUSA import HyundaiBlueLinkApiUSA
@@ -21,6 +20,7 @@ from hyundai_kia_connect_api.Vehicle import Vehicle
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 class _FakeResponse:
     """Minimal fake for requests.Response."""
 
@@ -30,6 +30,7 @@ class _FakeResponse:
 
     def json(self):
         import json
+
         return json.loads(self.text)
 
 
@@ -61,8 +62,8 @@ def _make_api():
 # start_charge tests
 # ---------------------------------------------------------------------------
 
-class TestStartCharge:
 
+class TestStartCharge:
     def test_start_charge_normal_json_response(self):
         """start_charge succeeds when API returns valid JSON."""
         api = _make_api()
@@ -100,7 +101,10 @@ class TestStartCharge:
         with caplog.at_level(logging.DEBUG):
             api.start_charge(token, vehicle)
 
-        assert "empty body" in caplog.text.lower() or "treating as success" in caplog.text.lower()
+        assert (
+            "empty body" in caplog.text.lower()
+            or "treating as success" in caplog.text.lower()
+        )
 
     def test_start_charge_skipped_for_non_ev(self):
         """start_charge is a no-op for non-EV vehicles."""
@@ -131,8 +135,8 @@ class TestStartCharge:
 # stop_charge tests
 # ---------------------------------------------------------------------------
 
-class TestStopCharge:
 
+class TestStopCharge:
     def test_stop_charge_normal_json_response(self):
         """stop_charge succeeds when API returns valid JSON."""
         api = _make_api()
@@ -170,7 +174,10 @@ class TestStopCharge:
         with caplog.at_level(logging.DEBUG):
             api.stop_charge(token, vehicle)
 
-        assert "empty body" in caplog.text.lower() or "treating as success" in caplog.text.lower()
+        assert (
+            "empty body" in caplog.text.lower()
+            or "treating as success" in caplog.text.lower()
+        )
 
     def test_stop_charge_skipped_for_non_ev(self):
         """stop_charge is a no-op for non-EV vehicles."""


### PR DESCRIPTION
## Summary

Fixes `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` when calling `start_charge` or `stop_charge` on newer US vehicles (confirmed on 2026 Hyundai Ioniq 9).

Hyundai's API returns HTTP 200 OK with an **empty response body** for these commands on some vehicles. The library was unconditionally calling `response.json()` which raises `JSONDecodeError` on an empty body — even though the command executed successfully on the vehicle (confirmed via Hyundai app push notifications).

## Changes

Added a guard in `HyundaiBlueLinkApiUSA.py` before calling `.json()` on the response in both `start_charge` and `stop_charge`:

```python
if not response.text:
    _LOGGER.debug(
        f"{DOMAIN} - Charge response: empty body with status "
        f"{response.status_code}, treating as success"
    )
    return
```

## Testing

Verified on a 2026 Hyundai Ioniq 9 (USA). Commands now complete without error in Home Assistant.

## Note

⚠️ This PR also includes a small set of duplicate import lines near the top of the file (an artifact of the edit process) — please remove those before merging. The core fix in `start_charge` and `stop_charge` is correct.