### PR TITLE
feat: add supports_window_control capability flag

### DIFF
--- a/hyundai_kia_connect_api/ApiImpl.py
+++ b/hyundai_kia_connect_api/ApiImpl.py
@@ -89,6 +89,7 @@ class ApiImpl:
     temperature_range = None
     previous_latitude: float = None
     previous_longitude: float = None
+    supports_window_control: bool = False
 
     def __init__(self) -> None:
         """Initialize."""

--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -156,7 +156,7 @@ class ApiImplType1(ApiImpl):
                             "This appears to be corrupted data from Hyundai's API."
                         )
                         dte["ICE"] = None
-        except KeyError, TypeError, AttributeError:
+        except (KeyError, TypeError, AttributeError):  # fmt: skip
             # If the structure doesn't exist or is malformed, silently continue
             # This is defensive programming in case the API structure changes
             pass

--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -113,6 +113,8 @@ def _check_response_for_errors(response: dict) -> None:
 class ApiImplType1(ApiImpl):
     """ApiImplType1"""
 
+    supports_window_control: bool = True
+
     def __init__(self) -> None:
         """Initialize."""
 
@@ -154,7 +156,7 @@ class ApiImplType1(ApiImpl):
                             "This appears to be corrupted data from Hyundai's API."
                         )
                         dte["ICE"] = None
-        except (KeyError, TypeError, AttributeError):
+        except KeyError, TypeError, AttributeError:
             # If the structure doesn't exist or is malformed, silently continue
             # This is defensive programming in case the API structure changes
             pass

--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
@@ -288,7 +288,7 @@ class HyundaiBlueLinkApiBR(ApiImpl):
                         pass
                     else:
                         vehicle.air_temperature = (temp_value, temp_unit)
-                except ValueError, TypeError, KeyError:  # fmt skip
+                except (ValueError, TypeError, KeyError):  # fmt: skip
                     pass
 
         # Fuel information

--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
@@ -288,7 +288,7 @@ class HyundaiBlueLinkApiBR(ApiImpl):
                         pass
                     else:
                         vehicle.air_temperature = (temp_value, temp_unit)
-                except ValueError, TypeError, KeyError:
+                except ValueError, TypeError, KeyError:  # fmt skip
                     pass
 
         # Fuel information

--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
@@ -34,6 +34,7 @@ _LOGGER = logging.getLogger(__name__)
 class HyundaiBlueLinkApiBR(ApiImpl):
     """Brazilian Hyundai BlueLink API implementation."""
 
+    supports_window_control: bool = True
     data_timezone = dt.timezone(dt.timedelta(hours=-3))  # Brazil (BRT/BRST)
 
     def __init__(self, region: int, brand: int, language: str = "pt-BR"):
@@ -287,7 +288,7 @@ class HyundaiBlueLinkApiBR(ApiImpl):
                         pass
                     else:
                         vehicle.air_temperature = (temp_value, temp_unit)
-                except (ValueError, TypeError, KeyError):
+                except ValueError, TypeError, KeyError:
                     pass
 
         # Fuel information

--- a/hyundai_kia_connect_api/Vehicle.py
+++ b/hyundai_kia_connect_api/Vehicle.py
@@ -144,6 +144,7 @@ class Vehicle:
     back_left_window_is_open: bool = None
     back_right_window_is_open: bool = None
     sunroof_is_open: bool = None
+    supports_window_control: bool = None
 
     # Tire Pressure
     tire_pressure_all_warning_is_on: bool = None

--- a/hyundai_kia_connect_api/VehicleManager.py
+++ b/hyundai_kia_connect_api/VehicleManager.py
@@ -127,6 +127,7 @@ class VehicleManager:
             )
         vehicles = self.api.get_vehicles(self.token)
         for vehicle in vehicles:
+            vehicle.supports_window_control = self.api.supports_window_control
             self.vehicles[vehicle.id] = vehicle
 
     def get_vehicle(self, vehicle_id: str) -> Vehicle:


### PR DESCRIPTION
## Summary

- Add `supports_window_control: bool` class attribute to API implementations so the Home Assistant integration can check whether window control is supported before creating entities
- `ApiImpl` base class defaults to `False`; `ApiImplType1` (EU/CN/AU/IN) and `HyundaiBlueLinkApiBR` override to `True`
- USA and CA API classes inherit `False` from `ApiImpl`

## Problem

Issue #1655 in the kia_uvo integration: window cover entities appear for USA/CA vehicles because those APIs populate `front_left_window_is_open` etc. from vehicle status data (read-only), but `set_windows_state` raises `NotImplementedError` when users try to control them.

## Solution

A capability flag that the integration can check before creating window entities. Regions that implement `set_windows_state` (EU, CN, AU, IN, BR) set it to `True`; regions that don't (USA, CA) inherit `False`.

## Companion PR

Hyundai-Kia-Connect/kia_uvo#xxx — uses this flag to skip cover entity creation for unsupported regions