### PR TITLE
fix: JSONDecodeError for USA control commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 # https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files#configuring-ignored-files-for-all-repositories-on-your-computer
 __pycache__/
 .env
+*.egg-info

--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
@@ -59,6 +59,42 @@ def _check_response_for_errors(response: dict) -> None:
             )
 
 
+def _safe_parse_json(response, action_name: str):
+    """
+    Safely parse JSON response from Hyundai USA API.
+
+    Control commands (lock, unlock, climate, charge, etc.) return
+    HTTP 200 with an empty body on success. Calling response.json()
+    on an empty body raises JSONDecodeError even though the command
+    succeeded.
+
+    Args:
+        response: the HTTP response object
+        action_name: name of the action for logging purposes
+
+    Returns:
+        dict: parsed JSON if body exists
+        None: if body is empty (command succeeded, nothing to return)
+
+    Raises:
+        APIError: if HTTP status is not 200
+    """
+    if response.status_code != 200:
+        raise APIError(
+            f"{action_name} failed with "
+            f"HTTP {response.status_code}: '{response.text[:200]}'"
+        )
+
+    if not response.text.strip():
+        _LOGGER.debug(
+            f"{DOMAIN} - Empty response body for {action_name} "
+            f"(HTTP 200). Command succeeded."
+        )
+        return None
+
+    return response.json()
+
+
 class cipherAdapter(HTTPAdapter):
     """
     A HTTPAdapter that re-enables poor ciphers required by Hyundai.
@@ -832,8 +868,9 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
 
         data = {"userName": token.username, "vin": vehicle.VIN}
         response = self.sessions.post(url, headers=headers, json=data)
-        response_json = response.json()
-        _check_response_for_errors(response_json)
+        response_json = _safe_parse_json(response, "lock_action")
+        if response_json is not None:
+            _check_response_for_errors(response_json)
         # response_headers = response.headers
         # response = response.json()
         # action_status = self.check_action_status(token, headers["pAuth"], response_headers["transactionId"])  # noqa
@@ -911,8 +948,9 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
         _LOGGER.debug(f"{DOMAIN} - Start engine data: {data}")
 
         response = self.sessions.post(url, json=data, headers=headers)
-        response_json = response.json()
-        _check_response_for_errors(response_json)
+        response_json = _safe_parse_json(response, "start_climate")
+        if response_json is not None:
+            _check_response_for_errors(response_json)
         _LOGGER.debug(
             f"{DOMAIN} - Start engine response status code: {response.status_code}"
         )
@@ -931,8 +969,9 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
         _LOGGER.debug(f"{DOMAIN} - Stop engine headers: {headers}")
 
         response = self.sessions.post(url, headers=headers)
-        response_json = response.json()
-        _check_response_for_errors(response_json)
+        response_json = _safe_parse_json(response, "stop_climate")
+        if response_json is not None:
+            _check_response_for_errors(response_json)
         _LOGGER.debug(
             f"{DOMAIN} - Stop engine response status code: {response.status_code}"
         )
@@ -949,14 +988,9 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
         _LOGGER.debug(f"{DOMAIN} - Start charging headers: {headers}")
 
         response = self.sessions.post(url, headers=headers)
-        if not response.text:
-            _LOGGER.debug(
-                f"{DOMAIN} - Start charge response: empty body with status "
-                f"{response.status_code}, treating as success"
-            )
-            return
-        response_json = response.json()
-        _check_response_for_errors(response_json)
+        response_json = _safe_parse_json(response, "start_charge")
+        if response_json is not None:
+            _check_response_for_errors(response_json)
         _LOGGER.debug(
             f"{DOMAIN} - Start charge response status code: {response.status_code}"
         )
@@ -973,14 +1007,9 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
         _LOGGER.debug(f"{DOMAIN} - Stop charging headers: {headers}")
 
         response = self.sessions.post(url, headers=headers)
-        if not response.text:
-            _LOGGER.debug(
-                f"{DOMAIN} - Stop charge response: empty body with status "
-                f"{response.status_code}, treating as success"
-            )
-            return
-        response_json = response.json()
-        _check_response_for_errors(response_json)
+        response_json = _safe_parse_json(response, "stop_charge")
+        if response_json is not None:
+            _check_response_for_errors(response_json)
         _LOGGER.debug(
             f"{DOMAIN} - Stop charge response status code: {response.status_code}"
         )
@@ -1013,8 +1042,9 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
         _LOGGER.debug(f"{DOMAIN} - Setting charge limits body: {data}")
 
         response = self.sessions.post(url, json=data, headers=headers)
-        response_json = response.json()
-        _check_response_for_errors(response_json)
+        response_json = _safe_parse_json(response, "set_charge_limits")
+        if response_json is not None:
+            _check_response_for_errors(response_json)
         _LOGGER.debug(
             f"{DOMAIN} - Setting charge limits response status code: {response.status_code}"  # noqa
         )

--- a/tests/us_climate_command_test.py
+++ b/tests/us_climate_command_test.py
@@ -1,0 +1,138 @@
+"""Tests for start_climate and stop_climate commands in HyundaiBlueLinkApiUSA.
+
+Covers the fix for JSONDecodeError when Hyundai's API returns an empty
+response body (HTTP 200 OK, no body) for climate commands.
+"""
+
+import datetime as dt
+import logging
+from unittest.mock import MagicMock, patch
+
+from hyundai_kia_connect_api.HyundaiBlueLinkApiUSA import HyundaiBlueLinkApiUSA
+from hyundai_kia_connect_api.Token import Token
+from hyundai_kia_connect_api.Vehicle import Vehicle
+from hyundai_kia_connect_api.ApiImpl import ClimateRequestOptions
+
+
+class _FakeResponse:
+    """Minimal fake for requests.Response."""
+
+    def __init__(self, text="", status_code=200):
+        self.text = text
+        self.status_code = status_code
+
+    def json(self):
+        import json
+
+        return json.loads(self.text)
+
+
+def _make_vehicle():
+    return Vehicle(
+        id="test-id",
+        name="Ioniq 5",
+        model="IONIQ 5",
+        key="test-key",
+        timezone=dt.timezone(dt.timedelta(hours=-5)),
+    )
+
+
+def _make_token():
+    return MagicMock(spec=Token)
+
+
+def _make_api():
+    """Create a HyundaiBlueLinkApiUSA without calling __init__."""
+    api = object.__new__(HyundaiBlueLinkApiUSA)
+    api.API_URL = "https://api.telematics.hyundaiusa.com/ac/v2/"
+    api.sessions = MagicMock()
+    return api
+
+
+def _make_climate_options():
+    return ClimateRequestOptions(set_temp=72, defrost=False, climate=True, heating=True)
+
+
+class TestStartClimate:
+    def test_start_climate_empty_body_no_exception(self):
+        """start_climate must NOT raise JSONDecodeError on empty body."""
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(text="", status_code=200)
+        vehicle = _make_vehicle()
+        token = _make_token()
+        options = _make_climate_options()
+
+        with patch.object(api, "_get_vehicle_headers", return_value={}):
+            api.start_climate(token, vehicle, options)
+
+        api.sessions.post.assert_called_once()
+
+    def test_start_climate_normal_json_response(self):
+        """start_climate succeeds when API returns valid JSON."""
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(
+            text='{"status": "success"}', status_code=200
+        )
+        vehicle = _make_vehicle()
+        token = _make_token()
+        options = _make_climate_options()
+
+        with patch.object(api, "_get_vehicle_headers", return_value={}):
+            api.start_climate(token, vehicle, options)
+
+        api.sessions.post.assert_called_once()
+
+    def test_start_climate_empty_body_logs_debug(self, caplog):
+        """start_climate logs debug message when response body is empty."""
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(text="", status_code=200)
+        vehicle = _make_vehicle()
+        token = _make_token()
+        options = _make_climate_options()
+
+        with caplog.at_level(logging.DEBUG):
+            with patch.object(api, "_get_vehicle_headers", return_value={}):
+                api.start_climate(token, vehicle, options)
+
+        assert "empty" in caplog.text.lower()
+
+
+class TestStopClimate:
+    def test_stop_climate_empty_body_no_exception(self):
+        """stop_climate must NOT raise JSONDecodeError on empty body."""
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(text="", status_code=200)
+        vehicle = _make_vehicle()
+        token = _make_token()
+
+        with patch.object(api, "_get_vehicle_headers", return_value={}):
+            api.stop_climate(token, vehicle)
+
+        api.sessions.post.assert_called_once()
+
+    def test_stop_climate_normal_json_response(self):
+        """stop_climate succeeds when API returns valid JSON."""
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(
+            text='{"status": "success"}', status_code=200
+        )
+        vehicle = _make_vehicle()
+        token = _make_token()
+
+        with patch.object(api, "_get_vehicle_headers", return_value={}):
+            api.stop_climate(token, vehicle)
+
+        api.sessions.post.assert_called_once()
+
+    def test_stop_climate_empty_body_logs_debug(self, caplog):
+        """stop_climate logs debug message when response body is empty."""
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(text="", status_code=200)
+        vehicle = _make_vehicle()
+        token = _make_token()
+
+        with caplog.at_level(logging.DEBUG):
+            with patch.object(api, "_get_vehicle_headers", return_value={}):
+                api.stop_climate(token, vehicle)
+
+        assert "empty" in caplog.text.lower()

--- a/tests/us_lock_command_test.py
+++ b/tests/us_lock_command_test.py
@@ -1,0 +1,132 @@
+"""Tests for lock_action command in HyundaiBlueLinkApiUSA.
+
+Covers the fix for JSONDecodeError when Hyundai's API returns an empty
+response body (HTTP 200 OK, no body) for lock/unlock commands.
+"""
+
+import datetime as dt
+import logging
+from unittest.mock import MagicMock, patch
+
+from hyundai_kia_connect_api.HyundaiBlueLinkApiUSA import HyundaiBlueLinkApiUSA
+from hyundai_kia_connect_api.Token import Token
+from hyundai_kia_connect_api.Vehicle import Vehicle
+from hyundai_kia_connect_api.const import VEHICLE_LOCK_ACTION
+
+
+class _FakeResponse:
+    """Minimal fake for requests.Response."""
+
+    def __init__(self, text="", status_code=200):
+        self.text = text
+        self.status_code = status_code
+
+    def json(self):
+        import json
+
+        return json.loads(self.text)
+
+
+def _make_vehicle():
+    return Vehicle(
+        id="test-id",
+        name="Ioniq 5",
+        model="IONIQ 5",
+        key="test-key",
+        timezone=dt.timezone(dt.timedelta(hours=-5)),
+    )
+
+
+def _make_token():
+    return MagicMock(spec=Token)
+
+
+def _make_api():
+    """Create a HyundaiBlueLinkApiUSA without calling __init__."""
+    api = object.__new__(HyundaiBlueLinkApiUSA)
+    api.API_URL = "https://api.telematics.hyundaiusa.com/ac/v2/"
+    api.sessions = MagicMock()
+    return api
+
+
+class TestLockAction:
+    def test_lock_empty_body_no_exception(self):
+        """lock_action must NOT raise JSONDecodeError on empty body."""
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(text="", status_code=200)
+        vehicle = _make_vehicle()
+        token = _make_token()
+
+        with patch.object(api, "_get_vehicle_headers", return_value={}):
+            api.lock_action(token, vehicle, VEHICLE_LOCK_ACTION.LOCK)
+
+        api.sessions.post.assert_called_once()
+
+    def test_unlock_empty_body_no_exception(self):
+        """lock_action with UNLOCK must NOT raise JSONDecodeError on empty body."""
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(text="", status_code=200)
+        vehicle = _make_vehicle()
+        token = _make_token()
+
+        with patch.object(api, "_get_vehicle_headers", return_value={}):
+            api.lock_action(token, vehicle, VEHICLE_LOCK_ACTION.UNLOCK)
+
+        api.sessions.post.assert_called_once()
+
+    def test_lock_normal_json_response(self):
+        """lock_action succeeds when API returns valid JSON."""
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(
+            text='{"status": "success"}', status_code=200
+        )
+        vehicle = _make_vehicle()
+        token = _make_token()
+
+        with patch.object(api, "_get_vehicle_headers", return_value={}):
+            api.lock_action(token, vehicle, VEHICLE_LOCK_ACTION.LOCK)
+
+        api.sessions.post.assert_called_once()
+
+    def test_lock_empty_body_logs_debug(self, caplog):
+        """lock_action logs debug message when response body is empty."""
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(text="", status_code=200)
+        vehicle = _make_vehicle()
+        token = _make_token()
+
+        with caplog.at_level(logging.DEBUG):
+            with patch.object(api, "_get_vehicle_headers", return_value={}):
+                api.lock_action(token, vehicle, VEHICLE_LOCK_ACTION.LOCK)
+
+        assert "empty" in caplog.text.lower()
+
+    def test_lock_calls_correct_url(self):
+        """lock_action POSTs to rcs/rdo/off for LOCK."""
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(
+            text='{"status": "success"}', status_code=200
+        )
+        vehicle = _make_vehicle()
+        token = _make_token()
+
+        with patch.object(api, "_get_vehicle_headers", return_value={}):
+            api.lock_action(token, vehicle, VEHICLE_LOCK_ACTION.LOCK)
+
+        call_url = api.sessions.post.call_args[0][0]
+        assert "rcs/rdo/off" in call_url
+
+    def test_unlock_calls_correct_url(self):
+        """lock_action POSTs to rcs/rdo/on for UNLOCK."""
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(
+            text='{"status": "success"}', status_code=200
+        )
+        vehicle = _make_vehicle()
+        token = _make_token()
+
+        with patch.object(api, "_get_vehicle_headers", return_value={}):
+            api.lock_action(token, vehicle, VEHICLE_LOCK_ACTION.UNLOCK)
+
+        call_url = api.sessions.post.call_args[0][0]
+        assert "rcs/rdo/on" in call_url

--- a/tests/us_safe_parse_json_test.py
+++ b/tests/us_safe_parse_json_test.py
@@ -1,0 +1,60 @@
+"""Tests for _safe_parse_json helper in HyundaiBlueLinkApiUSA.
+
+Covers the fix for JSONDecodeError when Hyundai's USA API returns an
+empty response body (HTTP 200 OK, no body) for control commands.
+"""
+
+import pytest
+from hyundai_kia_connect_api.HyundaiBlueLinkApiUSA import _safe_parse_json
+from hyundai_kia_connect_api.exceptions import APIError
+
+
+class _FakeResponse:
+    """Minimal fake for requests.Response."""
+
+    def __init__(self, text="", status_code=200):
+        self.text = text
+        self.status_code = status_code
+
+    def json(self):
+        import json
+
+        return json.loads(self.text)
+
+
+class TestSafeParseJson:
+    def test_empty_body_200_returns_none(self):
+        """HTTP 200 with empty body should return None (command succeeded)."""
+        response = _FakeResponse(text="", status_code=200)
+        result = _safe_parse_json(response, "test_action")
+        assert result is None
+
+    def test_whitespace_body_200_returns_none(self):
+        """HTTP 200 with whitespace-only body should return None."""
+        response = _FakeResponse(text="   ", status_code=200)
+        result = _safe_parse_json(response, "test_action")
+        assert result is None
+
+    def test_valid_json_200_returns_dict(self):
+        """HTTP 200 with valid JSON body should return parsed dict."""
+        response = _FakeResponse(text='{"errorCode": "200"}', status_code=200)
+        result = _safe_parse_json(response, "test_action")
+        assert result == {"errorCode": "200"}
+
+    def test_non_200_raises_api_error(self):
+        """Non-200 status code should raise APIError."""
+        response = _FakeResponse(text="Server Error", status_code=502)
+        with pytest.raises(APIError):
+            _safe_parse_json(response, "test_action")
+
+    def test_non_200_error_message_contains_status(self):
+        """APIError message should include the HTTP status code."""
+        response = _FakeResponse(text="Not Found", status_code=404)
+        with pytest.raises(APIError, match="404"):
+            _safe_parse_json(response, "test_action")
+
+    def test_non_200_error_message_contains_action_name(self):
+        """APIError message should include the action name."""
+        response = _FakeResponse(text="Error", status_code=500)
+        with pytest.raises(APIError, match="lock_action"):
+            _safe_parse_json(response, "lock_action")


### PR DESCRIPTION
## Summary

Extends the fix from #1127 to cover all affected control commands.

All control commands for USA region vehicles return HTTP 200 with empty 
response body on success. The library was calling `response.json()` 
unconditionally, raising `JSONDecodeError` even though commands succeeded.

## Affected functions

- `lock_action()` (covers both lock and unlock)
- `start_climate()`
- `stop_climate()`
- `start_charge()` (previously fixed in #1127, refactored)
- `stop_charge()` (previously fixed in #1127, refactored)
- `set_charge_limits()`

## Fix

Added `_safe_parse_json()` helper that:
- Returns `None` for HTTP 200 with empty body (treats as success)
- Raises `APIError` for non-200 responses with descriptive message
- Falls back to standard `response.json()` when body exists

Replaces the per-function guards added in #1127 with a single reusable 
helper, making the pattern consistent across all control commands.

## Testing

- Added `tests/us_safe_parse_json_test.py` for the helper function
- Added `tests/us_lock_command_test.py` for lock/unlock commands
- Added `tests/us_climate_command_test.py` for climate commands
- Existing `tests/us_charge_command_test.py` from #1127 still passes
- Tested on 2024 Hyundai Ioniq 5, USA region (region=3, brand=2)

Closes #1125