### PR TITLE
fix: handle both token expiry error message variants

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -81,7 +81,8 @@ def _check_response_for_errors(response: dict) -> None:
     }
 
     error_message_to_exception_mapping = {
-        "Key not authorized: Token is expired": AuthenticationError
+        "Key not authorized: Token is expired": AuthenticationError,
+        "Key not authorized: token has expired": AuthenticationError,
     }
 
     if not any(


### PR DESCRIPTION
## Summary

The API returns `"Key not authorized: token has expired"` (lowercase) as an error message, but the `error_message_to_exception_mapping` in `_check_response_for_errors` only matched `"Key not authorized: Token is expired"` (title case). This caused the error to fall through to a generic `APIError("Unknown error in API response")` instead of being properly caught as `AuthenticationError`.

Added both variants to the mapping so the correct `AuthenticationError` is raised regardless of which casing the API returns.

## Context

Reported in #1104. The user's log showed:
```
WARNING: Token expired detected, attempting refresh: Unknown error in API response: Key not authorized: token has expired
```

The "Unknown error" prefix confirms it wasn't matching the mapping.

## Test plan

- [ ] Verify `"Key not authorized: token has expired"` now raises `AuthenticationError`
- [ ] Verify `"Key not authorized: Token is expired"` still raises `AuthenticationError`
- [ ] Run existing test suite: `pytest tests/ -q`

Fixes #1104