### PR TITLE
fix: add check_action_status to HyundaiBlueLinkApiUSA

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
@@ -18,6 +18,7 @@ from .const import (
     DISTANCE_UNITS,
     DOMAIN,
     ENGINE_TYPES,
+    ORDER_STATUS,
     SEAT_STATUS,
     TEMPERATURE_UNITS,
     VEHICLE_LOCK_ACTION,
@@ -851,7 +852,53 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
 
         return result
 
-    def lock_action(self, token: Token, vehicle: Vehicle, action) -> None:
+    def _get_transaction_id(self, response) -> str | None:
+        for key in ("tmsTid", "transactionId", "Xid"):
+            if key in response.headers:
+                return response.headers[key]
+        _LOGGER.warning(
+            f"{DOMAIN} - No transaction ID found in response headers: "
+            f"{dict(response.headers)}"
+        )
+        return None
+
+    def check_action_status(
+        self,
+        token: Token,
+        vehicle: Vehicle,
+        action_id: str,
+        synchronous: bool = False,
+        timeout: int = 120,
+    ) -> ORDER_STATUS:
+        url = self.API_URL + "rmt/getRunningStatus"
+        headers = self._get_vehicle_headers(token, vehicle)
+        headers["tid"] = action_id
+        headers["login_id"] = token.username
+        headers["service_type"] = "REMOTE_POLL"
+
+        max_attempts = 1 if not synchronous else max(1, timeout // 2)
+
+        for _ in range(max_attempts):
+            response = self.sessions.post(url, headers=headers)
+            response_json = _safe_parse_json(response, "check_action_status")
+            if response_json is None:
+                if not synchronous:
+                    return ORDER_STATUS.UNKNOWN
+                time.sleep(2)
+                continue
+            status = response_json.get("status", "")
+            if status == "SUCCESS":
+                return ORDER_STATUS.SUCCESS
+            elif status == "ERROR":
+                return ORDER_STATUS.FAILED
+            if synchronous:
+                time.sleep(2)
+
+        if synchronous:
+            return ORDER_STATUS.TIMEOUT
+        return ORDER_STATUS.PENDING
+
+    def lock_action(self, token: Token, vehicle: Vehicle, action) -> str:
         _LOGGER.debug(f"{DOMAIN} - Action for lock is: {action}")
 
         if action == VEHICLE_LOCK_ACTION.LOCK:
@@ -871,15 +918,12 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
         response_json = _safe_parse_json(response, "lock_action")
         if response_json is not None:
             _check_response_for_errors(response_json)
-        # response_headers = response.headers
-        # response = response.json()
-        # action_status = self.check_action_status(token, headers["pAuth"], response_headers["transactionId"])  # noqa
-
-        # _LOGGER.debug(f"{DOMAIN} - Received lock_action response {action_status}")
         _LOGGER.debug(
             f"{DOMAIN} - Received lock_action response status code: {response.status_code}"  # noqa
         )
         _LOGGER.debug(f"{DOMAIN} - Received lock_action response: {response.text}")
+
+        return self._get_transaction_id(response)
 
     def start_climate(
         self, token: Token, vehicle: Vehicle, options: ClimateRequestOptions
@@ -956,7 +1000,9 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
         )
         _LOGGER.debug(f"{DOMAIN} - Start engine response: {response.text}")
 
-    def stop_climate(self, token: Token, vehicle: Vehicle) -> None:
+        return self._get_transaction_id(response)
+
+    def stop_climate(self, token: Token, vehicle: Vehicle) -> str:
         _LOGGER.debug(f"{DOMAIN} - Stop engine..")
 
         if vehicle.engine_type == ENGINE_TYPES.EV:
@@ -977,7 +1023,9 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
         )
         _LOGGER.debug(f"{DOMAIN} - Stop engine response: {response.text}")
 
-    def start_charge(self, token: Token, vehicle: Vehicle) -> None:
+        return self._get_transaction_id(response)
+
+    def start_charge(self, token: Token, vehicle: Vehicle) -> str:
         if vehicle.engine_type != ENGINE_TYPES.EV:
             return {}
 
@@ -996,7 +1044,9 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
         )
         _LOGGER.debug(f"{DOMAIN} - Start charge response: {response.text}")
 
-    def stop_charge(self, token: Token, vehicle: Vehicle) -> None:
+        return self._get_transaction_id(response)
+
+    def stop_charge(self, token: Token, vehicle: Vehicle) -> str:
         if vehicle.engine_type != ENGINE_TYPES.EV:
             return {}
 
@@ -1014,6 +1064,8 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
             f"{DOMAIN} - Stop charge response status code: {response.status_code}"
         )
         _LOGGER.debug(f"{DOMAIN} - Stop charge response: {response.text}")
+
+        return self._get_transaction_id(response)
 
     def set_charge_limits(
         self, token: Token, vehicle: Vehicle, ac: int, dc: int
@@ -1049,3 +1101,5 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
             f"{DOMAIN} - Setting charge limits response status code: {response.status_code}"  # noqa
         )
         _LOGGER.debug(f"{DOMAIN} - Setting charge limits: {response.text}")
+
+        return self._get_transaction_id(response)

--- a/tests/us_action_status_test.py
+++ b/tests/us_action_status_test.py
@@ -1,0 +1,146 @@
+"""Tests for check_action_status in HyundaiBlueLinkApiUSA."""
+
+import datetime as dt
+from unittest.mock import MagicMock, patch
+
+from hyundai_kia_connect_api.HyundaiBlueLinkApiUSA import HyundaiBlueLinkApiUSA
+from hyundai_kia_connect_api.Token import Token
+from hyundai_kia_connect_api.Vehicle import Vehicle
+from hyundai_kia_connect_api.const import ORDER_STATUS
+
+
+class _FakeResponse:
+    """Minimal fake for requests.Response."""
+
+    def __init__(self, json_data=None, status_code=200):
+        self.json_data = json_data
+        self.status_code = status_code
+        self.text = '{"status": "success"}' if json_data else ""
+        self.headers = {"tmsTid": "test-transaction-id"}
+
+    def json(self):
+        if self.json_data is not None:
+            return self.json_data
+        import json
+
+        return json.loads(self.text)
+
+
+def _make_vehicle():
+    return Vehicle(
+        id="test-id",
+        name="Ioniq 5",
+        model="IONIQ 5",
+        key="test-key",
+        timezone=dt.timezone(dt.timedelta(hours=-5)),
+    )
+
+
+def _make_token():
+    return MagicMock(spec=Token)
+
+
+def _make_api():
+    api = object.__new__(HyundaiBlueLinkApiUSA)
+    api.API_URL = "https://api.telematics.hyundaiusa.com/ac/v2/"
+    api.sessions = MagicMock()
+    return api
+
+
+class TestCheckActionStatus:
+    def test_success(self):
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(json_data={"status": "SUCCESS"})
+        vehicle = _make_vehicle()
+        token = _make_token()
+
+        with patch.object(api, "_get_vehicle_headers", return_value={}):
+            result = api.check_action_status(token, vehicle, "tx-123")
+
+        assert result == ORDER_STATUS.SUCCESS
+
+    def test_failed(self):
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(json_data={"status": "ERROR"})
+        vehicle = _make_vehicle()
+        token = _make_token()
+
+        with patch.object(api, "_get_vehicle_headers", return_value={}):
+            result = api.check_action_status(token, vehicle, "tx-123")
+
+        assert result == ORDER_STATUS.FAILED
+
+    def test_pending(self):
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(json_data={"status": "PENDING"})
+        vehicle = _make_vehicle()
+        token = _make_token()
+
+        with patch.object(api, "_get_vehicle_headers", return_value={}):
+            result = api.check_action_status(token, vehicle, "tx-123")
+
+        assert result == ORDER_STATUS.PENDING
+
+    def test_empty_response_returns_unknown(self):
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(json_data=None)
+        vehicle = _make_vehicle()
+        token = _make_token()
+
+        with patch.object(api, "_get_vehicle_headers", return_value={}):
+            result = api.check_action_status(token, vehicle, "tx-123")
+
+        assert result == ORDER_STATUS.UNKNOWN
+
+    def test_synchronous_timeout(self):
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(json_data={"status": "PENDING"})
+        vehicle = _make_vehicle()
+        token = _make_token()
+
+        with patch.object(api, "_get_vehicle_headers", return_value={}):
+            with patch("hyundai_kia_connect_api.HyundaiBlueLinkApiUSA.time.sleep"):
+                result = api.check_action_status(
+                    token, vehicle, "tx-123", synchronous=True, timeout=4
+                )
+
+        assert result == ORDER_STATUS.TIMEOUT
+
+    def test_synchronous_success(self):
+        api = _make_api()
+        api.sessions.post.return_value = _FakeResponse(json_data={"status": "SUCCESS"})
+        vehicle = _make_vehicle()
+        token = _make_token()
+
+        with patch.object(api, "_get_vehicle_headers", return_value={}):
+            result = api.check_action_status(
+                token, vehicle, "tx-123", synchronous=True, timeout=4
+            )
+
+        assert result == ORDER_STATUS.SUCCESS
+
+
+class TestGetTransactionId:
+    def test_finds_tmsTid(self):
+        api = _make_api()
+        response = MagicMock()
+        response.headers = {"tmsTid": "abc-123"}
+        assert api._get_transaction_id(response) == "abc-123"
+
+    def test_finds_transactionId(self):
+        api = _make_api()
+        response = MagicMock()
+        response.headers = {"transactionId": "def-456"}
+        assert api._get_transaction_id(response) == "def-456"
+
+    def test_finds_Xid(self):
+        api = _make_api()
+        response = MagicMock()
+        response.headers = {"Xid": "ghi-789"}
+        assert api._get_transaction_id(response) == "ghi-789"
+
+    def test_returns_none_when_not_found(self):
+        api = _make_api()
+        response = MagicMock()
+        response.headers = {"content-type": "application/json"}
+        assert api._get_transaction_id(response) is None

--- a/tests/us_charge_command_test.py
+++ b/tests/us_charge_command_test.py
@@ -24,9 +24,10 @@ from hyundai_kia_connect_api.Vehicle import Vehicle
 class _FakeResponse:
     """Minimal fake for requests.Response."""
 
-    def __init__(self, text="", status_code=200):
+    def __init__(self, text="", status_code=200, headers=None):
         self.text = text
         self.status_code = status_code
+        self.headers = headers or {"tmsTid": "test-transaction-id"}
 
     def json(self):
         import json
@@ -73,7 +74,8 @@ class TestStartCharge:
         vehicle = _make_vehicle()
         token = _make_token()
 
-        api.start_charge(token, vehicle)
+        with patch.object(api, "_get_vehicle_headers", return_value={}):
+            api.start_charge(token, vehicle)
         api.sessions.post.assert_called_once()
 
     def test_start_charge_empty_body_no_exception(self):
@@ -88,7 +90,8 @@ class TestStartCharge:
         vehicle = _make_vehicle()
         token = _make_token()
 
-        api.start_charge(token, vehicle)
+        with patch.object(api, "_get_vehicle_headers", return_value={}):
+            api.start_charge(token, vehicle)
         api.sessions.post.assert_called_once()
 
     def test_start_charge_empty_body_logs_debug(self, caplog):
@@ -99,10 +102,11 @@ class TestStartCharge:
         token = _make_token()
 
         with caplog.at_level(logging.DEBUG):
-            api.start_charge(token, vehicle)
+            with patch.object(api, "_get_vehicle_headers", return_value={}):
+                api.start_charge(token, vehicle)
 
         assert (
-            "empty body" in caplog.text.lower()
+            "empty response body" in caplog.text.lower()
             or "treating as success" in caplog.text.lower()
         )
 
@@ -146,7 +150,8 @@ class TestStopCharge:
         vehicle = _make_vehicle()
         token = _make_token()
 
-        api.stop_charge(token, vehicle)
+        with patch.object(api, "_get_vehicle_headers", return_value={}):
+            api.stop_charge(token, vehicle)
         api.sessions.post.assert_called_once()
 
     def test_stop_charge_empty_body_no_exception(self):
@@ -161,7 +166,8 @@ class TestStopCharge:
         vehicle = _make_vehicle()
         token = _make_token()
 
-        api.stop_charge(token, vehicle)
+        with patch.object(api, "_get_vehicle_headers", return_value={}):
+            api.stop_charge(token, vehicle)
         api.sessions.post.assert_called_once()
 
     def test_stop_charge_empty_body_logs_debug(self, caplog):
@@ -172,10 +178,11 @@ class TestStopCharge:
         token = _make_token()
 
         with caplog.at_level(logging.DEBUG):
-            api.stop_charge(token, vehicle)
+            with patch.object(api, "_get_vehicle_headers", return_value={}):
+                api.stop_charge(token, vehicle)
 
         assert (
-            "empty body" in caplog.text.lower()
+            "empty response body" in caplog.text.lower()
             or "treating as success" in caplog.text.lower()
         )
 

--- a/tests/us_climate_command_test.py
+++ b/tests/us_climate_command_test.py
@@ -17,9 +17,10 @@ from hyundai_kia_connect_api.ApiImpl import ClimateRequestOptions
 class _FakeResponse:
     """Minimal fake for requests.Response."""
 
-    def __init__(self, text="", status_code=200):
+    def __init__(self, text="", status_code=200, headers=None):
         self.text = text
         self.status_code = status_code
+        self.headers = headers or {"tmsTid": "test-transaction-id"}
 
     def json(self):
         import json

--- a/tests/us_lock_command_test.py
+++ b/tests/us_lock_command_test.py
@@ -17,9 +17,10 @@ from hyundai_kia_connect_api.const import VEHICLE_LOCK_ACTION
 class _FakeResponse:
     """Minimal fake for requests.Response."""
 
-    def __init__(self, text="", status_code=200):
+    def __init__(self, text="", status_code=200, headers=None):
         self.text = text
         self.status_code = status_code
+        self.headers = headers or {"tmsTid": "test-transaction-id"}
 
     def json(self):
         import json


### PR DESCRIPTION
## Summary
- Fixes #1061 — Hyundai USA BlueLink API does not wait for response completion after sending commands
- Adds `check_action_status` method that polls `ac/v2/rmt/getRunningStatus` endpoint (based on [reference implementation](https://github.com/andyfase/egmp-bluelink-scriptable/blob/07d49ee19fc29cd3e1dd7f17e52526943c9fe900/src/lib/bluelink-regions/usa.ts#L272-L321))
- Updates all command methods to return the transaction ID from response headers, enabling callers to poll for completion

## Changes
1. **`check_action_status` method**: Polls `ac/v2/rmt/getRunningStatus` with the transaction ID from command response headers. Supports synchronous (polling loop with timeout) and non-synchronous (single check) modes. Returns proper `ORDER_STATUS` enum values.

2. **`_get_transaction_id` helper**: Extracts transaction ID from response headers. Checks `tmsTid` (from reference TypeScript implementation), `transactionId` (from commented code), and `Xid` (from Kia USA API) as fallbacks. Logs warning if no transaction ID found.

3. **Command methods updated**: `lock_action`, `start_climate`, `stop_climate`, `start_charge`, `stop_charge`, `set_charge_limits` now return the transaction ID string instead of `None`, aligning with KiaUvoApiUSA which returns `response.headers["Xid"]`.

## Test plan
- [x] 10 new unit tests for `check_action_status` and `_get_transaction_id`
- [x] All 162 existing tests pass
- [x] Existing USA command tests updated with proper headers mocking
- [ ] Verify transaction ID header name against real Hyundai USA API (currently checking `tmsTid`, `transactionId`, `Xid` as fallbacks)