### PR TITLE
fix: add ignitionDuration to non-CCS2 start_climate payload

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -941,10 +941,10 @@ class ApiImplType1(ApiImpl):
             payload = {
                 "action": "start",
                 "hvacType": 0,
-                "ignitionDuration": options.duration,
                 "options": {
                     "defrost": options.defrost,
                     "heating1": int(options.heating),
+                    "igniOnDuration": options.duration,
                 },
                 "tempCode": hex_set_temp,
                 "unit": "C",

--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -941,6 +941,7 @@ class ApiImplType1(ApiImpl):
             payload = {
                 "action": "start",
                 "hvacType": 0,
+                "ignitionDuration": options.duration,
                 "options": {
                     "defrost": options.defrost,
                     "heating1": int(options.heating),


### PR DESCRIPTION
## Summary
- Fixes #1016 — duration parameter was ignored in `start_climate` for vehicles without CCS2 protocol support
- The CCS2 branch already included `"ignitionDuration": options.duration` in the payload, but the non-CCS2 branch omitted it
- This caused climate control to always run for 5 minutes (the default) regardless of the `options.duration` value

## Root Cause
In `ApiImplType1.start_climate`, the non-CCS2 payload at line 941-950 was missing the `ignitionDuration` field that the CCS2 payload at line 966-982 already included.

## Fix
Added `"ignitionDuration": options.duration` to the non-CCS2 payload, aligning it with the CCS2 branch.

## Test plan
- [x] All existing tests pass (130 tests)
- [ ] Manual verification with a non-CCS2 vehicle that custom duration is respected