### PR TITLE
feat: add set_navigation method for EU/AU/CN/IN regions

### DIFF
--- a/hyundai_kia_connect_api/ApiImpl.py
+++ b/hyundai_kia_connect_api/ApiImpl.py
@@ -84,6 +84,45 @@ class ScheduleChargingClimateRequestOptions:
     defrost: bool = None
 
 
+@dataclass
+class POICoord:
+    lat: float = None
+    lon: float = None
+    alt: int = 0
+    type: int = 0
+
+
+@dataclass
+class POIInfo:
+    phone: str = ""
+    waypoint_id: int = 1
+    lang: int = 1
+    src: str = "HERE"
+    coord: POICoord = None
+    addr: str = ""
+    zip: str = ""
+    place_id: str = ""
+    name: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "phone": self.phone,
+            "waypointID": self.waypoint_id,
+            "lang": self.lang,
+            "src": self.src,
+            "coord": {
+                "lat": self.coord.lat,
+                "alt": self.coord.alt,
+                "lon": self.coord.lon,
+                "type": self.coord.type,
+            },
+            "addr": self.addr,
+            "zip": self.zip,
+            "placeid": self.place_id,
+            "name": self.name,
+        }
+
+
 class ApiImpl:
     data_timezone = dt.timezone.utc
     temperature_range = None
@@ -354,6 +393,12 @@ class ApiImpl:
         raise NotImplementedError(
             "set_vehicle_to_load_discharge_limit is not implemented for this region"
         )
+
+    def set_navigation(
+        self, token: Token, vehicle: Vehicle, poi_list: list[POIInfo]
+    ) -> str:
+        """Send navigation destinations to the vehicle. Returns the tracking ID."""
+        raise NotImplementedError("set_navigation is not implemented for this region")
 
     def refresh_access_token(self, token: Token) -> Token | OTPRequest:
         """Refresh the token using the refresh token"""

--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -14,6 +14,7 @@ from .ApiImpl import (
     ScheduleChargingClimateRequestOptions,
     ClimateRequestOptions,
     WindowRequestOptions,
+    POIInfo,
 )
 from .Token import Token
 from .Vehicle import Vehicle
@@ -1086,6 +1087,23 @@ class ApiImplType1(ApiImpl):
             url, json=payload, headers=self._get_control_headers(token, vehicle)
         ).json()
         _LOGGER.debug(f"{DOMAIN} - Window State Action Response: {response}")
+        _check_response_for_errors(response)
+        token.device_id = self._get_device_id(self._get_stamp())
+        return response["msgId"]
+
+    def set_navigation(
+        self, token: Token, vehicle: Vehicle, poi_list: list[POIInfo]
+    ) -> str:
+        url = self.SPA_API_URL_V2 + "vehicles/" + vehicle.id + "/location/routes"
+        payload = {
+            "deviceID": token.device_id,
+            "poiInfoList": [poi.to_dict() for poi in poi_list],
+        }
+        _LOGGER.debug(f"{DOMAIN} - Set Navigation Request: {payload}")
+        response = requests.post(
+            url, json=payload, headers=self._get_control_headers(token, vehicle)
+        ).json()
+        _LOGGER.debug(f"{DOMAIN} - Set Navigation Response: {response}")
         _check_response_for_errors(response)
         token.device_id = self._get_device_id(self._get_stamp())
         return response["msgId"]

--- a/hyundai_kia_connect_api/VehicleManager.py
+++ b/hyundai_kia_connect_api/VehicleManager.py
@@ -12,6 +12,7 @@ from .ApiImpl import (
     ScheduleChargingClimateRequestOptions,
     WindowRequestOptions,
     OTPRequest,
+    POIInfo,
 )
 from .const import (
     BRAND_GENESIS,
@@ -368,6 +369,11 @@ class VehicleManager:
     def set_vehicle_to_load_discharge_limit(self, vehicle_id: str, limit: int) -> str:
         return self.api.set_vehicle_to_load_discharge_limit(
             self.token, self.get_vehicle(vehicle_id), limit
+        )
+
+    def set_navigation(self, vehicle_id: str, poi_list: list[POIInfo]) -> str:
+        return self.api.set_navigation(
+            self.token, self.get_vehicle(vehicle_id), poi_list
         )
 
     @staticmethod

--- a/hyundai_kia_connect_api/__init__.py
+++ b/hyundai_kia_connect_api/__init__.py
@@ -5,6 +5,8 @@ from .ApiImpl import (
     ClimateRequestOptions,
     WindowRequestOptions,
     ScheduleChargingClimateRequestOptions,
+    POIInfo,
+    POICoord,
 )
 
 from .Token import Token

--- a/tests/set_navigation_test.py
+++ b/tests/set_navigation_test.py
@@ -1,0 +1,264 @@
+"""Tests for set_navigation method in ApiImplType1 and POIInfo dataclass."""
+
+import datetime as dt
+from unittest.mock import MagicMock, patch
+
+from hyundai_kia_connect_api.ApiImpl import POICoord, POIInfo
+from hyundai_kia_connect_api.ApiImplType1 import ApiImplType1
+from hyundai_kia_connect_api.Token import Token
+from hyundai_kia_connect_api.Vehicle import Vehicle
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal fake for requests.Response."""
+
+    def __init__(self, json_data=None, status_code=200):
+        self.json_data = json_data
+        self.status_code = status_code
+
+    def json(self):
+        return self.json_data
+
+
+def _make_vehicle():
+    v = Vehicle(
+        id="test-vehicle-id",
+        name="Ioniq 5",
+        model="IONIQ 5",
+        key="test-key",
+        timezone=dt.timezone(dt.timedelta(hours=1)),
+    )
+    v.ccu_ccs2_protocol_support = 1
+    return v
+
+
+def _make_token():
+    t = MagicMock(spec=Token)
+    t.device_id = "test-device-id"
+    t.access_token = "Bearer test-access"
+    return t
+
+
+def _make_api():
+    """Create an ApiImplType1 without calling __init__."""
+    api = object.__new__(ApiImplType1)
+    api.SPA_API_URL_V2 = "https://prd.eu-ccapi.kia.com:8080/api/v2/spa/"
+    api._get_control_headers = MagicMock(return_value={})
+    api._get_device_id = MagicMock(return_value="new-device-id")
+    api._get_stamp = MagicMock(return_value="test-stamp")
+    return api
+
+
+# ---------------------------------------------------------------------------
+# POIInfo / POICoord dataclass tests
+# ---------------------------------------------------------------------------
+
+
+class TestPOICoord:
+    def test_defaults(self):
+        c = POICoord()
+        assert c.lat is None
+        assert c.lon is None
+        assert c.alt == 0
+        assert c.type == 0
+
+    def test_custom_values(self):
+        c = POICoord(lat=52.52, lon=13.405, alt=34, type=1)
+        assert c.lat == 52.52
+        assert c.lon == 13.405
+        assert c.alt == 34
+        assert c.type == 1
+
+
+class TestPOIInfo:
+    def test_defaults(self):
+        p = POIInfo()
+        assert p.phone == ""
+        assert p.waypoint_id == 1
+        assert p.lang == 1
+        assert p.src == "HERE"
+        assert p.coord is None
+        assert p.addr == ""
+        assert p.zip == ""
+        assert p.place_id == ""
+        assert p.name == ""
+
+    def test_to_dict_camelCase_keys(self):
+        p = POIInfo(
+            phone="+491234",
+            waypoint_id=2,
+            coord=POICoord(lat=52.52, lon=13.405, alt=34),
+            addr="Berlin, Germany",
+            zip="10115",
+            place_id="here:af:street:example",
+            name="Berlin Central Station",
+        )
+        d = p.to_dict()
+
+        assert d["phone"] == "+491234"
+        assert d["waypointID"] == 2
+        assert d["lang"] == 1
+        assert d["src"] == "HERE"
+        assert d["coord"]["lat"] == 52.52
+        assert d["coord"]["lon"] == 13.405
+        assert d["coord"]["alt"] == 34
+        assert d["coord"]["type"] == 0
+        assert d["addr"] == "Berlin, Germany"
+        assert d["zip"] == "10115"
+        assert d["placeid"] == "here:af:street:example"
+        assert d["name"] == "Berlin Central Station"
+
+    def test_to_dict_no_snake_case_keys(self):
+        """Ensure to_dict never leaks Python snake_case keys."""
+        p = POIInfo(coord=POICoord(lat=1.0, lon=2.0))
+        d = p.to_dict()
+
+        assert "waypoint_id" not in d
+        assert "place_id" not in d
+        assert "waypointID" in d
+        assert "placeid" in d
+
+    def test_to_dict_fixed_values(self):
+        """lang=1 and src='HERE' are always sent per bluelinky spec."""
+        p = POIInfo(coord=POICoord(lat=0, lon=0))
+        d = p.to_dict()
+        assert d["lang"] == 1
+        assert d["src"] == "HERE"
+
+
+# ---------------------------------------------------------------------------
+# set_navigation API method tests
+# ---------------------------------------------------------------------------
+
+
+class TestSetNavigation:
+    def test_posts_to_correct_url(self):
+        api = _make_api()
+        vehicle = _make_vehicle()
+        token = _make_token()
+        poi = POIInfo(coord=POICoord(lat=52.52, lon=13.405), name="Berlin")
+
+        mock_response = _FakeResponse(json_data={"retCode": "S", "msgId": "nav-msg-1"})
+        with patch("hyundai_kia_connect_api.ApiImplType1.requests.post") as mock_post:
+            mock_post.return_value = mock_response
+            api.set_navigation(token, vehicle, [poi])
+
+        call_url = mock_post.call_args[0][0]
+        assert "vehicles/test-vehicle-id/location/routes" in call_url
+
+    def test_sends_deviceID_in_body(self):
+        api = _make_api()
+        vehicle = _make_vehicle()
+        token = _make_token()
+        poi = POIInfo(coord=POICoord(lat=52.52, lon=13.405), name="Berlin")
+
+        mock_response = _FakeResponse(json_data={"retCode": "S", "msgId": "nav-msg-1"})
+        with patch("hyundai_kia_connect_api.ApiImplType1.requests.post") as mock_post:
+            mock_post.return_value = mock_response
+            api.set_navigation(token, vehicle, [poi])
+
+        call_payload = mock_post.call_args[1]["json"]
+        assert call_payload["deviceID"] == "test-device-id"
+
+    def test_sends_poiInfoList_in_body(self):
+        api = _make_api()
+        vehicle = _make_vehicle()
+        token = _make_token()
+        poi = POIInfo(coord=POICoord(lat=52.52, lon=13.405), name="Berlin")
+
+        mock_response = _FakeResponse(json_data={"retCode": "S", "msgId": "nav-msg-1"})
+        with patch("hyundai_kia_connect_api.ApiImplType1.requests.post") as mock_post:
+            mock_post.return_value = mock_response
+            api.set_navigation(token, vehicle, [poi])
+
+        call_payload = mock_post.call_args[1]["json"]
+        assert len(call_payload["poiInfoList"]) == 1
+        assert call_payload["poiInfoList"][0]["name"] == "Berlin"
+
+    def test_returns_msgId(self):
+        api = _make_api()
+        vehicle = _make_vehicle()
+        token = _make_token()
+        poi = POIInfo(coord=POICoord(lat=52.52, lon=13.405))
+
+        mock_response = _FakeResponse(json_data={"retCode": "S", "msgId": "nav-msg-42"})
+        with patch("hyundai_kia_connect_api.ApiImplType1.requests.post") as mock_post:
+            mock_post.return_value = mock_response
+            result = api.set_navigation(token, vehicle, [poi])
+
+        assert result == "nav-msg-42"
+
+    def test_multiple_pois(self):
+        api = _make_api()
+        vehicle = _make_vehicle()
+        token = _make_token()
+        pois = [
+            POIInfo(
+                waypoint_id=1, coord=POICoord(lat=52.52, lon=13.405), name="Berlin"
+            ),
+            POIInfo(waypoint_id=2, coord=POICoord(lat=48.85, lon=2.35), name="Paris"),
+        ]
+
+        mock_response = _FakeResponse(
+            json_data={"retCode": "S", "msgId": "nav-msg-multi"}
+        )
+        with patch("hyundai_kia_connect_api.ApiImplType1.requests.post") as mock_post:
+            mock_post.return_value = mock_response
+            api.set_navigation(token, vehicle, pois)
+
+        call_payload = mock_post.call_args[1]["json"]
+        assert len(call_payload["poiInfoList"]) == 2
+        assert call_payload["poiInfoList"][0]["waypointID"] == 1
+        assert call_payload["poiInfoList"][1]["waypointID"] == 2
+
+    def test_uses_control_headers(self):
+        api = _make_api()
+        vehicle = _make_vehicle()
+        token = _make_token()
+        poi = POIInfo(coord=POICoord(lat=52.52, lon=13.405))
+
+        mock_response = _FakeResponse(json_data={"retCode": "S", "msgId": "nav-msg-1"})
+        with patch("hyundai_kia_connect_api.ApiImplType1.requests.post") as mock_post:
+            mock_post.return_value = mock_response
+            api.set_navigation(token, vehicle, [poi])
+
+        api._get_control_headers.assert_called_once_with(token, vehicle)
+
+    def test_regenerates_device_id_after_call(self):
+        api = _make_api()
+        vehicle = _make_vehicle()
+        token = _make_token()
+        poi = POIInfo(coord=POICoord(lat=52.52, lon=13.405))
+
+        mock_response = _FakeResponse(json_data={"retCode": "S", "msgId": "nav-msg-1"})
+        with patch("hyundai_kia_connect_api.ApiImplType1.requests.post") as mock_post:
+            mock_post.return_value = mock_response
+            api.set_navigation(token, vehicle, [poi])
+
+        api._get_device_id.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# NotImplementedError for unsupported regions
+# ---------------------------------------------------------------------------
+
+
+class TestSetNavigationNotImplemented:
+    def test_base_api_impl_raises(self):
+        from hyundai_kia_connect_api.ApiImpl import ApiImpl
+
+        api = ApiImpl()
+        token = MagicMock(spec=Token)
+        vehicle = _make_vehicle()
+        poi = POIInfo(coord=POICoord(lat=0, lon=0))
+
+        try:
+            api.set_navigation(token, vehicle, [poi])
+            assert False, "Should have raised NotImplementedError"
+        except NotImplementedError as e:
+            assert "set_navigation" in str(e)


### PR DESCRIPTION
## Summary

Add `set_navigation` method to send POI (Point of Interest) destinations to the vehicle's built-in navigation system, matching the [bluelinky](https://github.com/Hacksore/bluelinky) TypeScript implementation.

### Changes

- **`ApiImpl.py`**: Add `POICoord` and `POIInfo` dataclasses + abstract `set_navigation` stub
  - `POIInfo.to_dict()` converts Python snake_case fields to API camelCase keys (`waypointID`, `placeid`)
  - Fixed values: `lang=1`, `src="HERE"` per bluelinky spec
- **`ApiImplType1.py`**: Implement `set_navigation` — `POST /api/v2/spa/vehicles/{id}/location/routes`
  - Covers EU (Kia), AU, CN, IN (all inherit from `ApiImplType1`)
  - Same auth pattern as `start_hazard_lights`: `_get_control_headers`, `_check_response_for_errors`, device_id regeneration
- **`VehicleManager.py`**: Add `set_navigation(vehicle_id, poi_list)` convenience method
- **`__init__.py`**: Export `POIInfo` and `POICoord` from package

### Region support

| Region | Supported? |
|--------|-----------|
| EU (Kia) | Yes (via `ApiImplType1`) |
| EU (Hyundai CCI) | **Deferred** — separate PR |
| AU | Yes (via `ApiImplType1`) |
| CN | Yes (via `ApiImplType1`) |
| IN | Yes (via `ApiImplType1`) |
| CA | No (`tods/api/` protocol) |
| USA | No |

### Endpoint

`POST /api/v2/spa/vehicles/{vehicleId}/location/routes`

Request body:
```json
{
  "deviceID": "<device-id>",
  "poiInfoList": [
    {
      "phone": "", "waypointID": 1, "lang": 1, "src": "HERE",
      "coord": {"lat": 52.52, "alt": 0, "lon": 13.405, "type": 0},
      "addr": "Berlin", "zip": "10115", "placeid": "...", "name": "Berlin Central Station"
    }
  ]
}
```

### Usage

```python
from hyundai_kia_connect_api import VehicleManager, POIInfo, POICoord

poi = POIInfo(
    coord=POICoord(lat=52.5200, lon=13.4050),
    addr="Berlin, Germany",
    zip="10115",
    name="Berlin Central Station",
    place_id="here:af:street:example",
)
vm.set_navigation(vehicle_id, [poi])
```

## Test plan

- [ ] Import check: `from hyundai_kia_connect_api import POIInfo, POICoord` works
- [ ] Dataclass: `POIInfo(...).to_dict()` produces correct camelCase keys
- [ ] NotImplementedError raised for USA/CA regions
- [ ] Live test on EU vehicle: send a single POI destination and verify it appears on the car's navigation