### PR TITLE
fix: avoid KeyError on unmapped seat heater/vent status codes

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -296,21 +296,21 @@ class ApiImplType1(ApiImpl):
 
         # TODO: status.sideMirrorHeat
 
-        vehicle.front_left_seat_status = SEAT_STATUS[
+        vehicle.front_left_seat_status = SEAT_STATUS.get(
             get_child_value(state, "Cabin.Seat.Row1.Driver.Climate.State")
-        ]
+        )
 
-        vehicle.front_right_seat_status = SEAT_STATUS[
+        vehicle.front_right_seat_status = SEAT_STATUS.get(
             get_child_value(state, "Cabin.Seat.Row1.Passenger.Climate.State")
-        ]
+        )
 
-        vehicle.rear_left_seat_status = SEAT_STATUS[
+        vehicle.rear_left_seat_status = SEAT_STATUS.get(
             get_child_value(state, "Cabin.Seat.Row2.Left.Climate.State")
-        ]
+        )
 
-        vehicle.rear_right_seat_status = SEAT_STATUS[
+        vehicle.rear_right_seat_status = SEAT_STATUS.get(
             get_child_value(state, "Cabin.Seat.Row2.Right.Climate.State")
-        ]
+        )
 
         vehicle.front_left_door_is_open = get_child_value(
             state, "Cabin.Door.Row1.Driver.Open"

--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
@@ -381,18 +381,18 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
         vehicle.side_mirror_heater_is_on = get_child_value(
             state, "vehicleStatus.sideMirrorHeat"
         )
-        vehicle.front_left_seat_status = SEAT_STATUS[
+        vehicle.front_left_seat_status = SEAT_STATUS.get(
             get_child_value(state, "vehicleStatus.seatHeaterVentState.flSeatHeatState")
-        ]
-        vehicle.front_right_seat_status = SEAT_STATUS[
+        )
+        vehicle.front_right_seat_status = SEAT_STATUS.get(
             get_child_value(state, "vehicleStatus.seatHeaterVentState.frSeatHeatState")
-        ]
-        vehicle.rear_left_seat_status = SEAT_STATUS[
+        )
+        vehicle.rear_left_seat_status = SEAT_STATUS.get(
             get_child_value(state, "vehicleStatus.seatHeaterVentState.rlSeatHeatState")
-        ]
-        vehicle.rear_right_seat_status = SEAT_STATUS[
+        )
+        vehicle.rear_right_seat_status = SEAT_STATUS.get(
             get_child_value(state, "vehicleStatus.seatHeaterVentState.rrSeatHeatState")
-        ]
+        )
         vehicle.tire_pressure_rear_left_warning_is_on = bool(
             get_child_value(
                 state, "vehicleStatus.tirePressureLamp.tirePressureWarningLampRearLeft"

--- a/hyundai_kia_connect_api/KiaUvoApiAU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiAU.py
@@ -290,18 +290,18 @@ class KiaUvoApiAU(ApiImplType1):
         vehicle.side_mirror_heater_is_on = get_child_value(
             state, "status.sideMirrorHeat"
         )
-        vehicle.front_left_seat_status = SEAT_STATUS[
+        vehicle.front_left_seat_status = SEAT_STATUS.get(
             get_child_value(state, "status.seatHeaterVentState.flSeatHeatState")
-        ]
-        vehicle.front_right_seat_status = SEAT_STATUS[
+        )
+        vehicle.front_right_seat_status = SEAT_STATUS.get(
             get_child_value(state, "status.seatHeaterVentState.frSeatHeatState")
-        ]
-        vehicle.rear_left_seat_status = SEAT_STATUS[
+        )
+        vehicle.rear_left_seat_status = SEAT_STATUS.get(
             get_child_value(state, "status.seatHeaterVentState.rlSeatHeatState")
-        ]
-        vehicle.rear_right_seat_status = SEAT_STATUS[
+        )
+        vehicle.rear_right_seat_status = SEAT_STATUS.get(
             get_child_value(state, "status.seatHeaterVentState.rrSeatHeatState")
-        ]
+        )
         vehicle.is_locked = get_child_value(state, "status.doorLock")
         vehicle.front_left_door_is_open = get_child_value(
             state, "status.doorOpen.frontLeft"

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -593,18 +593,18 @@ class KiaUvoApiCA(ApiImpl):
         vehicle.side_mirror_heater_is_on = get_child_value(
             state, "status.sideMirrorHeat"
         )
-        vehicle.front_left_seat_status = SEAT_STATUS[
+        vehicle.front_left_seat_status = SEAT_STATUS.get(
             get_child_value(state, "status.seatHeaterVentState.flSeatHeatState")
-        ]
-        vehicle.front_right_seat_status = SEAT_STATUS[
+        )
+        vehicle.front_right_seat_status = SEAT_STATUS.get(
             get_child_value(state, "status.seatHeaterVentState.frSeatHeatState")
-        ]
-        vehicle.rear_left_seat_status = SEAT_STATUS[
+        )
+        vehicle.rear_left_seat_status = SEAT_STATUS.get(
             get_child_value(state, "status.seatHeaterVentState.rlSeatHeatState")
-        ]
-        vehicle.rear_right_seat_status = SEAT_STATUS[
+        )
+        vehicle.rear_right_seat_status = SEAT_STATUS.get(
             get_child_value(state, "status.seatHeaterVentState.rrSeatHeatState")
-        ]
+        )
         # Additional status fields observed in logs (exposed as binary sensors)
         vehicle.accessory_on = get_child_value(state, "status.acc")
         vehicle.ign3 = get_child_value(state, "status.ign3")

--- a/hyundai_kia_connect_api/KiaUvoApiCN.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCN.py
@@ -356,18 +356,18 @@ class KiaUvoApiCN(ApiImplType1):
         vehicle.side_mirror_heater_is_on = get_child_value(
             state, "status.sideMirrorHeat"
         )
-        vehicle.front_left_seat_status = SEAT_STATUS[
+        vehicle.front_left_seat_status = SEAT_STATUS.get(
             get_child_value(state, "status.seatHeaterVentState.flSeatHeatState")
-        ]
-        vehicle.front_right_seat_status = SEAT_STATUS[
+        )
+        vehicle.front_right_seat_status = SEAT_STATUS.get(
             get_child_value(state, "status.seatHeaterVentState.frSeatHeatState")
-        ]
-        vehicle.rear_left_seat_status = SEAT_STATUS[
+        )
+        vehicle.rear_left_seat_status = SEAT_STATUS.get(
             get_child_value(state, "status.seatHeaterVentState.rlSeatHeatState")
-        ]
-        vehicle.rear_right_seat_status = SEAT_STATUS[
+        )
+        vehicle.rear_right_seat_status = SEAT_STATUS.get(
             get_child_value(state, "status.seatHeaterVentState.rrSeatHeatState")
-        ]
+        )
         vehicle.is_locked = get_child_value(state, "status.doorLock")
         vehicle.front_left_door_is_open = get_child_value(
             state, "status.doorOpen.frontLeft"

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -506,18 +506,18 @@ class KiaUvoApiEU(ApiImplType1):
         vehicle.side_mirror_heater_is_on = get_child_value(
             state, "vehicleStatus.sideMirrorHeat"
         )
-        vehicle.front_left_seat_status = SEAT_STATUS[
+        vehicle.front_left_seat_status = SEAT_STATUS.get(
             get_child_value(state, "vehicleStatus.seatHeaterVentState.flSeatHeatState")
-        ]
-        vehicle.front_right_seat_status = SEAT_STATUS[
+        )
+        vehicle.front_right_seat_status = SEAT_STATUS.get(
             get_child_value(state, "vehicleStatus.seatHeaterVentState.frSeatHeatState")
-        ]
-        vehicle.rear_left_seat_status = SEAT_STATUS[
+        )
+        vehicle.rear_left_seat_status = SEAT_STATUS.get(
             get_child_value(state, "vehicleStatus.seatHeaterVentState.rlSeatHeatState")
-        ]
-        vehicle.rear_right_seat_status = SEAT_STATUS[
+        )
+        vehicle.rear_right_seat_status = SEAT_STATUS.get(
             get_child_value(state, "vehicleStatus.seatHeaterVentState.rrSeatHeatState")
-        ]
+        )
         # lamp wire status (nested)
         vehicle.headlamp_status = get_child_value(
             state, "vehicleStatus.lampWireStatus.headLamp.headLampStatus"

--- a/hyundai_kia_connect_api/KiaUvoApiIN.py
+++ b/hyundai_kia_connect_api/KiaUvoApiIN.py
@@ -328,18 +328,18 @@ class KiaUvoApiIN(ApiImplType1):
             vehicle.steering_wheel_heater_is_on = True
 
         vehicle.back_window_heater_is_on = get_child_value(state, "sideBackWindowHeat")
-        vehicle.front_left_seat_status = SEAT_STATUS[
+        vehicle.front_left_seat_status = SEAT_STATUS.get(
             get_child_value(state, "seatHeaterVentState.astSeatHeatState")
-        ]
-        vehicle.front_right_seat_status = SEAT_STATUS[
+        )
+        vehicle.front_right_seat_status = SEAT_STATUS.get(
             get_child_value(state, "seatHeaterVentState.drvSeatHeatState")
-        ]
-        vehicle.rear_left_seat_status = SEAT_STATUS[
+        )
+        vehicle.rear_left_seat_status = SEAT_STATUS.get(
             get_child_value(state, "seatHeaterVentState.rlSeatHeatState")
-        ]
-        vehicle.rear_right_seat_status = SEAT_STATUS[
+        )
+        vehicle.rear_right_seat_status = SEAT_STATUS.get(
             get_child_value(state, "seatHeaterVentState.rrSeatHeatState")
-        ]
+        )
         vehicle.is_locked = get_child_value(state, "doorLock")
         vehicle.front_left_door_is_open = get_child_value(state, "doorOpen.frontLeft")
         vehicle.front_right_door_is_open = get_child_value(state, "doorOpen.frontRight")

--- a/tests/test_seat_status_unknown.py
+++ b/tests/test_seat_status_unknown.py
@@ -1,0 +1,34 @@
+"""Regression test: unmapped seat heater/vent codes must not crash parsing.
+
+Some vehicles (e.g. Genesis G80 EU) report ``seatHeaterVentState`` codes that
+are not present in ``const.SEAT_STATUS`` (observed: 15). The seat status lookup
+must degrade to ``None`` instead of raising ``KeyError`` and aborting the whole
+vehicle update (which leaves every entity unavailable).
+"""
+
+from hyundai_kia_connect_api.KiaUvoApiEU import KiaUvoApiEU
+from hyundai_kia_connect_api.Vehicle import Vehicle
+
+from tests.fixture_helpers import load_fixture
+
+
+def _eu_api() -> KiaUvoApiEU:
+    api = KiaUvoApiEU.__new__(KiaUvoApiEU)
+    api.data_timezone = KiaUvoApiEU.data_timezone
+    api.temperature_range = KiaUvoApiEU.temperature_range
+    return api
+
+
+def test_unknown_seat_status_code_does_not_raise():
+    data = load_fixture("eu_kia_ev6_2023_with_soc.json")
+    # Unmapped code reported by some vehicles (e.g. Genesis G80 EU -> 15)
+    data["vehicleStatus"]["seatHeaterVentState"]["rlSeatHeatState"] = 15
+
+    vehicle = Vehicle()
+    # Must not raise KeyError on the unmapped code.
+    _eu_api()._update_vehicle_properties(vehicle, data)
+
+    # Unknown code degrades to None ...
+    assert vehicle.rear_left_seat_status is None
+    # ... while known codes still map correctly (fixture has 0 -> "Off").
+    assert vehicle.front_left_seat_status == "Off"


### PR DESCRIPTION
## Problem

`vehicle.*_seat_status` is assigned via `SEAT_STATUS[code]`. When a vehicle
reports a seat heater/vent code that is not present in `SEAT_STATUS` (only
`0`–`8` + `None` are mapped), this raises `KeyError` and aborts the entire
`_update_vehicle_properties` run — leaving **every** entity unavailable in
Home Assistant.

Observed with a Genesis G80 Electrified (EU), which reports `rlSeatHeatState`
(and `rrSeatHeatState`) = `15`:

```
File ".../hyundai_kia_connect_api/KiaUvoApiEU.py", line 515, in _update_vehicle_properties
    vehicle.rear_left_seat_status = SEAT_STATUS[
        get_child_value(state, "vehicleStatus.seatHeaterVentState.rlSeatHeatState")
    ]
KeyError: 15
```

## Fix

Switch the seat status lookups from `SEAT_STATUS[code]` to
`SEAT_STATUS.get(code)`, so an unknown code degrades to `None` instead of
raising. This matches what `HyundaiBlueLinkApiBR` already does.

Applied consistently across all backends that used the hard lookup: EU, USA,
CA, AU, IN, CN and the shared `ApiImplType1` base (CCS2). `None` is the natural
degraded value — `Vehicle` already declares the four `*_seat_status` fields
with `None` defaults, and `SEAT_STATUS[None]` was already `None`.

## Tests

Adds a focused regression test that feeds an unmapped seat code (`15`) through
the EU parser and asserts it degrades to `None` while a known code still maps
correctly. The test fails on `master` with `KeyError` and passes with this fix.

Full suite: `177 passed`.
