### PR TITLE
fix: correct last_updated_at time being one hour off in summer

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -5,7 +5,6 @@ import requests
 import logging
 import math
 from typing import Optional
-from datetime import timedelta, timezone
 
 from time import sleep
 
@@ -238,15 +237,14 @@ class ApiImplType1(ApiImpl):
         }
 
     def _update_vehicle_properties_ccs2(self, vehicle: Vehicle, state: dict) -> None:
-        if get_child_value(state, "Offset"):
-            offset = float(get_child_value(state, "Offset"))
-            hours = int(offset)
-            minutes = int((offset - hours) * 60)
-            vehicle.timezone = timezone(timedelta(hours=hours, minutes=minutes))
         if get_child_value(state, "Date"):
+            # CCS2 'Date' is always in UTC, convert to the region timezone.
+            # Always use a named timezone to ensure DST adjustment.
+            # In EU, CCS2 'Offset' is always 1 (CET), but CEST is UTC+0100.
+            # In AU, CCS2 'Offset' is 10 (AEST), but AEDT is UTC+1100.
             vehicle.last_updated_at = parse_datetime(
-                get_child_value(state, "Date"), vehicle.timezone
-            )
+                get_child_value(state, "Date"), dt.timezone.utc
+            ).astimezone(self.data_timezone)
         else:
             vehicle.last_updated_at = dt.datetime.now(self.data_timezone)
 


### PR DESCRIPTION
The last_updated_at times for Kona EU (CCS2) were off by one in summer. A previous fix for AU (#770) broke summer time transitions.

API response for Mon, 25 May 2026 01:17:34 +0200 (CEST):

    "lastUpdateTime": "1779664654458",
    "state": {
      "Vehicle": {
        "Date": "20260524231733.000",
        "Offset": "1",
    }

API response for Sat, 21 Mar 2026 17:02:07 +0100 (CET):

    "lastUpdateTime": "1774108927875",
    "state": {
      "Vehicle": {
        "Date": "20260321160206.000",
        "Offset": "1",
    }

Fixes #1096