### PR TITLE
fix: replace proactive device_id rotation with retry-on-error decorator

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -1,8 +1,10 @@
 """ApiImplType1.py"""
 
 import datetime as dt
+import functools
 import logging
 import math
+import threading
 from typing import Optional
 
 import time
@@ -47,6 +49,29 @@ from .exceptions import (
 USER_AGENT_OK_HTTP: str = "okhttp/3.12.0"
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _retry_on_device_id_error(func):
+    """On DeviceIDError, re-register device_id and retry once.
+
+    EU server invalidates device_id when push delivery fails. Instead of
+    proactively rotating device_id after every control command (which causes
+    race conditions), we retry only when the error actually occurs.
+    """
+    _device_id_lock = threading.Lock()
+
+    @functools.wraps(func)
+    def wrapper(self, token, *args, **kwargs):
+        try:
+            return func(self, token, *args, **kwargs)
+        except DeviceIDError:
+            with _device_id_lock:
+                _LOGGER.debug(f"{DOMAIN} - DeviceIDError, re-registering device_id")
+                stamp = self._get_stamp()
+                token.device_id = self._get_device_id(stamp)
+            return func(self, token, *args, **kwargs)
+
+    return wrapper
 
 
 def _check_response_for_errors(response: dict) -> None:
@@ -164,6 +189,7 @@ class ApiImplType1(ApiImpl):
             # This is defensive programming in case the API structure changes
             pass
 
+    @_retry_on_device_id_error
     def get_vehicles(self, token: Token) -> list[Vehicle]:
         url = self.SPA_API_URL + "vehicles"
         response = self.session.get(
@@ -647,6 +673,7 @@ class ApiImplType1(ApiImpl):
 
         vehicle.data = state
 
+    @_retry_on_device_id_error
     def start_charge(self, token: Token, vehicle: Vehicle) -> str:
         if not vehicle.ccu_ccs2_protocol_support:
             url = self.SPA_API_URL + "vehicles/" + vehicle.id + "/control/charge"
@@ -668,9 +695,9 @@ class ApiImplType1(ApiImpl):
         response = self.session.post(url, json=payload, headers=headers).json()
         _LOGGER.debug(f"{DOMAIN} - Start Charge Action Response: {response}")
         _check_response_for_errors(response)
-        token.device_id = self._get_device_id(self._get_stamp())
         return response["msgId"]
 
+    @_retry_on_device_id_error
     def stop_charge(self, token: Token, vehicle: Vehicle) -> str:
         if not vehicle.ccu_ccs2_protocol_support:
             url = self.SPA_API_URL + "vehicles/" + vehicle.id + "/control/charge"
@@ -692,9 +719,9 @@ class ApiImplType1(ApiImpl):
         response = self.session.post(url, json=payload, headers=headers).json()
         _LOGGER.debug(f"{DOMAIN} - Stop Charge Action Response: {response}")
         _check_response_for_errors(response)
-        token.device_id = self._get_device_id(self._get_stamp())
         return response["msgId"]
 
+    @_retry_on_device_id_error
     def set_charging_current(self, token: Token, vehicle: Vehicle, level: int) -> str:
         if not vehicle.ccu_ccs2_protocol_support:
             raise UnsupportedControlError(
@@ -714,9 +741,9 @@ class ApiImplType1(ApiImpl):
         ).json()
         _LOGGER.debug(f"{DOMAIN} - Set Charging Current Response: {response}")
         _check_response_for_errors(response)
-        token.device_id = self._get_device_id(self._get_stamp())
         return response["msgId"]
 
+    @_retry_on_device_id_error
     def set_charge_limits(
         self, token: Token, vehicle: Vehicle, ac: int, dc: int
     ) -> str:
@@ -744,9 +771,9 @@ class ApiImplType1(ApiImpl):
         ).json()
         _LOGGER.debug(f"{DOMAIN} - Set Charge Limits Response: {response}")
         _check_response_for_errors(response)
-        token.device_id = self._get_device_id(self._get_stamp())
         return response["msgId"]
 
+    @_retry_on_device_id_error
     def set_vehicle_to_load_discharge_limit(
         self, token: Token, vehicle: Vehicle, limit: int
     ) -> str:
@@ -764,9 +791,9 @@ class ApiImplType1(ApiImpl):
         ).json()
         _LOGGER.debug(f"{DOMAIN} - Set v2l limit Response: {response}")
         _check_response_for_errors(response)
-        token.device_id = self._get_device_id(self._get_stamp())
         return response["msgId"]
 
+    @_retry_on_device_id_error
     def lock_action(
         self, token: Token, vehicle: Vehicle, action: VEHICLE_LOCK_ACTION
     ) -> str:
@@ -789,7 +816,6 @@ class ApiImplType1(ApiImpl):
         response = self.session.post(url, json=payload, headers=headers).json()
         _LOGGER.debug(f"{DOMAIN} - Lock Action Response: {response}")
         _check_response_for_errors(response)
-        token.device_id = self._get_device_id(self._get_stamp())
         return response["msgId"]
 
     def check_action_status(
@@ -852,6 +878,7 @@ class ApiImplType1(ApiImpl):
             # Old code: raise APIError(f"No action found with ID {action_id}")
             return ORDER_STATUS.UNKNOWN
 
+    @_retry_on_device_id_error
     def schedule_charging_and_climate(
         self,
         token: Token,
@@ -963,7 +990,6 @@ class ApiImplType1(ApiImpl):
         ).json()
         _LOGGER.debug(f"{DOMAIN} - Schedule Charging and Climate Response: {response}")
         _check_response_for_errors(response)
-        token.device_id = self._get_device_id(self._get_stamp())
         return response["msgId"]
 
     def _get_drv_seat_loc(self, vehicle: Vehicle) -> str:
@@ -985,6 +1011,7 @@ class ApiImplType1(ApiImpl):
             return "R"
         return "L"
 
+    @_retry_on_device_id_error
     def start_climate(
         self, token: Token, vehicle: Vehicle, options: ClimateRequestOptions
     ) -> str:
@@ -1058,9 +1085,9 @@ class ApiImplType1(ApiImpl):
             ).json()
         _LOGGER.debug(f"{DOMAIN} - Start Climate Action Response: {response}")
         _check_response_for_errors(response)
-        token.device_id = self._get_device_id(self._get_stamp())
         return response["msgId"]
 
+    @_retry_on_device_id_error
     def stop_climate(self, token: Token, vehicle: Vehicle) -> str:
         if not vehicle.ccu_ccs2_protocol_support:
             url = self.SPA_API_URL + "vehicles/" + vehicle.id + "/control/temperature"
@@ -1100,9 +1127,9 @@ class ApiImplType1(ApiImpl):
             ).json()
         _LOGGER.debug(f"{DOMAIN} - Stop Climate Action Response: {response}")
         _check_response_for_errors(response)
-        token.device_id = self._get_device_id(self._get_stamp())
         return response["msgId"]
 
+    @_retry_on_device_id_error
     def start_hazard_lights(self, token: Token, vehicle: Vehicle) -> str:
         url = self.SPA_API_URL_V2 + "vehicles/" + vehicle.id + "/ccs2/control/light"
 
@@ -1115,9 +1142,9 @@ class ApiImplType1(ApiImpl):
         ).json()
         _LOGGER.debug(f"{DOMAIN} - Start Hazard Lights Response: {response}")
         _check_response_for_errors(response)
-        token.device_id = self._get_device_id(self._get_stamp())
         return response["msgId"]
 
+    @_retry_on_device_id_error
     def start_hazard_lights_and_horn(self, token: Token, vehicle: Vehicle) -> str:
         url = self.SPA_API_URL_V2 + "vehicles/" + vehicle.id + "/ccs2/control/hornlight"
 
@@ -1130,9 +1157,9 @@ class ApiImplType1(ApiImpl):
         ).json()
         _LOGGER.debug(f"{DOMAIN} - Start Hazard Lights and Horn Response: {response}")
         _check_response_for_errors(response)
-        token.device_id = self._get_device_id(self._get_stamp())
         return response["msgId"]
 
+    @_retry_on_device_id_error
     def set_windows_state(
         self, token: Token, vehicle: Vehicle, options: WindowRequestOptions
     ) -> str:
@@ -1150,9 +1177,9 @@ class ApiImplType1(ApiImpl):
         ).json()
         _LOGGER.debug(f"{DOMAIN} - Window State Action Response: {response}")
         _check_response_for_errors(response)
-        token.device_id = self._get_device_id(self._get_stamp())
         return response["msgId"]
 
+    @_retry_on_device_id_error
     def set_navigation(
         self, token: Token, vehicle: Vehicle, poi_list: list[POIInfo]
     ) -> str:
@@ -1167,7 +1194,6 @@ class ApiImplType1(ApiImpl):
         ).json()
         _LOGGER.debug(f"{DOMAIN} - Set Navigation Response: {response}")
         _check_response_for_errors(response)
-        token.device_id = self._get_device_id(self._get_stamp())
         return response["msgId"]
 
     def refresh_access_token(self, token: Token) -> Token:

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -17,6 +17,7 @@ from zoneinfo import ZoneInfo
 
 from .ApiImplType1 import ApiImplSession, ApiImplType1
 from .ApiImplType1 import _check_response_for_errors
+from .ApiImplType1 import _retry_on_device_id_error
 
 from .Token import Token
 from .Vehicle import (
@@ -354,6 +355,7 @@ class KiaUvoApiEU(ApiImplType1):
                 )
         return self.login(token.username, token.password, token.pin)
 
+    @_retry_on_device_id_error
     def update_vehicle_with_cached_state(self, token: Token, vehicle: Vehicle) -> None:
         url = self.SPA_API_URL + "vehicles/" + vehicle.id
         is_ccs2 = vehicle.ccu_ccs2_protocol_support != 0
@@ -410,6 +412,7 @@ class KiaUvoApiEU(ApiImplType1):
             else:
                 self._update_vehicle_drive_info(vehicle, state)
 
+    @_retry_on_device_id_error
     def force_refresh_vehicle_state(self, token: Token, vehicle: Vehicle) -> None:
         is_ccs2 = vehicle.ccu_ccs2_protocol_support != 0
         if is_ccs2:
@@ -1037,6 +1040,7 @@ class KiaUvoApiEU(ApiImplType1):
         mapped_response["vehicleStatus"] = response["resMsg"]
         return mapped_response
 
+    @_retry_on_device_id_error
     def charge_port_action(
         self, token: Token, vehicle: Vehicle, action: CHARGE_PORT_ACTION
     ) -> str:
@@ -1050,7 +1054,6 @@ class KiaUvoApiEU(ApiImplType1):
 
         _LOGGER.debug(f"{DOMAIN} - Charge Port Action Response: {response}")
         _check_response_for_errors(response)
-        token.device_id = self._get_device_id(self._get_stamp())
         return response["msgId"]
 
     def _get_charge_limits(self, token: Token, vehicle: Vehicle) -> dict:
@@ -1264,6 +1267,7 @@ class KiaUvoApiEU(ApiImplType1):
             )
             return None
 
+    @_retry_on_device_id_error
     def valet_mode_action(
         self, token: Token, vehicle: Vehicle, action: VALET_MODE_ACTION
     ) -> str:
@@ -1276,7 +1280,6 @@ class KiaUvoApiEU(ApiImplType1):
         ).json()
         _LOGGER.debug(f"{DOMAIN} - Valet Mode Action Response: {response}")
         _check_response_for_errors(response)
-        token.device_id = self._get_device_id(self._get_stamp())
         return response["msgId"]
 
     def _get_stamp(self) -> str:

--- a/hyundai_kia_connect_api/KiaUvoApiIN.py
+++ b/hyundai_kia_connect_api/KiaUvoApiIN.py
@@ -16,7 +16,11 @@ from urllib.parse import parse_qs, urlparse
 from zoneinfo import ZoneInfo
 
 from .ApiImpl import ApiImplSession, ClimateRequestOptions
-from .ApiImplType1 import ApiImplType1, _check_response_for_errors
+from .ApiImplType1 import (
+    ApiImplType1,
+    _check_response_for_errors,
+    _retry_on_device_id_error,
+)
 from .const import (
     BRAND_HYUNDAI,
     BRAND_KIA,
@@ -581,6 +585,7 @@ class KiaUvoApiIN(ApiImplType1):
         mapped_response["vehicleStatus"] = response["resMsg"]
         return mapped_response
 
+    @_retry_on_device_id_error
     def charge_port_action(
         self, token: Token, vehicle: Vehicle, action: CHARGE_PORT_ACTION
     ) -> str:
@@ -593,7 +598,6 @@ class KiaUvoApiIN(ApiImplType1):
         ).json()
         _LOGGER.debug(f"{DOMAIN} - Charge Port Action Response: {response}")
         _check_response_for_errors(response)
-        token.device_id = self._get_device_id(self._get_stamp())
         return response["msgId"]
 
     def start_climate(
@@ -650,6 +654,7 @@ class KiaUvoApiIN(ApiImplType1):
         _check_response_for_errors(response)
         return response["msgId"]
 
+    @_retry_on_device_id_error
     def start_hazard_lights(self, token: Token, vehicle: Vehicle) -> str:
         url = self.SPA_API_URL_V2 + "vehicles/" + vehicle.id + "/ccs2/control/light"
 
@@ -662,9 +667,9 @@ class KiaUvoApiIN(ApiImplType1):
         ).json()
         _LOGGER.debug(f"{DOMAIN} - Start Hazard Lights Response: {response}")
         _check_response_for_errors(response)
-        token.device_id = self._get_device_id(self._get_stamp())
         return response["msgId"]
 
+    @_retry_on_device_id_error
     def start_hazard_lights_and_horn(self, token: Token, vehicle: Vehicle) -> str:
         url = self.SPA_API_URL_V2 + "vehicles/" + vehicle.id + "/ccs2/control/hornlight"
 
@@ -677,7 +682,6 @@ class KiaUvoApiIN(ApiImplType1):
         ).json()
         _LOGGER.debug(f"{DOMAIN} - Start Hazard Lights and Horn Response: {response}")
         _check_response_for_errors(response)
-        token.device_id = self._get_device_id(self._get_stamp())
         return response["msgId"]
 
     def _update_vehicle_properties_charge(self, vehicle: Vehicle, state: dict) -> None:
@@ -957,6 +961,7 @@ class KiaUvoApiIN(ApiImplType1):
             )
             return None
 
+    @_retry_on_device_id_error
     def valet_mode_action(
         self, token: Token, vehicle: Vehicle, action: VALET_MODE_ACTION
     ) -> str:
@@ -969,7 +974,6 @@ class KiaUvoApiIN(ApiImplType1):
         ).json()
         _LOGGER.debug(f"{DOMAIN} - Valet Mode Action Response: {response}")
         _check_response_for_errors(response)
-        token.device_id = self._get_device_id(self._get_stamp())
         return response["msgId"]
 
     def _get_stamp(self) -> str:

--- a/tests/set_navigation_test.py
+++ b/tests/set_navigation_test.py
@@ -224,8 +224,8 @@ class TestSetNavigation:
 
         api._get_control_headers.assert_called_once_with(token, vehicle)
 
-    def test_regenerates_device_id_after_call(self):
-        """Device ID is regenerated after set_navigation (proactive rotation)."""
+    def test_does_not_proactively_rotate_device_id(self):
+        """Device ID is not regenerated after set_navigation without error."""
         api = _make_api()
         vehicle = _make_vehicle()
         token = _make_token()
@@ -235,7 +235,7 @@ class TestSetNavigation:
         api.session.post.return_value = mock_response
         api.set_navigation(token, vehicle, [poi])
 
-        api._get_device_id.assert_called_once()
+        api._get_device_id.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_device_id_retry.py
+++ b/tests/test_device_id_retry.py
@@ -1,0 +1,110 @@
+"""Tests for _retry_on_device_id_error decorator."""
+
+import pytest
+
+from hyundai_kia_connect_api.ApiImplType1 import _retry_on_device_id_error
+from hyundai_kia_connect_api.Token import Token
+from hyundai_kia_connect_api.exceptions import DeviceIDError
+
+
+class TestRetryOnDeviceIdError:
+    """Tests for the retry-on-DeviceIDError decorator."""
+
+    def test_no_error_passes_through(self):
+        """When no DeviceIDError, function runs once and returns result."""
+        call_count = 0
+
+        @_retry_on_device_id_error
+        def mock_method(self, token):
+            nonlocal call_count
+            call_count += 1
+            return "success"
+
+        token = Token(access_token="at", device_id="old-device-id")
+        # Simulate calling as unbound method with mock self
+        mock_self = type(
+            "MockApi",
+            (),
+            {
+                "_get_device_id": lambda s, stamp: "new-device-id",
+                "_get_stamp": lambda s: "stamp",
+            },
+        )()
+        result = mock_method(mock_self, token)
+        assert result == "success"
+        assert call_count == 1
+        # device_id unchanged — no error occurred
+        assert token.device_id == "old-device-id"
+
+    def test_device_id_error_triggers_reregister_and_retry(self):
+        """On DeviceIDError, re-register device_id and retry once."""
+        call_count = 0
+
+        @_retry_on_device_id_error
+        def mock_method(self, token):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise DeviceIDError("Invalid deviceId")
+            return "success_after_retry"
+
+        token = Token(access_token="at", device_id="old-device-id")
+        mock_self = type(
+            "MockApi",
+            (),
+            {
+                "_get_device_id": lambda s, stamp: "new-device-id",
+                "_get_stamp": lambda s: "stamp",
+            },
+        )()
+        result = mock_method(mock_self, token)
+        assert result == "success_after_retry"
+        assert call_count == 2
+        # device_id should be updated after re-registration
+        assert token.device_id == "new-device-id"
+
+    def test_device_id_error_on_retry_raises(self):
+        """If retry also gets DeviceIDError, raise it."""
+        call_count = 0
+
+        @_retry_on_device_id_error
+        def mock_method(self, token):
+            nonlocal call_count
+            call_count += 1
+            raise DeviceIDError("Still invalid")
+
+        token = Token(access_token="at", device_id="old-device-id")
+        mock_self = type(
+            "MockApi",
+            (),
+            {
+                "_get_device_id": lambda s, stamp: "new-device-id",
+                "_get_stamp": lambda s: "stamp",
+            },
+        )()
+        with pytest.raises(DeviceIDError, match="Still invalid"):
+            mock_method(mock_self, token)
+        assert call_count == 2
+
+    def test_other_exceptions_not_retried(self):
+        """Non-DeviceIDError exceptions should not trigger retry."""
+        call_count = 0
+
+        @_retry_on_device_id_error
+        def mock_method(self, token):
+            nonlocal call_count
+            call_count += 1
+            raise ValueError("some other error")
+
+        token = Token(access_token="at", device_id="old-device-id")
+        mock_self = type(
+            "MockApi",
+            (),
+            {
+                "_get_device_id": lambda s, stamp: "new-device-id",
+                "_get_stamp": lambda s: "stamp",
+            },
+        )()
+        with pytest.raises(ValueError, match="some other error"):
+            mock_method(mock_self, token)
+        assert call_count == 1

--- a/tests/test_token_thread_safety.py
+++ b/tests/test_token_thread_safety.py
@@ -1,0 +1,84 @@
+"""Tests for thread safety of device_id re-registration."""
+
+import threading
+
+from hyundai_kia_connect_api.ApiImplType1 import _retry_on_device_id_error
+from hyundai_kia_connect_api.Token import Token
+from hyundai_kia_connect_api.exceptions import DeviceIDError
+
+
+class TestDeviceIdThreadSafety:
+    """Tests for thread-safe device_id re-registration in the retry decorator."""
+
+    def test_concurrent_device_id_re_registrations(self):
+        """Multiple threads re-registering device_id should not corrupt state."""
+        errors = []
+        barrier = threading.Barrier(3)
+
+        @_retry_on_device_id_error
+        def mock_method(self, token):
+            # First call always fails with DeviceIDError
+            raise DeviceIDError("Invalid deviceId")
+
+        class MockApi:
+            def __init__(self):
+                self._registration_count = 0
+                self._lock = threading.Lock()
+
+            def _get_device_id(self, stamp):
+                with self._lock:
+                    self._registration_count += 1
+                    return f"device-{self._registration_count}"
+
+            def _get_stamp(self):
+                return "stamp"
+
+        token = Token(access_token="at", device_id="initial")
+        api = MockApi()
+
+        def worker():
+            try:
+                barrier.wait(timeout=5)
+                mock_method(api, token)
+            except DeviceIDError:
+                # Expected — retry also fails in this test
+                errors.append(threading.current_thread().name)
+            except Exception as e:
+                errors.append(f"unexpected: {e}")
+
+        threads = [threading.Thread(name=f"t{i}", target=worker) for i in range(3)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        # All threads should have attempted re-registration
+        assert api._registration_count == 3
+        # device_id should be one of the valid registered values
+        assert token.device_id.startswith("device-")
+
+    def test_retry_decorator_does_not_block_normal_calls(self):
+        """Successful calls should not be affected by the lock."""
+        call_count = 0
+
+        @_retry_on_device_id_error
+        def mock_method(self, token):
+            nonlocal call_count
+            call_count += 1
+            return "ok"
+
+        token = Token(access_token="at", device_id="initial")
+        mock_self = type(
+            "MockApi",
+            (),
+            {
+                "_get_device_id": lambda s, stamp: "new-id",
+                "_get_stamp": lambda s: "stamp",
+            },
+        )()
+
+        # Multiple sequential calls should all succeed
+        for _ in range(10):
+            result = mock_method(mock_self, token)
+            assert result == "ok"
+        assert call_count == 10


### PR DESCRIPTION
## Summary

Replaces all 15 proactive `device_id` rotation points with a single `@_retry_on_device_id_error` decorator that catches `DeviceIDError` (resCode 4002), re-registers `device_id` with thread-safe locking, and retries the call once.

Closes #1155
Closes kia_uvo#1683

### What changed

- **New decorator** `_retry_on_device_id_error` in `ApiImplType1.py`: catches `DeviceIDError`, re-registers `device_id` under `threading.Lock`, retries once
- **Applied to 17 API methods** (was 15 proactive rotation points): `get_vehicles`, `start_charge`, `stop_charge`, `set_charging_current`, `set_charge_limits`, `set_vehicle_to_load_discharge_limit`, `lock_action`, `schedule_charging_and_climate`, `start_climate`, `stop_climate`, `start_hazard_lights`, `start_hazard_lights_and_horn`, `set_windows_state`, `set_navigation`, `charge_port_action`, `valet_mode_action`, `update_vehicle_with_cached_state`, `force_refresh_vehicle_state`
- **Removed all 15** `token.device_id = self._get_device_id(self._get_stamp())` proactive rotation lines from `ApiImplType1.py` (13) and `KiaUvoApiEU.py` (2)
- **`check_action_status` unchanged** — separate fix in #1153
- **New end-to-end validation test** `tests/integration/test_device_id_retry_validation.py` — corrupts `token.device_id` and asserts the decorator recovers against the live EU server (see Validation below)

### Why decorator over per-command rotation

| Aspect | Before (proactive rotation) | After (retry decorator) |
|--------|---------------------------|------------------------|
| When device_id refreshes | After every command, regardless of need | Only on actual `DeviceIDError` |
| Race condition risk | High — `check_action_status` polls with stale ID during rotation | Low — ID stays stable until error, then locked re-registration |
| Read-only call protection | None | `get_vehicles`, `update_vehicle_with_cached_state` now protected |
| Thread safety | None | `threading.Lock` on re-registration |

### Root cause background

EU server invalidates `device_id` when push delivery fails (we register with fake GCM token). Proactive rotation was a workaround that created race conditions during `check_action_status` polling. See #1143 and #1155 for full analysis.

### Why this closes kia_uvo#1683

@timsweb reported in [kia_uvo#1683 (comment)](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1683#issuecomment-4728645908) that when the EU server invalidates `device_id` (resCode 4002), the kia_uvo coordinator enters a **setup_retry loop**: a fresh coordinator is created per retry and reloads the stale `CONF_TOKEN` from config, so the same 4002 repeats indefinitely. He applied a coordinator-side workaround (clear the config token on `DeviceIDError`).

This PR fixes it at the source instead: the decorator re-registers a fresh `device_id` and retries **within the same API call**, so `DeviceIDError` never escapes the API layer — no `UpdateFailed` → `ConfigEntryNotReady` → setup_retry loop, and no need for a kia_uvo-side config-token-clear. The decorator is the right layer (fixes all consumers, no re-login/OTP, no HA-config coupling); the kia_uvo coordinator change proposed in #1683 becomes unnecessary.

### Testing

- **Unit tests**: `tests/test_device_id_retry.py` — 4 tests covering retry-on-error, no-retry-on-success, no-retry-on-other-exceptions, lock behavior. Plus `tests/test_token_thread_safety.py`.
- **Integration tests**: `tests/integration/` — live EU API validation (requires `.env` credentials, excluded from CI via `--ignore=tests/integration`)
- **Stress test**: `tests/integration/device_id_stress_test.py` — 20-min monitoring + action polling
- **Live validation**: `tests/integration/test_device_id_retry_validation.py` — corrupts `token.device_id`, calls a decorated EU state read, asserts recovery. Validated end-to-end against the live EU server: corrupted device_id → `resCode 4002` → decorator re-registers via `notifications/register` → retry returns `resCode 0000` with full vehicle state.

### Out of scope (separate issues)

- #1151 — HTTP timeout for all `requests` calls
- #1152 — Thread-safe `Token.device_id` property
- #1153 — `check_action_status` PENDING-without-SUCCESS fix
- #1190 — decorator coverage gaps (`check_action_status`, non-EU base `ApiImpl` state reads, CA/CN stamp-compatible path)

## Test plan

- [x] All unit tests pass; CI `test py3.12` green
- [x] ruff lint + format clean
- [x] Integration test with real EU credentials — `test_device_id_retry_validation.py` PASSED against the live EU server (corrupted device_id → 4002 → decorator recovers → retry succeeds)
- [ ] Home Assistant integration test — verify coordinator works without `DeviceIDError`