### PR TITLE
fix: preserve last known unit when API returns None (unit-only)

### DIFF
--- a/hyundai_kia_connect_api/Vehicle.py
+++ b/hyundai_kia_connect_api/Vehicle.py
@@ -392,8 +392,9 @@ class Vehicle:
     @total_driving_range.setter
     def total_driving_range(self, value):
         self._total_driving_range_value = value[0]
-        self._total_driving_range_unit = value[1]
         self._total_driving_range = value[0]
+        if value[1] is not None:
+            self._total_driving_range_unit = value[1]
 
     @property
     def next_service_distance(self):
@@ -402,8 +403,9 @@ class Vehicle:
     @next_service_distance.setter
     def next_service_distance(self, value):
         self._next_service_distance_value = value[0]
-        self._next_service_distance_unit = value[1]
         self._next_service_distance = value[0]
+        if value[1] is not None:
+            self._next_service_distance_unit = value[1]
 
     @property
     def last_service_distance(self):
@@ -412,8 +414,9 @@ class Vehicle:
     @last_service_distance.setter
     def last_service_distance(self, value):
         self._last_service_distance_value = value[0]
-        self._last_service_distance_unit = value[1]
         self._last_service_distance = value[0]
+        if value[1] is not None:
+            self._last_service_distance_unit = value[1]
 
     @property
     def last_updated_at(self):
@@ -487,8 +490,9 @@ class Vehicle:
     def odometer(self, value):
         float_value = get_float(value[0])
         self._odometer_value = float_value
-        self._odometer_unit = value[1]
         self._odometer = float_value
+        if value[1] is not None:
+            self._odometer_unit = value[1]
 
     @property
     def outside_temperature(self):
@@ -497,8 +501,9 @@ class Vehicle:
     @outside_temperature.setter
     def outside_temperature(self, value):
         self._outside_temperature_value = value[0]
-        self._outside_temperature_unit = value[1]
         self._outside_temperature = value[0]
+        if value[1] is not None:
+            self._outside_temperature_unit = value[1]
 
     @property
     def air_temperature(self):
@@ -507,8 +512,9 @@ class Vehicle:
     @air_temperature.setter
     def air_temperature(self, value):
         self._air_temperature_value = value[0]
-        self._air_temperature_unit = value[1]
         self._air_temperature = value[0] if value[0] != "OFF" else None
+        if value[1] is not None:
+            self._air_temperature_unit = value[1]
 
     @property
     def ev_battery_water_temperature(self):
@@ -521,8 +527,9 @@ class Vehicle:
     @ev_battery_water_temperature.setter
     def ev_battery_water_temperature(self, value):
         self._ev_battery_water_temperature_value = value[0]
-        self._ev_battery_water_temperature_unit = value[1]
         self._ev_battery_water_temperature = value[0]
+        if value[1] is not None:
+            self._ev_battery_water_temperature_unit = value[1]
 
     @property
     def ev_battery_temperature_min(self):
@@ -535,8 +542,9 @@ class Vehicle:
     @ev_battery_temperature_min.setter
     def ev_battery_temperature_min(self, value):
         self._ev_battery_temperature_min_value = value[0]
-        self._ev_battery_temperature_min_unit = value[1]
         self._ev_battery_temperature_min = value[0]
+        if value[1] is not None:
+            self._ev_battery_temperature_min_unit = value[1]
 
     @property
     def ev_battery_temperature_max(self):
@@ -549,8 +557,9 @@ class Vehicle:
     @ev_battery_temperature_max.setter
     def ev_battery_temperature_max(self, value):
         self._ev_battery_temperature_max_value = value[0]
-        self._ev_battery_temperature_max_unit = value[1]
         self._ev_battery_temperature_max = value[0]
+        if value[1] is not None:
+            self._ev_battery_temperature_max_unit = value[1]
 
     @property
     def ev_driving_range(self):
@@ -563,8 +572,9 @@ class Vehicle:
     @ev_driving_range.setter
     def ev_driving_range(self, value):
         self._ev_driving_range_value = value[0]
-        self._ev_driving_range_unit = value[1]
         self._ev_driving_range = value[0]
+        if value[1] is not None:
+            self._ev_driving_range_unit = value[1]
 
     @property
     def ev_estimated_current_charge_duration(self):
@@ -573,8 +583,9 @@ class Vehicle:
     @ev_estimated_current_charge_duration.setter
     def ev_estimated_current_charge_duration(self, value):
         self._ev_estimated_current_charge_duration_value = value[0]
-        self._ev_estimated_current_charge_duration_unit = value[1]
         self._ev_estimated_current_charge_duration = value[0]
+        if value[1] is not None:
+            self._ev_estimated_current_charge_duration_unit = value[1]
 
     @property
     def ev_estimated_fast_charge_duration(self):
@@ -583,8 +594,9 @@ class Vehicle:
     @ev_estimated_fast_charge_duration.setter
     def ev_estimated_fast_charge_duration(self, value):
         self._ev_estimated_fast_charge_duration_value = value[0]
-        self._ev_estimated_fast_charge_duration_unit = value[1]
         self._ev_estimated_fast_charge_duration = value[0]
+        if value[1] is not None:
+            self._ev_estimated_fast_charge_duration_unit = value[1]
 
     @property
     def ev_estimated_portable_charge_duration(self):
@@ -593,8 +605,9 @@ class Vehicle:
     @ev_estimated_portable_charge_duration.setter
     def ev_estimated_portable_charge_duration(self, value):
         self._ev_estimated_portable_charge_duration_value = value[0]
-        self._ev_estimated_portable_charge_duration_unit = value[1]
         self._ev_estimated_portable_charge_duration = value[0]
+        if value[1] is not None:
+            self._ev_estimated_portable_charge_duration_unit = value[1]
 
     @property
     def ev_estimated_station_charge_duration(self):
@@ -603,8 +616,9 @@ class Vehicle:
     @ev_estimated_station_charge_duration.setter
     def ev_estimated_station_charge_duration(self, value):
         self._ev_estimated_station_charge_duration_value = value[0]
-        self._ev_estimated_station_charge_duration_unit = value[1]
         self._ev_estimated_station_charge_duration = value[0]
+        if value[1] is not None:
+            self._ev_estimated_station_charge_duration_unit = value[1]
 
     @property
     def ev_target_range_charge_AC(self):
@@ -617,8 +631,9 @@ class Vehicle:
     @ev_target_range_charge_AC.setter
     def ev_target_range_charge_AC(self, value):
         self._ev_target_range_charge_AC_value = value[0]
-        self._ev_target_range_charge_AC_unit = value[1]
         self._ev_target_range_charge_AC = value[0]
+        if value[1] is not None:
+            self._ev_target_range_charge_AC_unit = value[1]
 
     @property
     def ev_target_range_charge_DC(self):
@@ -631,8 +646,9 @@ class Vehicle:
     @ev_target_range_charge_DC.setter
     def ev_target_range_charge_DC(self, value):
         self._ev_target_range_charge_DC_value = value[0]
-        self._ev_target_range_charge_DC_unit = value[1]
         self._ev_target_range_charge_DC = value[0]
+        if value[1] is not None:
+            self._ev_target_range_charge_DC_unit = value[1]
 
     @property
     def ev_first_departure_climate_temperature(self):
@@ -645,8 +661,9 @@ class Vehicle:
     @ev_first_departure_climate_temperature.setter
     def ev_first_departure_climate_temperature(self, value):
         self._ev_first_departure_climate_temperature_value = value[0]
-        self._ev_first_departure_climate_temperature_unit = value[1]
         self._ev_first_departure_climate_temperature = value[0]
+        if value[1] is not None:
+            self._ev_first_departure_climate_temperature_unit = value[1]
 
     @property
     def ev_second_departure_climate_temperature(self):
@@ -659,8 +676,9 @@ class Vehicle:
     @ev_second_departure_climate_temperature.setter
     def ev_second_departure_climate_temperature(self, value):
         self._ev_second_departure_climate_temperature_value = value[0]
-        self._ev_second_departure_climate_temperature_unit = value[1]
         self._ev_second_departure_climate_temperature = value[0]
+        if value[1] is not None:
+            self._ev_second_departure_climate_temperature_unit = value[1]
 
     @property
     def fuel_driving_range(self):
@@ -669,5 +687,6 @@ class Vehicle:
     @fuel_driving_range.setter
     def fuel_driving_range(self, value):
         self._fuel_driving_range_value = value[0]
-        self._fuel_driving_range_unit = value[1]
         self._fuel_driving_range = value[0]
+        if value[1] is not None:
+            self._fuel_driving_range_unit = value[1]

--- a/tests/test_vehicle_unit_preservation.py
+++ b/tests/test_vehicle_unit_preservation.py
@@ -1,0 +1,84 @@
+"""Tests for Vehicle (value, unit) setter unit preservation.
+
+When the API returns a value but no unit (unit is None), the setter must keep
+the last known unit instead of overwriting it with None. Overwriting with None
+causes Home Assistant unit flip-flop ("km" -> "" -> "km") and the recorder
+error "unit (None) cannot be converted to previously compiled statistics (km)"
+(see kia_uvo#1725, kia_uvo#1430).
+
+The value itself is NOT preserved: if the API returns None for a value, that
+is reflected (the data is genuinely unavailable). Only the unit is held, per
+the maintainer's request in API#1161 ("only unit should hold").
+"""
+
+import pytest
+
+from hyundai_kia_connect_api.Vehicle import Vehicle
+
+
+@pytest.fixture
+def vehicle():
+    return Vehicle()
+
+
+class TestUnitPreservation:
+    """Each (value, unit) setter must preserve the last known unit on None."""
+
+    @pytest.mark.parametrize(
+        "attr",
+        [
+            "total_driving_range",
+            "next_service_distance",
+            "last_service_distance",
+            "odometer",
+            "outside_temperature",
+            "air_temperature",
+            "ev_battery_water_temperature",
+            "ev_battery_temperature_min",
+            "ev_battery_temperature_max",
+            "ev_driving_range",
+            "ev_estimated_current_charge_duration",
+            "ev_estimated_fast_charge_duration",
+            "ev_estimated_portable_charge_duration",
+            "ev_estimated_station_charge_duration",
+            "ev_target_range_charge_AC",
+            "ev_target_range_charge_DC",
+            "ev_first_departure_climate_temperature",
+            "ev_second_departure_climate_temperature",
+            "fuel_driving_range",
+        ],
+    )
+    def test_unit_preserved_when_api_returns_none_unit(self, vehicle, attr):
+        # First write sets both value and unit.
+        setattr(vehicle, attr, (100, "km"))
+        assert getattr(vehicle, attr) == 100
+        assert getattr(vehicle, "_" + attr + "_unit") == "km"
+
+        # API returns a fresh value but no unit -> unit must stay "km".
+        setattr(vehicle, attr, (95, None))
+        assert getattr(vehicle, attr) == 95
+        assert getattr(vehicle, "_" + attr + "_unit") == "km"
+
+    @pytest.mark.parametrize(
+        "attr",
+        [
+            "total_driving_range",
+            "odometer",
+            "ev_driving_range",
+            "fuel_driving_range",
+        ],
+    )
+    def test_unit_updates_when_api_returns_new_unit(self, vehicle, attr):
+        setattr(vehicle, attr, (100, "km"))
+        assert getattr(vehicle, "_" + attr + "_unit") == "km"
+
+        setattr(vehicle, attr, (50, "mi"))
+        assert getattr(vehicle, attr) == 50
+        assert getattr(vehicle, "_" + attr + "_unit") == "mi"
+
+    def test_value_reflects_none_when_api_returns_none_value(self, vehicle):
+        # Only the unit is held; a None value is reflected, not preserved.
+        vehicle.total_driving_range = (100, "km")
+        vehicle.total_driving_range = (None, "km")
+        assert vehicle.total_driving_range is None
+        assert vehicle.total_driving_range_unit == "km"


### PR DESCRIPTION
## Summary

Vehicle `(value, unit)` setters now keep the last known **unit** when the API returns `None` for the unit, instead of overwriting it. Prevents the Home Assistant unit flip-flop (`km` → `""` → `km`) and the recorder error:

```
The unit of sensor.X_total_driving_range (None) cannot be converted to the unit
of previously compiled statistics (km). Generation of long term statistics will
be suppressed...
```

Reported in kia_uvo#1430 and kia_uvo#1725 (the latter has a real recorder log).

## Scope — unit only (per review)

The value itself is **not** preserved: if the API returns `None` for a value, that is reflected as-is (the data is genuinely unavailable). Only the unit is held. This is the scope cdnninja asked for in the earlier round of this PR: *"only unit should hold."*

## Why reopen (I closed this too hastily before)

When I closed this PR earlier I wrote that the flip-flop "may have been a symptom of #1124 rather than a separate issue." That was wrong. kia_uvo#1725 is a CA / Hyundai Ioniq6 (Type1) vehicle — #1124 only touches CCS2 force-refresh, so it cannot have fixed this. The recorder log in #1725 is the unit→`None` flip happening on a non-CCS2 vehicle, ~once a month. That's the evidence I was missing when I agreed to close.

Applied to all 19 `(value, unit)` setters: `total_driving_range`, `next_service_distance`, `last_service_distance`, `odometer`, `outside_temperature`, `air_temperature`, `ev_battery_water_temperature`, `ev_battery_temperature_min/max`, `ev_driving_range`, `ev_estimated_*_charge_duration` (4), `ev_target_range_charge_AC/DC`, `ev_first/second_departure_climate_temperature`, `fuel_driving_range`.

## Test plan

- [x] `tests/test_vehicle_unit_preservation.py` — unit preserved when API returns `None` unit (all 19 setters), unit updates when API returns a new unit, value reflects `None` when API returns `None` value
- [x] `pytest tests/ -q` — 216 passed
- [x] `pre-commit` clean
