### PR TITLE
feat: Add fields for high and bifunc headlamp status and add light status readout to new dataformat handler

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -312,6 +312,40 @@ class ApiImplType1(ApiImpl):
             get_child_value(state, "Cabin.Seat.Row2.Right.Climate.State")
         )
 
+        vehicle.headlamp_status = get_child_value(
+            state, "Body.Lights.Front.HeadLamp.SystemWarning"
+        )
+        vehicle.headlamp_left_low = get_child_value(
+            state, "Body.Lights.Front.Left.Low.Warning"
+        )
+        vehicle.headlamp_right_low = get_child_value(
+            state, "Body.Lights.Front.Right.Low.Warning"
+        )
+        vehicle.headlamp_left_high = get_child_value(
+            state, "Body.Lights.Front.Left.High.Warning"
+        )
+        vehicle.headlamp_right_high = get_child_value(
+            state, "Body.Lights.Front.Right.High.Warning"
+        )
+        vehicle.stop_lamp_left = get_child_value(
+            state, "Body.Lights.Rear.Left.StopLamp.Warning"
+        )
+        vehicle.stop_lamp_right = get_child_value(
+            state, "Body.Lights.Rear.Right.StopLamp.Warning"
+        )
+        vehicle.turn_signal_left_front = get_child_value(
+            state, "Body.Lights.Front.Left.TurnSignal.Warning"
+        )
+        vehicle.turn_signal_right_front = get_child_value(
+            state, "Body.Lights.Front.Right.TurnSignal.Warning"
+        )
+        vehicle.turn_signal_left_rear = get_child_value(
+            state, "Body.Lights.Rear.Left.TurnSignal.Warning"
+        )
+        vehicle.turn_signal_right_rear = get_child_value(
+            state, "Body.Lights.Rear.Right.TurnSignal.Warning"
+        )
+
         vehicle.front_left_door_is_open = get_child_value(
             state, "Cabin.Door.Row1.Driver.Open"
         )

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -622,6 +622,18 @@ class KiaUvoApiCA(ApiImpl):
         vehicle.headlamp_right_low = get_child_value(
             state, "status.lampWireStatus.headLamp.rightLowLamp"
         )
+        vehicle.headlamp_left_high = get_child_value(
+            state, "status.lampWireStatus.headLamp.leftHighLamp"
+        )
+        vehicle.headlamp_right_high = get_child_value(
+            state, "status.lampWireStatus.headLamp.rightHighLamp"
+        )
+        vehicle.headlamp_left_bifunc = get_child_value(
+            state, "status.lampWireStatus.headLamp.leftBifuncLamp"
+        )
+        vehicle.headlamp_right_bifunc = get_child_value(
+            state, "status.lampWireStatus.headLamp.rightBifuncLamp"
+        )
         vehicle.stop_lamp_left = get_child_value(
             state, "status.lampWireStatus.stopLamp.leftLamp"
         )

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -528,6 +528,18 @@ class KiaUvoApiEU(ApiImplType1):
         vehicle.headlamp_right_low = get_child_value(
             state, "vehicleStatus.lampWireStatus.headLamp.rightLowLamp"
         )
+        vehicle.headlamp_left_high = get_child_value(
+            state, "vehicleStatus.lampWireStatus.headLamp.leftHighLamp"
+        )
+        vehicle.headlamp_right_high = get_child_value(
+            state, "vehicleStatus.lampWireStatus.headLamp.rightHighLamp"
+        )
+        vehicle.headlamp_left_bifunc = get_child_value(
+            state, "vehicleStatus.lampWireStatus.headLamp.leftBifuncLamp"
+        )
+        vehicle.headlamp_right_bifunc = get_child_value(
+            state, "vehicleStatus.lampWireStatus.headLamp.rightBifuncLamp"
+        )
         vehicle.stop_lamp_left = get_child_value(
             state, "vehicleStatus.lampWireStatus.stopLamp.leftLamp"
         )

--- a/hyundai_kia_connect_api/KiaUvoApiIN.py
+++ b/hyundai_kia_connect_api/KiaUvoApiIN.py
@@ -398,6 +398,18 @@ class KiaUvoApiIN(ApiImplType1):
         vehicle.headlamp_right_low = bool(
             get_child_value(state, "lampWireStatus.headLamp.rightLowLamp")
         )
+        vehicle.headlamp_left_high = bool(
+            get_child_value(state, "lampWireStatus.headLamp.leftHighLamp")
+        )
+        vehicle.headlamp_right_high = bool(
+            get_child_value(state, "lampWireStatus.headLamp.rightHighLamp")
+        )
+        vehicle.headlamp_left_bifunc = bool(
+            get_child_value(state, "lampWireStatus.headLamp.leftBifuncLamp")
+        )
+        vehicle.headlamp_right_bifunc = bool(
+            get_child_value(state, "lampWireStatus.headLamp.rightBifuncLamp")
+        )
         vehicle.stop_lamp_left = bool(
             get_child_value(state, "lampWireStatus.stopLamp.leftLamp")
         )

--- a/hyundai_kia_connect_api/Vehicle.py
+++ b/hyundai_kia_connect_api/Vehicle.py
@@ -204,6 +204,10 @@ class Vehicle:
     headlamp_status: str = None
     headlamp_left_low: bool = None
     headlamp_right_low: bool = None
+    headlamp_left_high: bool = None
+    headlamp_right_high: bool = None
+    headlamp_left_bifunc: bool = None
+    headlamp_right_bifunc: bool = None
     stop_lamp_left: bool = None
     stop_lamp_right: bool = None
     turn_signal_left_front: bool = None


### PR DESCRIPTION
Hello,

I noticed that my MY 2023 Hyundai IONIQ 5 was reporting also the status of the high and bifunc headlamps which were not yet implemented in this API. In addition I noticed that my father's MY 2025 Hyundai IONIQ 5 which uses the new dataformat did not show any lamp status although the information were present in the reported data.
This PR adds both functionalities by introducing additional fields for the information that were not yet covered. I introduced them into all regional APIs that already had the low headlamp status although I could only verify the presence of the datafields for the EU version. Maybe someone from one of these other regions can verify that these fields also exist there.

Best regards,
Triple-S