### PR TITLE
fix: raise UnsupportedControlError for set_charging_current on non-CCS2 vehicles

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -657,6 +657,10 @@ class ApiImplType1(ApiImpl):
         return response["msgId"]
 
     def set_charging_current(self, token: Token, vehicle: Vehicle, level: int) -> str:
+        if not vehicle.ccu_ccs2_protocol_support:
+            raise UnsupportedControlError(
+                "set_charging_current requires CCS2 protocol support"
+            )
         url = (
             self.SPA_API_URL + "vehicles/" + vehicle.id + "/ccs2/charge/chargingcurrent"
         )


### PR DESCRIPTION
## Summary

Vehicles without CCS2 protocol support (`ccu_ccs2_protocol_support=0`) silently accept the `/ccs2/charge/chargingcurrent` API call but ignore the command — the API returns `{'retCode': 'S', 'resCode': '0000'}` (success) while the car does nothing.

This adds a guard at the start of `set_charging_current` that raises `UnsupportedControlError` when `vehicle.ccu_ccs2_protocol_support` is falsy. In kia_uvo (with PR #1635), this produces a clear "Vehicle does not support this action" message instead of appearing to succeed.

The pattern matches existing CCS2 guards in `start_charge`, `stop_charge`, `set_lock`, `start_climate`, and `stop_climate` — all of which branch between `/control/` and `/ccs2/` endpoints based on this flag. Since `set_charging_current` has no non-CCS2 fallback endpoint, the correct behavior is to reject the call entirely.

Fixes #1693

## Test plan

- [ ] Call `set_charging_current` on a vehicle with `ccu_ccs2_protocol_support=0` → should raise `UnsupportedControlError`
- [ ] Call `set_charging_current` on a vehicle with `ccu_ccs2_protocol_support=1` → should work as before
- [ ] Existing tests pass (`pytest tests/`)