### PR TITLE
feat(CA): add Cloudflare __cf_bm cookie for bot management bypass

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -137,6 +137,8 @@ class KiaUvoApiCA(ApiImpl):
             "client_secret": "CLISCR01AHSPA",
         }
         self._sessions = None
+        self._cloudflare_cookie: str = ""
+        self._cloudflare_cookie_fetched_at: dt.datetime | None = None
 
     def _get_device_id(self) -> str:
         """Generate a deterministic device ID based on MAC address and hostname.
@@ -145,6 +147,32 @@ class KiaUvoApiCA(ApiImpl):
             uuid.NAMESPACE_DNS, f"{uuid.getnode():x}-{platform.node() or ''}"
         )
         return base64.b64encode(device_uuid.hex.encode()).decode()
+
+    def _get_cloudflare_cookie(self) -> str:
+        """Fetch Cloudflare __cf_bm cookie from the login page.
+
+        The Canadian API is behind Cloudflare bot management.
+        Fetching the __cf_bm cookie from the login page allows
+        subsequent requests to pass Cloudflare validation.
+        """
+        try:
+            url = f"https://{self.BASE_URL}/login"
+            response = requests.get(url, timeout=10)
+            for cookie_name, cookie_value in response.cookies.items():
+                if cookie_name.lower() == "__cf_bm":
+                    self._cloudflare_cookie = f"__cf_bm={cookie_value}"
+                    self._cloudflare_cookie_fetched_at = dt.datetime.now(
+                        dt.timezone.utc
+                    )
+                    _LOGGER.debug(f"{DOMAIN} - Got Cloudflare __cf_bm cookie")
+                    return self._cloudflare_cookie
+            _LOGGER.debug(f"{DOMAIN} - No __cf_bm cookie in response")
+            self._cloudflare_cookie = ""
+            return ""
+        except Exception as e:
+            _LOGGER.debug(f"{DOMAIN} - Failed to fetch Cloudflare cookie: {e}")
+            self._cloudflare_cookie = ""
+            return ""
 
     def get_implementation_by_region_brand(self, region, brand, language):
         return KiaUvoApiCA(region, brand, language)

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -174,6 +174,24 @@ class KiaUvoApiCA(ApiImpl):
             self._cloudflare_cookie = ""
             return ""
 
+    def _ensure_cloudflare_cookie(self) -> str:
+        """Return the Cloudflare cookie, refreshing if expired or older than 25 min."""
+        if self._cloudflare_cookie and self._cloudflare_cookie_fetched_at:
+            age = (
+                dt.datetime.now(dt.timezone.utc) - self._cloudflare_cookie_fetched_at
+            ).total_seconds()
+            if age < 1500:  # 25 minutes
+                return self._cloudflare_cookie
+        # Cookie missing or stale — fetch fresh
+        return self._get_cloudflare_cookie()
+
+    def _add_cloudflare_cookie(self, headers: dict) -> dict:
+        """Add Cloudflare cookie to request headers if available."""
+        cf_cookie = self._ensure_cloudflare_cookie()
+        if cf_cookie:
+            headers["Cookie"] = cf_cookie
+        return headers
+
     def get_implementation_by_region_brand(self, region, brand, language):
         return KiaUvoApiCA(region, brand, language)
 

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -192,6 +192,27 @@ class KiaUvoApiCA(ApiImpl):
             headers["Cookie"] = cf_cookie
         return headers
 
+    def _is_cloudflare_block(self, response) -> bool:
+        """Check if response is a Cloudflare block page."""
+        if response.status_code == 403:
+            content_type = response.headers.get("Content-Type", "")
+            if "text/html" in content_type or "cloudflare" in response.text.lower():
+                return True
+        return False
+
+    def _post_with_cloudflare_retry(self, url, **kwargs):
+        """POST with automatic Cloudflare cookie refresh on 403."""
+        response = self.sessions.post(url, **kwargs)
+        if self._is_cloudflare_block(response):
+            _LOGGER.debug(
+                f"{DOMAIN} - Cloudflare block detected, refreshing cookie and retrying"
+            )
+            self._get_cloudflare_cookie()
+            if "headers" in kwargs and self._cloudflare_cookie:
+                kwargs["headers"]["Cookie"] = self._cloudflare_cookie
+            response = self.sessions.post(url, **kwargs)
+        return response
+
     def get_implementation_by_region_brand(self, region, brand, language):
         return KiaUvoApiCA(region, brand, language)
 
@@ -260,7 +281,7 @@ class KiaUvoApiCA(ApiImpl):
 
         self._add_cloudflare_cookie(headers)
         headers["Deviceid"] = device_id
-        response = self.sessions.post(url, json=data, headers=headers)
+        response = self._post_with_cloudflare_retry(url, json=data, headers=headers)
         response_json = response.json()
 
         # Check if OTP is required (error code 7110)
@@ -278,7 +299,7 @@ class KiaUvoApiCA(ApiImpl):
             self._add_cloudflare_cookie(selverifmeth_headers)
             selverifmeth_data = {"mfaApiCode": "0107", "userAccount": username}
 
-            selverifmeth_response = self.sessions.post(
+            selverifmeth_response = self._post_with_cloudflare_retry(
                 selverifmeth_url, json=selverifmeth_data, headers=selverifmeth_headers
             )
             _LOGGER.debug(
@@ -355,7 +376,7 @@ class KiaUvoApiCA(ApiImpl):
         else:  # Should never happen due to enum, but just in case
             raise ValueError("Invalid notify type")
 
-        response = self.sessions.post(url, headers=headers, json=data)
+        response = self._post_with_cloudflare_retry(url, headers=headers, json=data)
         _LOGGER.debug(f"{DOMAIN} - Send OTP Response {response.text}")
         response_json = response.json()
 
@@ -388,7 +409,7 @@ class KiaUvoApiCA(ApiImpl):
             "mfaApiCode": "0107",
         }
 
-        response = self.sessions.post(url, headers=headers, json=data)
+        response = self._post_with_cloudflare_retry(url, headers=headers, json=data)
         _LOGGER.debug(f"{DOMAIN} - Verify OTP Response {response.text}")
         response_json = response.json()
 
@@ -416,7 +437,7 @@ class KiaUvoApiCA(ApiImpl):
             "mfaYn": "Y",
         }
 
-        genmfatkn_response = self.sessions.post(
+        genmfatkn_response = self._post_with_cloudflare_retry(
             genmfatkn_url, json=genmfatkn_data, headers=genmfatkn_headers
         )
         genmfatkn_json = genmfatkn_response.json()
@@ -452,7 +473,7 @@ class KiaUvoApiCA(ApiImpl):
         headers = self.API_HEADERS.copy()
         headers["accessToken"] = token.access_token
         self._add_cloudflare_cookie(headers)
-        response = self.sessions.post(url, headers=headers)
+        response = self._post_with_cloudflare_retry(url, headers=headers)
         _LOGGER.debug(f"{DOMAIN} - Test Token Response {response.text}")
         response = response.json()
         token_errors = ["7403", "7602"]
@@ -468,7 +489,7 @@ class KiaUvoApiCA(ApiImpl):
         headers = self.API_HEADERS.copy()
         headers["accessToken"] = token.access_token
         self._add_cloudflare_cookie(headers)
-        response = self.sessions.post(url, headers=headers)
+        response = self._post_with_cloudflare_retry(url, headers=headers)
         _LOGGER.debug(f"{DOMAIN} - Get Vehicles Response {response.text}")
         response = response.json()
 
@@ -845,7 +866,7 @@ class KiaUvoApiCA(ApiImpl):
         headers["vehicleId"] = vehicle.id
         self._add_cloudflare_cookie(headers)
 
-        response = self.sessions.post(url, headers=headers)
+        response = self._post_with_cloudflare_retry(url, headers=headers)
         if response.ok:
             response = response.json()
             _LOGGER.debug(
@@ -892,7 +913,7 @@ class KiaUvoApiCA(ApiImpl):
         headers["vehicleId"] = vehicle.id
         self._add_cloudflare_cookie(headers)
 
-        response = self.sessions.post(url, headers=headers)
+        response = self._post_with_cloudflare_retry(url, headers=headers)
         response = response.json()
         _LOGGER.debug(f"{DOMAIN} - get_cached_vehicle_status response {response}")
 
@@ -913,7 +934,7 @@ class KiaUvoApiCA(ApiImpl):
         headers["vehicleId"] = vehicle.id
         self._add_cloudflare_cookie(headers)
 
-        response = self.sessions.post(url, headers=headers)
+        response = self._post_with_cloudflare_retry(url, headers=headers)
         response = response.json()
 
         _LOGGER.debug(f"{DOMAIN} - Received forced vehicle data {response}")
@@ -933,7 +954,7 @@ class KiaUvoApiCA(ApiImpl):
         headers["vehicleId"] = vehicle.id
         self._add_cloudflare_cookie(headers)
         url = self.API_URL + "nxtsvc"
-        response = self.sessions.post(url, headers=headers)
+        response = self._post_with_cloudflare_retry(url, headers=headers)
         response = response.json()
         _LOGGER.debug(f"{DOMAIN} - Get Service status data {response}")
 
@@ -953,7 +974,9 @@ class KiaUvoApiCA(ApiImpl):
         self._add_cloudflare_cookie(headers)
         try:
             headers["pAuth"] = self._get_pin_token(token, vehicle)
-            response = self.sessions.post(url, headers=headers, json={"pin": token.pin})
+            response = self._post_with_cloudflare_retry(
+                url, headers=headers, json={"pin": token.pin}
+            )
             response = response.json()
             _LOGGER.debug(f"{DOMAIN} - Get Vehicle Location {response}")
             if response["responseHeader"]["responseCode"] != 0:
@@ -969,7 +992,9 @@ class KiaUvoApiCA(ApiImpl):
         headers["accessToken"] = token.access_token
         headers["vehicleId"] = vehicle.id
         self._add_cloudflare_cookie(headers)
-        response = self.sessions.post(url, headers=headers, json={"pin": token.pin})
+        response = self._post_with_cloudflare_retry(
+            url, headers=headers, json={"pin": token.pin}
+        )
         _LOGGER.debug(f"{DOMAIN} - Received Pin validation response {response.json()}")
         result = response.json()["result"]
         return result["pAuth"]
@@ -988,7 +1013,7 @@ class KiaUvoApiCA(ApiImpl):
         headers["pAuth"] = self._get_pin_token(token, vehicle)
         self._add_cloudflare_cookie(headers)
 
-        response = self.sessions.post(
+        response = self._post_with_cloudflare_retry(
             url, headers=headers, data=json.dumps({"pin": token.pin})
         )
         response_headers = response.headers
@@ -1127,7 +1152,9 @@ class KiaUvoApiCA(ApiImpl):
             f"{DOMAIN} - Planned start_climate payload {self._mask_sensitive_data(payload)}"
         )
 
-        response = self.sessions.post(url, headers=headers, data=json.dumps(payload))
+        response = self._post_with_cloudflare_retry(
+            url, headers=headers, data=json.dumps(payload)
+        )
         response_headers = response.headers
         response = response.json()
 
@@ -1145,7 +1172,7 @@ class KiaUvoApiCA(ApiImpl):
         headers["pAuth"] = self._get_pin_token(token, vehicle)
         self._add_cloudflare_cookie(headers)
 
-        response = self.sessions.post(
+        response = self._post_with_cloudflare_retry(
             url, headers=headers, data=json.dumps({"pin": token.pin})
         )
         response_headers = response.headers
@@ -1173,7 +1200,7 @@ class KiaUvoApiCA(ApiImpl):
         headers["transactionId"] = action_id
         headers["pAuth"] = self._get_pin_token(token, vehicle)
         self._add_cloudflare_cookie(headers)
-        response = self.sessions.post(url, headers=headers)
+        response = self._post_with_cloudflare_retry(url, headers=headers)
         response = response.json()
 
         last_action_completed = (
@@ -1212,7 +1239,7 @@ class KiaUvoApiCA(ApiImpl):
         _LOGGER.debug(
             f"{DOMAIN} - Planned start_charge payload {self._mask_sensitive_data(data)}"
         )
-        response = self.sessions.post(
+        response = self._post_with_cloudflare_retry(
             url, headers=headers, data=json.dumps({"pin": token.pin})
         )
         response_headers = response.headers
@@ -1229,7 +1256,7 @@ class KiaUvoApiCA(ApiImpl):
         headers["pAuth"] = self._get_pin_token(token, vehicle)
         self._add_cloudflare_cookie(headers)
 
-        response = self.sessions.post(
+        response = self._post_with_cloudflare_retry(
             url, headers=headers, data=json.dumps({"pin": token.pin})
         )
         response_headers = response.headers
@@ -1258,7 +1285,7 @@ class KiaUvoApiCA(ApiImpl):
         headers["vehicleId"] = vehicle.id
         self._add_cloudflare_cookie(headers)
 
-        response = self.sessions.post(url, headers=headers)
+        response = self._post_with_cloudflare_retry(url, headers=headers)
         response = response.json()
         _LOGGER.debug(f"{DOMAIN} - Received get_charge_limits: {response}")
 
@@ -1298,7 +1325,9 @@ class KiaUvoApiCA(ApiImpl):
         _LOGGER.debug(
             f"{DOMAIN} - Planned set_charge_limits payload {self._mask_sensitive_data(payload)}"
         )
-        response = self.sessions.post(url, headers=headers, data=json.dumps(payload))
+        response = self._post_with_cloudflare_retry(
+            url, headers=headers, data=json.dumps(payload)
+        )
         response_headers = response.headers
         response = response.json()
         _LOGGER.debug(f"{DOMAIN} - Received set_charge_limits response {response}")

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -240,6 +240,11 @@ class KiaUvoApiCA(ApiImpl):
         device_id = self._get_device_id()
         _LOGGER.debug(f"{DOMAIN} - Using deterministic device ID")
 
+        # Fetch Cloudflare cookie before login
+        cf_cookie = self._get_cloudflare_cookie()
+        if cf_cookie:
+            headers["Cookie"] = cf_cookie
+
         headers["Deviceid"] = device_id
         response = self.sessions.post(url, json=data, headers=headers)
         response_json = response.json()

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -258,11 +258,7 @@ class KiaUvoApiCA(ApiImpl):
         device_id = self._get_device_id()
         _LOGGER.debug(f"{DOMAIN} - Using deterministic device ID")
 
-        # Fetch Cloudflare cookie before login
-        cf_cookie = self._get_cloudflare_cookie()
-        if cf_cookie:
-            headers["Cookie"] = cf_cookie
-
+        self._add_cloudflare_cookie(headers)
         headers["Deviceid"] = device_id
         response = self.sessions.post(url, json=data, headers=headers)
         response_json = response.json()
@@ -279,6 +275,7 @@ class KiaUvoApiCA(ApiImpl):
             selverifmeth_headers = self.API_HEADERS.copy()
             selverifmeth_headers.pop("accessToken", None)
             selverifmeth_headers["Deviceid"] = self._get_device_id()
+            self._add_cloudflare_cookie(selverifmeth_headers)
             selverifmeth_data = {"mfaApiCode": "0107", "userAccount": username}
 
             selverifmeth_response = self.sessions.post(
@@ -338,6 +335,7 @@ class KiaUvoApiCA(ApiImpl):
         url = self.API_URL + "mfa/sendotp"
         headers = self.API_HEADERS.copy()
         headers["Deviceid"] = self._get_device_id()
+        self._add_cloudflare_cookie(headers)
         if notify_type == OTP_NOTIFY_TYPE.EMAIL:
             data = {
                 "otpMethod": "E",
@@ -382,6 +380,7 @@ class KiaUvoApiCA(ApiImpl):
         url = self.API_URL + "mfa/validateotp"
         headers = self.API_HEADERS.copy()
         headers["Deviceid"] = self._get_device_id()
+        self._add_cloudflare_cookie(headers)
         data = {
             "otpNo": otp_code,
             "userAccount": username,
@@ -407,6 +406,7 @@ class KiaUvoApiCA(ApiImpl):
         # Call mfa/genmfatkn to get the access token and refresh token
         genmfatkn_url = self.API_URL + "mfa/genmfatkn"
         genmfatkn_headers = self.API_HEADERS.copy()
+        self._add_cloudflare_cookie(genmfatkn_headers)
         genmfatkn_headers["Deviceid"] = self._get_device_id()
         genmfatkn_data = {
             "userAccount": username,
@@ -451,6 +451,7 @@ class KiaUvoApiCA(ApiImpl):
         url = self.API_URL + "vhcllst"
         headers = self.API_HEADERS.copy()
         headers["accessToken"] = token.access_token
+        self._add_cloudflare_cookie(headers)
         response = self.sessions.post(url, headers=headers)
         _LOGGER.debug(f"{DOMAIN} - Test Token Response {response.text}")
         response = response.json()
@@ -466,6 +467,7 @@ class KiaUvoApiCA(ApiImpl):
         url = self.API_URL + "vhcllst"
         headers = self.API_HEADERS.copy()
         headers["accessToken"] = token.access_token
+        self._add_cloudflare_cookie(headers)
         response = self.sessions.post(url, headers=headers)
         _LOGGER.debug(f"{DOMAIN} - Get Vehicles Response {response.text}")
         response = response.json()
@@ -841,6 +843,7 @@ class KiaUvoApiCA(ApiImpl):
         headers = self.API_HEADERS.copy()
         headers["accessToken"] = token.access_token
         headers["vehicleId"] = vehicle.id
+        self._add_cloudflare_cookie(headers)
 
         response = self.sessions.post(url, headers=headers)
         if response.ok:
@@ -887,6 +890,7 @@ class KiaUvoApiCA(ApiImpl):
         headers = self.API_HEADERS.copy()
         headers["accessToken"] = token.access_token
         headers["vehicleId"] = vehicle.id
+        self._add_cloudflare_cookie(headers)
 
         response = self.sessions.post(url, headers=headers)
         response = response.json()
@@ -907,6 +911,7 @@ class KiaUvoApiCA(ApiImpl):
         headers = self.API_HEADERS.copy()
         headers["accessToken"] = token.access_token
         headers["vehicleId"] = vehicle.id
+        self._add_cloudflare_cookie(headers)
 
         response = self.sessions.post(url, headers=headers)
         response = response.json()
@@ -926,6 +931,7 @@ class KiaUvoApiCA(ApiImpl):
         headers = self.API_HEADERS.copy()
         headers["accessToken"] = token.access_token
         headers["vehicleId"] = vehicle.id
+        self._add_cloudflare_cookie(headers)
         url = self.API_URL + "nxtsvc"
         response = self.sessions.post(url, headers=headers)
         response = response.json()
@@ -944,6 +950,7 @@ class KiaUvoApiCA(ApiImpl):
         headers["vehicleId"] = vehicle.id
         headers["from"] = "SPA"
         headers["Referer"] = f"https://{self.BASE_URL}/remote/"
+        self._add_cloudflare_cookie(headers)
         try:
             headers["pAuth"] = self._get_pin_token(token, vehicle)
             response = self.sessions.post(url, headers=headers, json={"pin": token.pin})
@@ -961,6 +968,7 @@ class KiaUvoApiCA(ApiImpl):
         headers = self.API_HEADERS.copy()
         headers["accessToken"] = token.access_token
         headers["vehicleId"] = vehicle.id
+        self._add_cloudflare_cookie(headers)
         response = self.sessions.post(url, headers=headers, json={"pin": token.pin})
         _LOGGER.debug(f"{DOMAIN} - Received Pin validation response {response.json()}")
         result = response.json()["result"]
@@ -974,10 +982,11 @@ class KiaUvoApiCA(ApiImpl):
         elif action == VEHICLE_LOCK_ACTION.UNLOCK:
             url = self.API_URL + "drulck"
             _LOGGER.debug(f"{DOMAIN} - Calling unlock")
-        headers = self.API_HEADERS
+        headers = self.API_HEADERS.copy()
         headers["accessToken"] = token.access_token
         headers["vehicleId"] = vehicle.id
         headers["pAuth"] = self._get_pin_token(token, vehicle)
+        self._add_cloudflare_cookie(headers)
 
         response = self.sessions.post(
             url, headers=headers, data=json.dumps({"pin": token.pin})
@@ -995,10 +1004,11 @@ class KiaUvoApiCA(ApiImpl):
             url = self.API_URL + "evc/rfon"
         else:
             url = self.API_URL + "rmtstrt"
-        headers = self.API_HEADERS
+        headers = self.API_HEADERS.copy()
         headers["accessToken"] = token.access_token
         headers["vehicleId"] = vehicle.id
         headers["pAuth"] = self._get_pin_token(token, vehicle)
+        self._add_cloudflare_cookie(headers)
 
         if options.climate is None:
             options.climate = True
@@ -1129,10 +1139,11 @@ class KiaUvoApiCA(ApiImpl):
             url = self.API_URL + "evc/rfoff"
         else:
             url = self.API_URL + "rmtstp"
-        headers = self.API_HEADERS
+        headers = self.API_HEADERS.copy()
         headers["accessToken"] = token.access_token
         headers["vehicleId"] = vehicle.id
         headers["pAuth"] = self._get_pin_token(token, vehicle)
+        self._add_cloudflare_cookie(headers)
 
         response = self.sessions.post(
             url, headers=headers, data=json.dumps({"pin": token.pin})
@@ -1156,11 +1167,12 @@ class KiaUvoApiCA(ApiImpl):
         start_time = dt.datetime.now()
 
         url = self.API_URL + "rmtsts"
-        headers = self.API_HEADERS
+        headers = self.API_HEADERS.copy()
         headers["accessToken"] = token.access_token
         headers["vehicleId"] = vehicle.id
         headers["transactionId"] = action_id
         headers["pAuth"] = self._get_pin_token(token, vehicle)
+        self._add_cloudflare_cookie(headers)
         response = self.sessions.post(url, headers=headers)
         response = response.json()
 
@@ -1191,10 +1203,11 @@ class KiaUvoApiCA(ApiImpl):
 
     def start_charge(self, token: Token, vehicle: Vehicle) -> str:
         url = self.API_URL + "evc/rcstrt"
-        headers = self.API_HEADERS
+        headers = self.API_HEADERS.copy()
         headers["accessToken"] = token.access_token
         headers["vehicleId"] = vehicle.id
         headers["pAuth"] = self._get_pin_token(token, vehicle)
+        self._add_cloudflare_cookie(headers)
         data = json.dumps({"pin": token.pin})
         _LOGGER.debug(
             f"{DOMAIN} - Planned start_charge payload {self._mask_sensitive_data(data)}"
@@ -1210,10 +1223,11 @@ class KiaUvoApiCA(ApiImpl):
 
     def stop_charge(self, token: Token, vehicle: Vehicle) -> str:
         url = self.API_URL + "evc/rcstp"
-        headers = self.API_HEADERS
+        headers = self.API_HEADERS.copy()
         headers["accessToken"] = token.access_token
         headers["vehicleId"] = vehicle.id
         headers["pAuth"] = self._get_pin_token(token, vehicle)
+        self._add_cloudflare_cookie(headers)
 
         response = self.sessions.post(
             url, headers=headers, data=json.dumps({"pin": token.pin})
@@ -1242,6 +1256,7 @@ class KiaUvoApiCA(ApiImpl):
         headers = self.API_HEADERS.copy()
         headers["accessToken"] = token.access_token
         headers["vehicleId"] = vehicle.id
+        self._add_cloudflare_cookie(headers)
 
         response = self.sessions.post(url, headers=headers)
         response = response.json()
@@ -1256,7 +1271,7 @@ class KiaUvoApiCA(ApiImpl):
         self, token: Token, vehicle: Vehicle, ac: int, dc: int
     ) -> str:
         url = self.API_URL + "evc/setsoc"
-        headers = self.API_HEADERS
+        headers = self.API_HEADERS.copy()
         headers["accessToken"] = token.access_token
         headers["vehicleId"] = vehicle.id
         headers["pAuth"] = self._get_pin_token(token, vehicle)
@@ -1264,6 +1279,7 @@ class KiaUvoApiCA(ApiImpl):
         headers["offset"] = "-8"
         headers["priority"] = "u=1, i"
         headers["Referer"] = "https://kiaconnect.ca/remote/"
+        self._add_cloudflare_cookie(headers)
 
         payload = {
             "tsoc": [

--- a/tests/test_ca_cloudflare_cookie.py
+++ b/tests/test_ca_cloudflare_cookie.py
@@ -34,3 +34,36 @@ class TestGetCloudflareCookie:
         with patch("requests.get", side_effect=Exception("connection error")):
             result = ca_api._get_cloudflare_cookie()
         assert result == ""
+
+
+class TestCloudflareCookieInLogin:
+    def test_login_includes_cloudflare_cookie(self, ca_api):
+        """Login request should include Cookie header with __cf_bm."""
+        mock_cf_response = MagicMock()
+        mock_cf_response.cookies = {"__cf_bm": "test_cookie_value"}
+
+        mock_login_response = MagicMock()
+        mock_login_response.json.return_value = {
+            "responseHeader": {"responseCode": 0},
+            "result": {
+                "token": {
+                    "accessToken": "test_at",
+                    "refreshToken": "test_rt",
+                    "expireIn": 3600,
+                }
+            },
+        }
+
+        with (
+            patch("requests.get", return_value=mock_cf_response),
+            patch.object(
+                ca_api.sessions, "post", return_value=mock_login_response
+            ) as mock_post,
+        ):
+            ca_api.login("user@test.com", "password123")
+            call_kwargs = mock_post.call_args
+            headers = call_kwargs.kwargs.get(
+                "headers", call_kwargs[1].get("headers", {})
+            )
+            assert "Cookie" in headers
+            assert "__cf_bm=test_cookie_value" in headers["Cookie"]

--- a/tests/test_ca_cloudflare_cookie.py
+++ b/tests/test_ca_cloudflare_cookie.py
@@ -1,0 +1,36 @@
+"""Tests for KiaUvoApiCA Cloudflare __cf_bm cookie handling."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from hyundai_kia_connect_api.KiaUvoApiCA import KiaUvoApiCA
+
+
+@pytest.fixture
+def ca_api():
+    api = KiaUvoApiCA(region=2, brand=1, language="en")
+    return api
+
+
+class TestGetCloudflareCookie:
+    def test_extracts_cf_bm_cookie(self, ca_api):
+        """Should extract __cf_bm cookie from response."""
+        mock_response = MagicMock()
+        mock_response.cookies = {"__cf_bm": "abc123def456"}
+        with patch("requests.get", return_value=mock_response):
+            result = ca_api._get_cloudflare_cookie()
+        assert result == "__cf_bm=abc123def456"
+
+    def test_returns_empty_when_no_cf_bm(self, ca_api):
+        """Should return empty string when __cf_bm not in cookies."""
+        mock_response = MagicMock()
+        mock_response.cookies = {"other_cookie": "value"}
+        with patch("requests.get", return_value=mock_response):
+            result = ca_api._get_cloudflare_cookie()
+        assert result == ""
+
+    def test_returns_empty_on_request_failure(self, ca_api):
+        """Should return empty string when cookie fetch request fails."""
+        with patch("requests.get", side_effect=Exception("connection error")):
+            result = ca_api._get_cloudflare_cookie()
+        assert result == ""

--- a/tests/test_ca_cloudflare_cookie.py
+++ b/tests/test_ca_cloudflare_cookie.py
@@ -130,3 +130,118 @@ class TestAddCloudflareCookie:
         with patch("requests.get", return_value=MagicMock()):
             result = ca_api._add_cloudflare_cookie(headers)
         assert "Cookie" not in result
+
+
+class TestIsCloudflareBlock:
+    def test_403_html_is_cloudflare(self, ca_api):
+        """403 with HTML content type is a Cloudflare block."""
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.headers = {"Content-Type": "text/html"}
+        mock_response.text = "<html>Attention Required</html>"
+        assert ca_api._is_cloudflare_block(mock_response) is True
+
+    def test_403_with_cloudflare_in_body(self, ca_api):
+        """403 with 'cloudflare' in body is a Cloudflare block."""
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.headers = {"Content-Type": "text/plain"}
+        mock_response.text = "Cloudflare attention required"
+        assert ca_api._is_cloudflare_block(mock_response) is True
+
+    def test_403_json_not_cloudflare(self, ca_api):
+        """403 with JSON content type is NOT a Cloudflare block."""
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.text = '{"error": "auth failed"}'
+        assert ca_api._is_cloudflare_block(mock_response) is False
+
+    def test_200_not_cloudflare(self, ca_api):
+        """200 response is never a Cloudflare block."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        assert ca_api._is_cloudflare_block(mock_response) is False
+
+
+class TestPostWithCloudflareRetry:
+    def test_retries_on_cloudflare_403(self, ca_api):
+        """Should refresh cookie and retry on Cloudflare 403."""
+        ca_api._cloudflare_cookie = "__cf_bm=old_cookie"
+        ca_api._cloudflare_cookie_fetched_at = dt.datetime.now(dt.timezone.utc)
+
+        mock_cf_response = MagicMock()
+        mock_cf_response.cookies = {"__cf_bm": "new_cookie"}
+
+        call_count = 0
+
+        def mock_post(url, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                resp = MagicMock()
+                resp.status_code = 403
+                resp.headers = {"Content-Type": "text/html"}
+                resp.text = "<html>Cloudflare Attention Required</html>"
+                return resp
+            else:
+                resp = MagicMock()
+                resp.status_code = 200
+                resp.json.return_value = {
+                    "responseHeader": {"responseCode": 0},
+                    "result": {},
+                }
+                return resp
+
+        headers = {"accessToken": "test"}
+        with (
+            patch("requests.get", return_value=mock_cf_response),
+            patch.object(ca_api.sessions, "post", side_effect=mock_post),
+        ):
+            response = ca_api._post_with_cloudflare_retry(
+                "https://test.ca/api", headers=headers, json={"pin": "1234"}
+            )
+
+        assert call_count == 2
+        assert response.status_code == 200
+        assert headers["Cookie"] == "__cf_bm=new_cookie"
+
+    def test_no_retry_on_success(self, ca_api):
+        """Should not retry when response is 200."""
+        call_count = 0
+
+        def mock_post(url, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.json.return_value = {"responseHeader": {"responseCode": 0}}
+            return resp
+
+        headers = {"accessToken": "test"}
+        with patch.object(ca_api.sessions, "post", side_effect=mock_post):
+            ca_api._post_with_cloudflare_retry("https://test.ca/api", headers=headers)
+
+        assert call_count == 1
+
+    def test_no_retry_on_non_cloudflare_403(self, ca_api):
+        """Should not retry on 403 that is not Cloudflare."""
+        call_count = 0
+
+        def mock_post(url, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            resp = MagicMock()
+            resp.status_code = 403
+            resp.headers = {"Content-Type": "application/json"}
+            resp.text = '{"error": "unauthorized"}'
+            return resp
+
+        headers = {"accessToken": "test"}
+        with patch.object(ca_api.sessions, "post", side_effect=mock_post):
+            result = ca_api._post_with_cloudflare_retry(
+                "https://test.ca/api", headers=headers
+            )
+
+        assert call_count == 1
+        assert result.status_code == 403

--- a/tests/test_ca_cloudflare_cookie.py
+++ b/tests/test_ca_cloudflare_cookie.py
@@ -1,5 +1,7 @@
 """Tests for KiaUvoApiCA Cloudflare __cf_bm cookie handling."""
 
+import datetime as dt
+
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -67,3 +69,64 @@ class TestCloudflareCookieInLogin:
             )
             assert "Cookie" in headers
             assert "__cf_bm=test_cookie_value" in headers["Cookie"]
+
+
+class TestEnsureCloudflareCookie:
+    def test_proactive_refresh_after_25_min(self, ca_api):
+        """Should proactively refresh cookie after 25 minutes."""
+        ca_api._cloudflare_cookie = "__cf_bm=old_cookie"
+        ca_api._cloudflare_cookie_fetched_at = dt.datetime.now(
+            dt.timezone.utc
+        ) - dt.timedelta(minutes=26)
+
+        mock_cf_response = MagicMock()
+        mock_cf_response.cookies = {"__cf_bm": "new_cookie"}
+
+        with patch("requests.get", return_value=mock_cf_response):
+            result = ca_api._ensure_cloudflare_cookie()
+        assert result == "__cf_bm=new_cookie"
+
+    def test_skip_refresh_when_fresh(self, ca_api):
+        """Should not refresh cookie when less than 25 minutes old."""
+        ca_api._cloudflare_cookie = "__cf_bm=fresh_cookie"
+        ca_api._cloudflare_cookie_fetched_at = dt.datetime.now(dt.timezone.utc)
+
+        with patch("requests.get") as mock_get:
+            result = ca_api._ensure_cloudflare_cookie()
+        mock_get.assert_not_called()
+        assert result == "__cf_bm=fresh_cookie"
+
+    def test_fetch_when_no_cookie(self, ca_api):
+        """Should fetch cookie when none exists yet."""
+        ca_api._cloudflare_cookie = ""
+        ca_api._cloudflare_cookie_fetched_at = None
+
+        mock_cf_response = MagicMock()
+        mock_cf_response.cookies = {"__cf_bm": "first_cookie"}
+
+        with patch("requests.get", return_value=mock_cf_response):
+            result = ca_api._ensure_cloudflare_cookie()
+        assert result == "__cf_bm=first_cookie"
+
+
+class TestAddCloudflareCookie:
+    def test_adds_cookie_to_headers(self, ca_api):
+        """Should add Cloudflare cookie to headers dict."""
+        ca_api._cloudflare_cookie = "__cf_bm=test_value"
+        ca_api._cloudflare_cookie_fetched_at = dt.datetime.now(dt.timezone.utc)
+
+        headers = {"accessToken": "test"}
+        with patch("requests.get"):  # _ensure won't call since fresh
+            result = ca_api._add_cloudflare_cookie(headers)
+        assert "Cookie" in result
+        assert result["Cookie"] == "__cf_bm=test_value"
+
+    def test_no_cookie_key_when_empty(self, ca_api):
+        """Should not add Cookie key when no cookie available."""
+        ca_api._cloudflare_cookie = ""
+        ca_api._cloudflare_cookie_fetched_at = None
+
+        headers = {"accessToken": "test"}
+        with patch("requests.get", return_value=MagicMock()):
+            result = ca_api._add_cloudflare_cookie(headers)
+        assert "Cookie" not in result


### PR DESCRIPTION
## Problem

Hyundai Canada API is protected by Cloudflare bot management. Requests without the `__cf_bm` cookie get blocked with HTTP 403 / rate limit 1015, as reported in #1131.

## Solution

Fetch the `__cf_bm` cookie from the `/login` page and include it in all authenticated API requests:

- **`_get_cloudflare_cookie()`** — GET `https://{apiHost}/login`, extract `__cf_bm` from `Set-Cookie` header
- **`_ensure_cloudflare_cookie()`** — proactive refresh at 25 min (cookie expires ~30 min)
- **`_add_cloudflare_cookie(headers)`** — inject cookie into request headers
- **`_is_cloudflare_block(response)`** — detect 403 with Cloudflare HTML/keywords
- **`_post_with_cloudflare_retry(url, **kwargs)`** — POST wrapper that catches 403 Cloudflare blocks, refreshes cookie, retries

### Bug fixes found during implementation

7 instances of `headers = self.API_HEADERS` without `.copy()` — this permanently mutates the shared dict when headers are modified downstream. Fixed to `headers = self.API_HEADERS.copy()`.

## Testing

16 unit tests covering:
- Cookie fetch from login page
- Cookie injection in login flow
- Proactive refresh (25 min threshold)
- Cloudflare 403 detection (HTML body, "cloudflare" keyword)
- POST retry on Cloudflare block
- Non-Cloudflare 403 not triggering retry

Closes #1131

cc @paul-e-m @kiluazen — this should resolve the Cloudflare 403 blocks you were seeing. Would appreciate if you could test with your CA accounts.