### PR TITLE
feat(CA): hvacInfo→remoteControl self-correcting retry in start_climate

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -937,6 +937,39 @@ class KiaUvoApiCA(ApiImpl):
         _LOGGER.debug(f"{DOMAIN} - Received lock_action response {response}")
         return response_headers["transactionId"]
 
+    def _build_ev_climate_payload(
+        self,
+        token: Token,
+        options: ClimateRequestOptions,
+        hex_set_temp: str,
+        use_remote_control: bool = False,
+    ) -> dict:
+        """Build EV climate start payload.
+
+        Args:
+            use_remote_control: If True, use 'remoteControl' key instead of 'hvacInfo'.
+        """
+        payload = {"pin": token.pin}
+        payload_key = "remoteControl" if use_remote_control else "hvacInfo"
+        payload[payload_key] = {
+            "airCtrl": int(options.climate),
+            "defrost": options.defrost,
+            "heating1": options.heating,
+            "airTemp": {
+                "value": hex_set_temp,
+                "unit": 0,
+                "hvacTempType": 1,
+            },
+            "igniOnDuration": options.duration,
+            "seatHeaterVentCMD": {
+                "drvSeatOptCmd": options.front_left_seat,
+                "astSeatOptCmd": options.front_right_seat,
+                "rlSeatOptCmd": options.rear_left_seat,
+                "rrSeatOptCmd": options.rear_right_seat,
+            },
+        }
+        return payload
+
     def start_climate(
         self, token: Token, vehicle: Vehicle, options: ClimateRequestOptions
     ) -> str:
@@ -977,73 +1010,40 @@ class KiaUvoApiCA(ApiImpl):
                 self.temperature_range_c_old.index(options.set_temp)
             )
         if vehicle.engine_type == ENGINE_TYPES.EV:
-            payload = {
-                "pin": token.pin,
-            }
-            climate_settings = {
-                "airCtrl": int(options.climate),
-                "defrost": options.defrost,
-                "heating1": options.heating,
-                "airTemp": {
-                    "value": hex_set_temp,
-                    "unit": 0,
-                    "hvacTempType": 1,
-                },
-            }
-            if BRANDS[self.brand] == BRAND_KIA:
-                if vehicle.name == "EV9":
-                    payload["remoteControl"] = climate_settings
-                    payload["remoteControl"].update(
-                        {
-                            "igniOnDuration": options.duration,
-                            "seatHeaterVentCMD": {
-                                "drvSeatOptCmd": options.front_left_seat,
-                                "astSeatOptCmd": options.front_right_seat,
-                                "rlSeatOptCmd": options.rear_left_seat,
-                                "rrSeatOptCmd": options.rear_right_seat,
-                            },
-                        }
-                    )
-                else:
-                    payload["hvacInfo"] = climate_settings
-                    payload["hvacInfo"].update(
-                        {
-                            "igniOnDuration": options.duration,
-                            "seatHeaterVentCMD": {
-                                "drvSeatOptCmd": options.front_left_seat,
-                                "astSeatOptCmd": options.front_right_seat,
-                                "rlSeatOptCmd": options.rear_left_seat,
-                                "rrSeatOptCmd": options.rear_right_seat,
-                            },
-                        }
-                    )
-            else:
-                if vehicle.model == "IONIQ 9":
-                    payload["remoteControl"] = climate_settings
-                    payload["remoteControl"].update(
-                        {
-                            "igniOnDuration": options.duration,
-                            "seatHeaterVentCMD": {
-                                "drvSeatOptCmd": options.front_left_seat,
-                                "astSeatOptCmd": options.front_right_seat,
-                                "rlSeatOptCmd": options.rear_left_seat,
-                                "rrSeatOptCmd": options.rear_right_seat,
-                            },
-                        }
-                    )
-                else:
-                    payload["hvacInfo"] = climate_settings
-                    payload["hvacInfo"].update(
-                        {
-                            "igniOnDuration": options.duration,
-                            "seatHeaterVentCMD": {
-                                "drvSeatOptCmd": options.front_left_seat,
-                                "astSeatOptCmd": options.front_right_seat,
-                                "rlSeatOptCmd": options.rear_left_seat,
-                                "rrSeatOptCmd": options.rear_right_seat,
-                            },
-                        }
-                    )
+            # Try hvacInfo first, retry with remoteControl on failure
+            payload = self._build_ev_climate_payload(
+                token, options, hex_set_temp, use_remote_control=False
+            )
+            _LOGGER.debug(
+                f"{DOMAIN} - Planned start_climate payload {self._mask_sensitive_data(payload)}"
+            )
+
+            response = self.sessions.post(
+                url, headers=headers, data=json.dumps(payload)
+            )
+            response_json = response.json()
+
+            if response_json.get("responseHeader", {}).get("responseCode") != 0:
+                _LOGGER.warning(
+                    f"{DOMAIN} - Climate start with hvacInfo failed "
+                    f"(responseCode={response_json.get('responseHeader', {}).get('responseCode')}), "
+                    f"retrying with remoteControl payload"
+                )
+                payload = self._build_ev_climate_payload(
+                    token, options, hex_set_temp, use_remote_control=True
+                )
+                _LOGGER.debug(
+                    f"{DOMAIN} - Retry start_climate payload {self._mask_sensitive_data(payload)}"
+                )
+                response = self.sessions.post(
+                    url, headers=headers, data=json.dumps(payload)
+                )
+                response_json = response.json()
+
+            self._check_response_for_errors(response_json)
+            response_headers = response.headers
+            _LOGGER.debug(f"{DOMAIN} - Received start_climate response {response_json}")
+            return response_headers["transactionId"]
         else:
             payload = {
                 "setting": {

--- a/tests/test_ca_climate_retry.py
+++ b/tests/test_ca_climate_retry.py
@@ -1,0 +1,185 @@
+"""Tests for KiaUvoApiCA start_climate hvacInfo/remoteControl retry logic."""
+
+import json
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from hyundai_kia_connect_api.ApiImpl import ClimateRequestOptions
+from hyundai_kia_connect_api.KiaUvoApiCA import KiaUvoApiCA
+from hyundai_kia_connect_api.Token import Token
+from hyundai_kia_connect_api.Vehicle import Vehicle
+from hyundai_kia_connect_api.const import ENGINE_TYPES
+from hyundai_kia_connect_api.exceptions import APIError
+
+
+@pytest.fixture
+def ca_api_kia():
+    api = KiaUvoApiCA(region=2, brand=1, language="en")
+    return api
+
+
+@pytest.fixture
+def ev_vehicle():
+    v = Vehicle()
+    v.id = "test-vehicle-id"
+    v.engine_type = ENGINE_TYPES.EV
+    v.year = 2024
+    v.name = "EV6"
+    v.model = "EV6"
+    return v
+
+
+@pytest.fixture
+def token():
+    t = Token()
+    t.username = "test@example.com"
+    t.access_token = "test-access-token"
+    t.pin = "1234"
+    t.device_id = "test-device-id"
+    return t
+
+
+@pytest.fixture
+def climate_options():
+    opts = ClimateRequestOptions()
+    opts.climate = True
+    opts.set_temp = 22
+    opts.duration = 10
+    opts.heating = 0
+    opts.defrost = False
+    opts.front_left_seat = 0
+    opts.front_right_seat = 0
+    opts.rear_left_seat = 0
+    opts.rear_right_seat = 0
+    return opts
+
+
+class TestClimateRetry:
+    def test_retry_with_remote_control_on_hvacinfo_failure(
+        self, ca_api_kia, token, ev_vehicle, climate_options
+    ):
+        """Should retry with remoteControl key when hvacInfo payload fails."""
+        call_count = 0
+
+        def mock_post(url, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            resp = MagicMock()
+            if call_count == 1:
+                resp.json.return_value = {
+                    "responseHeader": {"responseCode": 1},
+                    "error": {
+                        "errorCode": "7445",
+                        "errorDesc": "Request could not be processed",
+                    },
+                }
+                resp.status_code = 200
+                resp.headers = {"transactionId": "txn-1"}
+            else:
+                resp.json.return_value = {
+                    "responseHeader": {"responseCode": 0},
+                    "result": {},
+                }
+                resp.status_code = 200
+                resp.headers = {"transactionId": "txn-2"}
+            return resp
+
+        with (
+            patch.object(ca_api_kia, "_get_pin_token", return_value="test-pauth"),
+            patch.object(ca_api_kia.sessions, "post", side_effect=mock_post),
+        ):
+            result = ca_api_kia.start_climate(token, ev_vehicle, climate_options)
+
+        assert call_count == 2
+        assert result == "txn-2"
+
+    def test_no_retry_on_success(self, ca_api_kia, token, ev_vehicle, climate_options):
+        """Should not retry when hvacInfo payload succeeds."""
+        call_count = 0
+
+        def mock_post(url, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            resp = MagicMock()
+            resp.json.return_value = {
+                "responseHeader": {"responseCode": 0},
+                "result": {},
+            }
+            resp.status_code = 200
+            resp.headers = {"transactionId": "txn-ok"}
+            return resp
+
+        with (
+            patch.object(ca_api_kia, "_get_pin_token", return_value="test-pauth"),
+            patch.object(ca_api_kia.sessions, "post", side_effect=mock_post),
+        ):
+            result = ca_api_kia.start_climate(token, ev_vehicle, climate_options)
+
+        assert call_count == 1
+        assert result == "txn-ok"
+
+    def test_raises_error_when_both_fail(
+        self, ca_api_kia, token, ev_vehicle, climate_options
+    ):
+        """Should raise APIError when both hvacInfo and remoteControl fail."""
+
+        def mock_post(url, **kwargs):
+            resp = MagicMock()
+            resp.json.return_value = {
+                "responseHeader": {"responseCode": 1},
+                "error": {
+                    "errorCode": "7404",
+                    "errorDesc": "Authentication failed",
+                },
+            }
+            resp.status_code = 200
+            resp.headers = {"transactionId": "txn-fail"}
+            return resp
+
+        with (
+            patch.object(ca_api_kia, "_get_pin_token", return_value="test-pauth"),
+            patch.object(ca_api_kia.sessions, "post", side_effect=mock_post),
+        ):
+            with pytest.raises(APIError):
+                ca_api_kia.start_climate(token, ev_vehicle, climate_options)
+
+    def test_remote_control_payload_structure(
+        self, ca_api_kia, token, ev_vehicle, climate_options
+    ):
+        """Verify remoteControl payload has correct structure on retry."""
+        captured_payloads = []
+
+        def mock_post(url, **kwargs):
+            data = kwargs.get("data", kwargs.get("json", "{}"))
+            if isinstance(data, str):
+                captured_payloads.append(json.loads(data))
+            resp = MagicMock()
+            if len(captured_payloads) == 1:
+                resp.json.return_value = {
+                    "responseHeader": {"responseCode": 1},
+                    "error": {
+                        "errorCode": "7445",
+                        "errorDesc": "Bad payload",
+                    },
+                }
+            else:
+                resp.json.return_value = {
+                    "responseHeader": {"responseCode": 0},
+                    "result": {},
+                }
+            resp.status_code = 200
+            resp.headers = {"transactionId": "txn-retry"}
+            return resp
+
+        with (
+            patch.object(ca_api_kia, "_get_pin_token", return_value="test-pauth"),
+            patch.object(ca_api_kia.sessions, "post", side_effect=mock_post),
+        ):
+            ca_api_kia.start_climate(token, ev_vehicle, climate_options)
+
+        # First payload should use hvacInfo, second should use remoteControl
+        assert "hvacInfo" in captured_payloads[0]
+        assert "remoteControl" not in captured_payloads[0]
+        assert "remoteControl" in captured_payloads[1]
+        assert "hvacInfo" not in captured_payloads[1]

--- a/tests/test_ca_climate_retry.py
+++ b/tests/test_ca_climate_retry.py
@@ -122,15 +122,15 @@ class TestClimateRetry:
     def test_raises_error_when_both_fail(
         self, ca_api_kia, token, ev_vehicle, climate_options
     ):
-        """Should raise APIError when both hvacInfo and remoteControl fail."""
+        """Should raise error when both hvacInfo and remoteControl fail."""
 
         def mock_post(url, **kwargs):
             resp = MagicMock()
             resp.json.return_value = {
                 "responseHeader": {"responseCode": 1},
                 "error": {
-                    "errorCode": "7404",
-                    "errorDesc": "Authentication failed",
+                    "errorCode": "7445",
+                    "errorDesc": "Request could not be processed",
                 },
             }
             resp.status_code = 200


### PR DESCRIPTION
## Problem

Newer CA EV vehicles (EV9, IONIQ 9) require the `remoteControl` payload key instead of `hvacInfo` for climate start. The previous approach used a brand/model whitelist (hardcoded EV9 for Kia, IONIQ 9 for Hyundai) — fragile and requires updating for every new model.

## Solution

Replace the whitelist with a **self-correcting retry**:

1. Try `hvacInfo` first (works for most vehicles)
2. If `responseCode != 0`, retry with `remoteControl`
3. If both fail, `_check_response_for_errors` raises the appropriate exception

This matches the pattern used by egmp-bluelink-scriptable and eliminates the need for a vehicle model whitelist.

### Refactoring

- Extracted `_build_ev_climate_payload(token, options, hex_set_temp, use_remote_control=False)` helper
- Removed brand-specific EV9/IONIQ 9 branching in favor of try-retry pattern

## Testing

4 unit tests:
- Retry on hvacInfo failure → remoteControl success
- No retry on hvacInfo success
- Raise error when both fail
- Payload structure verification (remoteControl vs hvacInfo key)