### PR TITLE
feat(USA): implement horn and hazard lights

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
@@ -124,6 +124,11 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
     # initialize with a timestamp which will allow the first fetch to occur
     last_loc_timestamp = dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=3)
 
+    # Maps transaction IDs to service_type values for action status polling.
+    # Horn/hazard commands need HORN_AND_LIGHTS or LIGHTS_ONLY instead of
+    # the default REMOTE_POLL.
+    _action_service_types: dict[str, str] = {}
+
     def __init__(self, region: int, brand: int, language: str):
         self.LANGUAGE: str = language
         self.BASE_URL: str = "api.telematics.hyundaiusa.com"
@@ -874,7 +879,8 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
         headers = self._get_vehicle_headers(token, vehicle)
         headers["tid"] = action_id
         headers["login_id"] = token.username
-        headers["service_type"] = "REMOTE_POLL"
+        service_type = self._action_service_types.pop(action_id, "REMOTE_POLL")
+        headers["service_type"] = service_type
 
         max_attempts = 1 if not synchronous else max(1, timeout // 2)
 
@@ -1122,7 +1128,10 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
             f"{DOMAIN} - Received start_hazard_lights response: {response.text}"
         )
 
-        return self._get_transaction_id(response)
+        action_id = self._get_transaction_id(response)
+        if action_id:
+            self._action_service_types[action_id] = "LIGHTS_ONLY"
+        return action_id
 
     def start_hazard_lights_and_horn(self, token: Token, vehicle: Vehicle) -> str:
         url = self.API_URL + "rcs/rhl/hnl"
@@ -1142,4 +1151,7 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
             f"{DOMAIN} - Received start_hazard_lights_and_horn response: {response.text}"
         )
 
-        return self._get_transaction_id(response)
+        action_id = self._get_transaction_id(response)
+        if action_id:
+            self._action_service_types[action_id] = "HORN_AND_LIGHTS"
+        return action_id

--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
@@ -1103,3 +1103,43 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
         _LOGGER.debug(f"{DOMAIN} - Setting charge limits: {response.text}")
 
         return self._get_transaction_id(response)
+
+    def start_hazard_lights(self, token: Token, vehicle: Vehicle) -> str:
+        url = self.API_URL + "rcs/rhl/light"
+        headers = self._get_vehicle_headers(token, vehicle)
+        headers["APPCLOUD-VIN"] = vehicle.VIN
+
+        data = {"userName": token.username, "vin": vehicle.VIN}
+        response = self.sessions.post(url, headers=headers, json=data)
+        response_json = _safe_parse_json(response, "start_hazard_lights")
+        if response_json is not None:
+            _check_response_for_errors(response_json)
+        _LOGGER.debug(
+            f"{DOMAIN} - Received start_hazard_lights response status code: "
+            f"{response.status_code}"
+        )
+        _LOGGER.debug(
+            f"{DOMAIN} - Received start_hazard_lights response: {response.text}"
+        )
+
+        return self._get_transaction_id(response)
+
+    def start_hazard_lights_and_horn(self, token: Token, vehicle: Vehicle) -> str:
+        url = self.API_URL + "rcs/rhl/hnl"
+        headers = self._get_vehicle_headers(token, vehicle)
+        headers["APPCLOUD-VIN"] = vehicle.VIN
+
+        data = {"userName": token.username, "vin": vehicle.VIN}
+        response = self.sessions.post(url, headers=headers, json=data)
+        response_json = _safe_parse_json(response, "start_hazard_lights_and_horn")
+        if response_json is not None:
+            _check_response_for_errors(response_json)
+        _LOGGER.debug(
+            f"{DOMAIN} - Received start_hazard_lights_and_horn response status code: "
+            f"{response.status_code}"
+        )
+        _LOGGER.debug(
+            f"{DOMAIN} - Received start_hazard_lights_and_horn response: {response.text}"
+        )
+
+        return self._get_transaction_id(response)


### PR DESCRIPTION
## Summary

- Add `start_hazard_lights` and `start_hazard_lights_and_horn` for Hyundai USA region
- Endpoints captured from native myHyundai iOS app v5.4.0:
  - Hazard lights only: `POST /ac/v2/rcs/rhl/light`
  - Horn + hazard lights: `POST /ac/v2/rcs/rhl/hnl`
- Both methods follow the same pattern as `lock_action` (userName+vin body, APPCLOUD-VIN header, tmsTid response header)

## Implementation notes

- Uses existing `_safe_parse_json` for empty-body response handling (horn/hazard return HTTP 200 with empty body)
- Action status polling uses default `REMOTE_POLL` service_type
- The native app uses `HORN_AND_LIGHTS` / `LIGHTS_ONLY` service_type for polling, but these are 30-second fire-and-forget commands where polling is secondary

## Testing

All 177 existing tests pass. Manual testing needed by a USA Hyundai owner to verify:
1. Horn + hazard lights button triggers both horn and lights
2. Hazard lights only button triggers just the lights
3. Action status polling returns correctly (or times out gracefully)

Closes #1167