### PR TITLE
feat(EU/AU): dynamic drvSeatLoc based on vehicle market (RHD vs LHD)

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -1018,7 +1018,9 @@ class ApiImplType1(ApiImpl):
                 "hvacTempType": 1,
                 "hvacTemp": options.set_temp,
                 "sideRearMirrorHeating": 1,
-                "drvSeatLoc": "R",
+                "drvSeatLoc": "R"
+                if vehicle.distance_unit == DISTANCE_UNITS[2]
+                else "L",
                 "seatClimateInfo": {
                     "drvSeatClimateState": options.front_left_seat,
                     "psgSeatClimateState": options.front_right_seat,


### PR DESCRIPTION
## Problem

CCS2 climate `start_climate()` hardcodes `drvSeatLoc: "R"` for all vehicles. This is correct for RHD markets (UK, AU, IN) but wrong for LHD markets (Germany, France, Spain — most of EU).

The driver seat location determines which seat receives climate settings. Sending `"R"` on an LHD vehicle applies seat heating/cooling to the wrong seat.

## Solution

Replace the hardcoded `"R"` with a dynamic check based on `vehicle.distance_unit`:

- Miles (`DISTANCE_UNITS[2]`) → `"R"` (RHD: UK, AU, IN)
- Kilometers (`DISTANCE_UNITS[1]`) → `"L"` (LHD: continental EU)

This matches egmp-bluelink-scriptable which uses `this.distanceUnit === "mi" ? "R" : "L"`.

## Testing

All existing snapshot tests pass (8 CCS2 + vehicle snapshots). The change is a single conditional expression, no new test file needed.

## References

- egmp-bluelink-scriptable `europe.ts` line 779: `drvSeatLoc: this.distanceUnit === "mi" ? "R" : "L"`