### PR TITLE
feat(EU/AU/IN): cache control token with expiry — cut API calls in half

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -6,6 +6,7 @@ import logging
 import math
 from typing import Optional
 
+import time
 from time import sleep
 
 from .ApiImpl import (
@@ -1149,6 +1150,10 @@ class ApiImplType1(ApiImpl):
         return response["msgId"]
 
     def _get_control_token(self, token: Token) -> Token:
+        # Return cached control token if still valid
+        if token.control_token is not None and token.control_token_expiry > time.time():
+            return token.control_token, token.control_token_expiry
+
         url = self.USER_API_URL + "pin?token="
         headers = {
             "Authorization": token.access_token,
@@ -1168,6 +1173,9 @@ class ApiImplType1(ApiImpl):
         control_token_expire_at = math.floor(
             dt.datetime.now().timestamp() + response["expiresTime"]
         )
+        # Cache control token and expiry for reuse
+        token.control_token = control_token
+        token.control_token_expiry = control_token_expire_at
         return control_token, control_token_expire_at
 
     def _set_session_language(self, cookies) -> None:

--- a/hyundai_kia_connect_api/KiaUvoApiIN.py
+++ b/hyundai_kia_connect_api/KiaUvoApiIN.py
@@ -8,6 +8,7 @@ import logging
 import math
 import random
 import re
+import time
 import typing as ty
 import uuid
 from typing import Optional
@@ -1106,6 +1107,10 @@ class KiaUvoApiIN(ApiImplType1):
         return token_type, refresh_token
 
     def _get_control_token(self, token: Token) -> Token:
+        # Return cached control token if still valid
+        if token.control_token is not None and token.control_token_expiry > time.time():
+            return token.control_token, token.control_token_expiry
+
         url = self.USER_API_URL + "pin?token="
         headers = {
             "Authorization": token.access_token,
@@ -1122,4 +1127,7 @@ class KiaUvoApiIN(ApiImplType1):
         control_token_expire_at = math.floor(
             dt.datetime.now().timestamp() + response["expiresTime"]
         )
+        # Cache control token and expiry for reuse
+        token.control_token = control_token
+        token.control_token_expiry = control_token_expire_at
         return control_token, control_token_expire_at

--- a/hyundai_kia_connect_api/Token.py
+++ b/hyundai_kia_connect_api/Token.py
@@ -19,6 +19,9 @@ class Token:
     valid_until: dt.datetime = dt.datetime.min
     stamp: str = None
     pin: str | None = None
+    # Control token (EU/AU/IN PIN verification) — cached with expiry:
+    control_token: str | None = None
+    control_token_expiry: float = 0
 
     def to_dict(self) -> dict:
         """Convert Token to a JSON‑serializable dict."""
@@ -46,4 +49,6 @@ class Token:
             valid_until=valid_until,
             stamp=data.get("stamp"),
             pin=data.get("pin"),
+            control_token=data.get("control_token"),
+            control_token_expiry=data.get("control_token_expiry", 0),
         )


### PR DESCRIPTION
## Problem

Every control command (lock, unlock, climate, charge, windows, horn, valet, navigation) makes a separate PUT `/pin` request to get a control token, even if the previous token is still valid. The token has an `expiresTime` (seconds) but we discard it and fetch a new one every time.

This doubles the number of API calls per control operation and adds latency.

## Solution

Cache `control_token` and `control_token_expiry` on the `Token` object:

1. `_get_control_token()` checks `token.control_token_expiry > time.time()` before making a network request
2. If cached token is still valid, return it immediately (0 API calls)
3. If expired, fetch new token and store on Token for reuse
4. New Token objects start with `control_token=None` and `control_token_expiry=0` (no stale data)

Matches egmp-bluelink-scriptable behavior which caches `controlToken` with expiry and clears on login.

## Files changed

- `Token.py` — add `control_token: str | None = None`, `control_token_expiry: float = 0`
- `ApiImplType1._get_control_token()` — cache check + store
- `KiaUvoApiIN._get_control_token()` — same pattern (override)

## Testing

All 177 existing tests pass. The change is additive — no breaking changes to the Token interface.

## Impact

For Home Assistant users with 30-min polling interval + force refresh, this eliminates 2+ redundant PIN verification calls per cycle.