### PR TITLE
feat(EU/AU/IN/CN): CCS2 force refresh polling loop

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -8,6 +8,7 @@ import threading
 
 import time
 from time import sleep
+from typing import Any
 
 from .ApiImpl import (
     ApiImpl,
@@ -797,6 +798,102 @@ class ApiImplType1(ApiImpl):
         # self._sanitize_ice_value(state)
 
         vehicle.data = state
+
+    def _inspect_ccs2_response(
+        self, response: dict[str, Any]
+    ) -> tuple[dict[str, Any] | None, dt.datetime | None]:
+        """Extract (state, last_updated) from a CCS2 /latest response.
+
+        Default impl for EU/AU shape: resMsg.state.Vehicle + Date (UTC).
+        Does NOT call the parser — caller checks freshness before applying.
+        """
+        try:
+            state: dict[str, Any] | None = response["resMsg"]["state"]["Vehicle"]
+        except (KeyError, TypeError):
+            return None, None
+        if state is None:
+            return None, None
+        raw_date = get_child_value(state, "Date")
+        if not raw_date:
+            return state, None
+        try:
+            last = parse_datetime(str(raw_date).split(".")[0], dt.timezone.utc)
+            return state, last.astimezone(self.data_timezone)
+        except (ValueError, TypeError):
+            _LOGGER.warning(f"{DOMAIN} - CCS2 _inspect: cannot parse Date '{raw_date}'")
+            return state, None
+
+    def _apply_ccs2_state(self, vehicle: Vehicle, state: dict[str, Any]) -> None:
+        """Parse + write vehicle state. Called only when data is fresh.
+
+        Default impl: CCS2 parser (EU/AU).
+        """
+        self._update_vehicle_properties_ccs2(vehicle, state)
+
+    def _post_refresh_ccs2_location(self, token: Token, vehicle: Vehicle) -> None:
+        """Refresh vehicle location after a CCS2 force-refresh.
+
+        Default impl: _get_location + inline set (AU/CN shape).
+        """
+        location = self._get_location(token, vehicle)
+        if location and get_child_value(location, "coord.lat"):
+            vehicle.location = (
+                get_child_value(location, "coord.lat"),
+                get_child_value(location, "coord.lon"),
+                parse_datetime(get_child_value(location, "time"), self.data_timezone),
+            )
+
+    def _force_refresh_vehicle_state_ccs2(self, token: Token, vehicle: Vehicle) -> None:
+        """Force-refresh CCS2 vehicle state: trigger, poll until fresh, apply.
+
+        1. GET /ccs2/carstatus (no /latest) to wake the vehicle.
+        2. Poll /ccs2/carstatus/latest every 10s, max 14 attempts (~140s window,
+           matching the app's controlRetrofit readTimeout = backend max
+           wake-to-report), until last_updated > trigger_time.
+        3. Apply state only when fresh (HA: do not mask stale).
+        4. Refresh location.
+        """
+        headers = self._get_authenticated_headers(
+            token, vehicle.ccu_ccs2_protocol_support
+        )
+        trigger_url = self.SPA_API_URL + "vehicles/" + vehicle.id + "/ccs2/carstatus"
+        self.session.get(trigger_url, headers=headers).json()
+        trigger_time = time.time()
+
+        poll_url = trigger_url + "/latest"
+        # Window ~140s = app controlRetrofit readTimeout (backend max wake for a
+        # slow/deep-sleep car). Early-exit on fresh => typical ~20s unchanged;
+        # 140s matters only for slow wakes. 10s interval => 14 calls max
+        # (server-friendly; HA force_refresh has no HA-side timeout cap).
+        max_attempts = 14
+        poll_interval = 10
+        fresh_state: dict[str, Any] | None = None
+
+        for attempt in range(1, max_attempts + 1):
+            sleep(poll_interval)
+            response: dict[str, Any] = self.session.get(
+                poll_url, headers=headers
+            ).json()
+            state, last_updated = self._inspect_ccs2_response(response)
+            if (
+                state is not None
+                and last_updated is not None
+                and last_updated.timestamp() > trigger_time
+            ):
+                fresh_state = state
+                _LOGGER.debug(
+                    f"{DOMAIN} - CCS2 force refresh: fresh after {attempt} polls"
+                )
+                break
+
+        if fresh_state is not None:
+            self._apply_ccs2_state(vehicle, fresh_state)
+            self._post_refresh_ccs2_location(token, vehicle)
+        else:
+            _LOGGER.warning(
+                f"{DOMAIN} - CCS2 force refresh: no fresh data after "
+                f"{max_attempts} polls, keeping previous vehicle state"
+            )
 
     @_retry_on_device_id_error
     def start_charge(self, token: Token, vehicle: Vehicle) -> str:

--- a/hyundai_kia_connect_api/KiaUvoApiAU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiAU.py
@@ -231,28 +231,6 @@ class KiaUvoApiAU(ApiImplType1):
             else:
                 self._update_vehicle_drive_info(vehicle, state)
 
-    def _force_refresh_vehicle_state_ccs2(self, token: Token, vehicle: Vehicle) -> None:
-        url = self.SPA_API_URL + "vehicles/" + vehicle.id + "/ccs2/carstatus"
-        response = self.session.get(
-            url,
-            headers=self._get_authenticated_headers(
-                token, vehicle.ccu_ccs2_protocol_support
-            ),
-        ).json()
-        _LOGGER.debug(
-            f"{DOMAIN} - Force refresh CCS2 vehicle status response: {response}"
-        )
-        _check_response_for_errors(response)
-        state = response["resMsg"]["state"]["Vehicle"]
-        self._update_vehicle_properties_ccs2(vehicle, state)
-        location = self._get_location(token, vehicle)
-        if location and get_child_value(location, "coord.lat"):
-            vehicle.location = (
-                get_child_value(location, "coord.lat"),
-                get_child_value(location, "coord.lon"),
-                parse_datetime(get_child_value(location, "time"), self.data_timezone),
-            )
-
     def _update_vehicle_properties(self, vehicle: Vehicle, state: dict) -> None:
         if get_child_value(state, "status.time"):
             vehicle.last_updated_at = parse_datetime(

--- a/hyundai_kia_connect_api/KiaUvoApiCN.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCN.py
@@ -8,6 +8,7 @@ import math
 import typing as ty
 import uuid
 from time import sleep
+from typing import Any
 from urllib.parse import parse_qs, urlparse
 from zoneinfo import ZoneInfo
 
@@ -269,27 +270,31 @@ class KiaUvoApiCN(ApiImplType1):
             else:
                 self._update_vehicle_drive_info(vehicle, state)
 
-    def _force_refresh_vehicle_state_ccs2(self, token: Token, vehicle: Vehicle) -> None:
-        url = self.SPA_API_URL + "vehicles/" + vehicle.id + "/ccs2/carstatus"
-        response = self.session.get(
-            url,
-            headers=self._get_authenticated_headers(
-                token, vehicle.ccu_ccs2_protocol_support
-            ),
-        ).json()
-        _LOGGER.debug(
-            f"{DOMAIN} - Force refresh CCS2 vehicle status response: {response}"
-        )
-        _check_response_for_errors(response)
-        state = response["resMsg"]
-        self._update_vehicle_properties(vehicle, state)
-        location = self._get_location(token, vehicle)
-        if location and get_child_value(location, "coord.lat"):
-            vehicle.location = (
-                get_child_value(location, "coord.lat"),
-                get_child_value(location, "coord.lon"),
-                parse_datetime(get_child_value(location, "time"), self.data_timezone),
+    def _inspect_ccs2_response(
+        self, response: dict[str, Any]
+    ) -> tuple[dict[str, Any] | None, dt.datetime | None]:
+        """CN CCS2 shape: resMsg root + status.time (non-CCS2 lookalike).
+
+        Does NOT call the parser — caller checks freshness before applying.
+        """
+        state = response.get("resMsg")
+        if not isinstance(state, dict):
+            return None, None
+        raw_time = get_child_value(state, "status.time")
+        if not raw_time:
+            return state, None
+        try:
+            last = parse_datetime(str(raw_time), self.data_timezone)
+            return state, last
+        except (ValueError, TypeError):  # fmt: skip
+            _LOGGER.warning(
+                f"{DOMAIN} - CN CCS2 _inspect: cannot parse status.time '{raw_time}'"
             )
+            return state, None
+
+    def _apply_ccs2_state(self, vehicle: Vehicle, state: dict[str, Any]) -> None:
+        """CN uses its own non-CCS2 parser (status.* path)."""
+        self._update_vehicle_properties(vehicle, state)
 
     def _update_vehicle_properties(self, vehicle: Vehicle, state: dict) -> None:
         if get_child_value(state, "status.time"):

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -444,22 +444,6 @@ class KiaUvoApiEU(ApiImplType1):
             else:
                 self._update_vehicle_drive_info(vehicle, state)
 
-    def _force_refresh_vehicle_state_ccs2(self, token: Token, vehicle: Vehicle) -> None:
-        url = self.SPA_API_URL + "vehicles/" + vehicle.id + "/ccs2/carstatus"
-        response = self.session.get(
-            url,
-            headers=self._get_authenticated_headers(
-                token, vehicle.ccu_ccs2_protocol_support
-            ),
-        ).json()
-        _LOGGER.debug(
-            f"{DOMAIN} - Force refresh CCS2 vehicle status response: {response}"
-        )
-        _check_response_for_errors(response)
-        state = response["resMsg"]["state"]["Vehicle"]
-        self._update_vehicle_properties_ccs2(vehicle, state)
-        self._set_cached_location_park(token, vehicle)
-
     def _update_vehicle_properties(self, vehicle: Vehicle, state: dict) -> None:
         if get_child_value(state, "vehicleStatus.time"):
             vehicle.last_updated_at = parse_datetime(
@@ -980,6 +964,10 @@ class KiaUvoApiEU(ApiImplType1):
         else:
             response = response["resMsg"]["state"]["Vehicle"]
         return response
+
+    def _post_refresh_ccs2_location(self, token: Token, vehicle: Vehicle) -> None:
+        """EU CCS2 location refresh uses /location/park endpoint."""
+        self._set_cached_location_park(token, vehicle)
 
     def _set_cached_location_park(self, token: Token, vehicle: Vehicle) -> None:
         url = self.SPA_API_URL + "vehicles/" + vehicle.id + "/location/park"

--- a/hyundai_kia_connect_api/KiaUvoApiIN.py
+++ b/hyundai_kia_connect_api/KiaUvoApiIN.py
@@ -11,6 +11,7 @@ import re
 import time
 import typing as ty
 import uuid
+from typing import Any
 from urllib.parse import parse_qs, urlparse
 from zoneinfo import ZoneInfo
 
@@ -35,7 +36,11 @@ from .const import (
 )
 from .exceptions import AuthenticationError
 from .Token import Token
-from .utils import get_child_value, get_hex_temp_into_index, get_index_into_hex_temp
+from .utils import (
+    get_child_value,
+    get_hex_temp_into_index,
+    get_index_into_hex_temp,
+)
 from .Vehicle import (
     DailyDrivingStats,
     DayTripCounts,
@@ -267,20 +272,31 @@ class KiaUvoApiIN(ApiImplType1):
             else:
                 self._update_vehicle_drive_info(vehicle, state)
 
-    def _force_refresh_vehicle_state_ccs2(self, token: Token, vehicle: Vehicle) -> None:
-        url = self.SPA_API_URL + "vehicles/" + vehicle.id + "/ccs2/carstatus"
-        response = self.session.get(
-            url,
-            headers=self._get_authenticated_headers(
-                token, vehicle.ccu_ccs2_protocol_support
-            ),
-        ).json()
-        _LOGGER.debug(
-            f"{DOMAIN} - Force refresh CCS2 vehicle status response: {response}"
-        )
-        _check_response_for_errors(response)
-        state = response["resMsg"]
+    def _inspect_ccs2_response(
+        self, response: dict[str, Any]
+    ) -> tuple[dict[str, Any] | None, dt.datetime | None]:
+        """IN CCS2 shape: resMsg root + state.time (not state.Vehicle)."""
+        state = response.get("resMsg")
+        if not isinstance(state, dict):
+            return None, None
+        time_val = get_child_value(state, "time")
+        if not time_val:
+            return state, None
+        try:
+            last = self.get_last_updated_at(time_val)
+            return state, last
+        except (ValueError, TypeError):  # fmt: skip
+            _LOGGER.warning(
+                f"{DOMAIN} - IN CCS2 _inspect: cannot parse time '{time_val}'"
+            )
+            return state, None
+
+    def _apply_ccs2_state(self, vehicle: Vehicle, state: dict[str, Any]) -> None:
+        """IN uses its own non-CCS2 parser (state.time / airTemp)."""
         self._update_vehicle_properties(vehicle, state)
+
+    def _post_refresh_ccs2_location(self, token: Token, vehicle: Vehicle) -> None:
+        """IN location refresh via _update_vehicle_location helper."""
         location = self._get_location(token, vehicle)
         self._update_vehicle_location(vehicle, location)
 

--- a/tests/test_au_ccs2_force_refresh.py
+++ b/tests/test_au_ccs2_force_refresh.py
@@ -1,0 +1,104 @@
+"""AU CCS2 force_refresh uses base impl (state.Vehicle + Date UTC + park location)."""
+
+import datetime as dt
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hyundai_kia_connect_api.KiaUvoApiAU import KiaUvoApiAU
+from hyundai_kia_connect_api.Token import Token
+from hyundai_kia_connect_api.Vehicle import Vehicle
+from hyundai_kia_connect_api.const import DISTANCE_UNITS, ENGINE_TYPES
+
+
+@pytest.fixture
+def au_api():
+    return KiaUvoApiAU(region=2, brand=2, language="en")
+
+
+@pytest.fixture
+def ccs2_vehicle():
+    v = Vehicle()
+    v.id = "test-vehicle-id"
+    v.engine_type = ENGINE_TYPES.PHEV
+    v.ccu_ccs2_protocol_support = 1
+    v.distance_unit = DISTANCE_UNITS[1]
+    return v
+
+
+@pytest.fixture
+def token():
+    t = Token()
+    t.access_token = "Bearer test"
+    t.pin = "1234"
+    t.device_id = "dev"
+    return t
+
+
+def test_au_force_refresh_uses_base_hooks(au_api, token, ccs2_vehicle):
+    """AU inherits base _inspect + _apply + _post_refresh hooks (no override).
+
+    Before override removal: AU's stale _force_refresh_vehicle_state_ccs2 calls
+    _update_vehicle_properties_ccs2 directly and inlines location, so the base
+    hooks _apply_ccs2_state / _post_refresh_ccs2_location are NOT called.
+    After removal: base impl calls both hooks once each.
+    """
+    fresh_date = (dt.datetime.now(dt.timezone.utc) + dt.timedelta(seconds=10)).strftime(
+        "%Y%m%d%H%M%S"
+    )
+
+    def mock_get(url, **kwargs):
+        resp = MagicMock()
+        if url.endswith("/ccs2/carstatus") and not url.endswith("/latest"):
+            resp.json.return_value = {"retCode": "S", "resCode": "0000"}
+        else:
+            resp.json.return_value = {
+                "retCode": "S",
+                "resMsg": {"state": {"Vehicle": {"Date": fresh_date}}},
+            }
+        return resp
+
+    with (
+        patch.object(au_api.session, "get", side_effect=mock_get),
+        patch("hyundai_kia_connect_api.ApiImplType1.sleep"),
+        # create=True so the patch works both while AU still imports sleep
+        # (override path) and after the import is removed (base path).
+        patch("hyundai_kia_connect_api.KiaUvoApiAU.sleep", create=True),
+        patch.object(au_api, "_apply_ccs2_state") as mock_apply,
+        patch.object(au_api, "_update_vehicle_properties_ccs2"),
+        patch.object(au_api, "_post_refresh_ccs2_location") as mock_loc,
+    ):
+        au_api._force_refresh_vehicle_state_ccs2(token, ccs2_vehicle)
+
+    # Base impl calls _apply_ccs2_state (which delegates to _update_vehicle_properties_ccs2).
+    # The stale AU override called _update_vehicle_properties_ccs2 directly, bypassing
+    # the _apply hook — so mock_apply.assert_called_once() is the RED/GREEN signal.
+    mock_apply.assert_called_once()
+    mock_loc.assert_called_once()
+
+
+def test_au_post_refresh_location_uses_base_get_location(au_api, token, ccs2_vehicle):
+    """AU inherits base _post_refresh_ccs2_location: _get_location + inline set.
+
+    Span-task coverage: the base default _post_refresh_ccs2_location lost its
+    direct test when EU overrode it (Task 4). AU inherits the base default, so
+    this test verifies _get_location is called and vehicle.location is set from
+    its coord.lat / coord.lon / time fields.
+    """
+    loc_time = "20260701120000"
+    loc_response = {
+        "coord": {"lat": -33.86, "lon": 151.21},
+        "time": loc_time,
+    }
+
+    with patch.object(au_api, "_get_location", return_value=loc_response):
+        au_api._post_refresh_ccs2_location(token, ccs2_vehicle)
+
+    expected_lat = -33.86
+    expected_lon = 151.21
+    expected_time = dt.datetime(2026, 7, 1, 12, 0, 0, tzinfo=au_api.data_timezone)
+    # Vehicle.location getter returns (lon, lat); setter takes (lat, lon, time)
+    assert ccs2_vehicle.location == (expected_lon, expected_lat)
+    assert ccs2_vehicle.location_latitude == expected_lat
+    assert ccs2_vehicle.location_longitude == expected_lon
+    assert ccs2_vehicle.location_last_updated_at == expected_time

--- a/tests/test_cn_force_refresh_nonccs2.py
+++ b/tests/test_cn_force_refresh_nonccs2.py
@@ -1,0 +1,122 @@
+"""CN force_refresh: non-CCS2 path + CCS2 path via base hooks (resMsg root)."""
+
+import datetime as dt
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hyundai_kia_connect_api.KiaUvoApiCN import KiaUvoApiCN
+from hyundai_kia_connect_api.Token import Token
+from hyundai_kia_connect_api.Vehicle import Vehicle
+from hyundai_kia_connect_api.const import ENGINE_TYPES
+
+
+@pytest.fixture
+def cn_api():
+    return KiaUvoApiCN(region=4, brand=2, language="en")
+
+
+@pytest.fixture
+def nonccs2_vehicle():
+    v = Vehicle()
+    v.id = "test-vid"
+    v.engine_type = ENGINE_TYPES.PHEV
+    # NOTE: real CN vehicles never populate ccu_ccs2_protocol_support, so the
+    # flag stays at its default None (not 0). Base is_ccs2 check is `flag != 0`
+    # -> None != 0 is True -> CCS2 path IS invoked, and the CN hooks
+    # (_inspect_ccs2_response / _apply_ccs2_state) handle the resMsg-root shape.
+    # This fixture pins flag=0 to characterize the genuine non-CCS2 sub-case.
+    v.ccu_ccs2_protocol_support = 0
+    return v
+
+
+@pytest.fixture
+def ccs2_vehicle():
+    """Real-world CN default: ccu_ccs2_protocol_support is None (not 0).
+
+    `None != 0` is True -> CCS2 path invoked. CN hooks parse resMsg root.
+    """
+    v = Vehicle()
+    v.id = "test-vid"
+    v.engine_type = ENGINE_TYPES.PHEV
+    v.ccu_ccs2_protocol_support = None
+    return v
+
+
+@pytest.fixture
+def token():
+    t = Token()
+    t.access_token = "Bearer test"
+    t.pin = "1234"
+    t.device_id = "dev"
+    return t
+
+
+def test_cn_nonccs2_force_refresh_does_not_call_ccs2(cn_api, token, nonccs2_vehicle):
+    """CN force_refresh on non-CCS2 vehicle uses _get_forced_vehicle_state, not ccs2."""
+    with (
+        patch.object(cn_api, "_force_refresh_vehicle_state_ccs2") as mock_ccs2,
+        patch.object(cn_api, "_get_forced_vehicle_state", return_value={}),
+        patch.object(cn_api, "_get_location", return_value=None),
+        patch.object(cn_api, "_update_vehicle_properties"),
+        patch.object(cn_api, "_get_driving_info", side_effect=Exception),
+    ):
+        cn_api.force_refresh_vehicle_state(token, nonccs2_vehicle)
+    mock_ccs2.assert_not_called()
+
+
+def test_cn_inspect_ccs2_response_resmsg_root(cn_api):
+    """CN _inspect reads resMsg root + status.time (not state.Vehicle)."""
+    response = {
+        "retCode": "S",
+        "resMsg": {"status": {"time": "20260101120010", "engine": False}},
+    }
+    state, last_updated = cn_api._inspect_ccs2_response(response)
+    assert state == {"status": {"time": "20260101120010", "engine": False}}
+    assert last_updated is not None
+    assert last_updated.tzinfo is not None
+
+
+def test_cn_force_refresh_uses_cn_hooks(cn_api, token, ccs2_vehicle):
+    """CN CCS2 force_refresh uses base polling loop + CN hooks (not CCS2 parser).
+
+    Reproduces the real-world CN scenario: ccu_ccs2_protocol_support=None ->
+    CCS2 path invoked. The base _force_refresh_vehicle_state_ccs2 polls
+    /ccs2/carstatus/latest and calls _inspect_ccs2_response (CN hook) until
+    fresh, then _apply_ccs2_state (CN hook -> _update_vehicle_properties,
+    the non-CCS2 parser). Location is refreshed via the base default
+    _post_refresh_ccs2_location (CN _get_location returns resMsg, which
+    matches the base default coord.lat/lon/time unpacking).
+    """
+    # NOTE: CN parse_datetime(status.time, data_timezone) treats the string as
+    # Asia/Shanghai wall-clock (UTC+8). If the string represents UTC wall-clock,
+    # the resulting epoch is off by -8h vs UTC. Use +9h to keep
+    # last_updated.timestamp() > trigger_time despite the tz interpretation.
+    # Production risk: if the CN server returns status.time in UTC, every
+    # force-refresh will timeout (deferred to live dump).
+    fresh_time = (dt.datetime.now(dt.timezone.utc) + dt.timedelta(hours=9)).strftime(
+        "%Y%m%d%H%M%S"
+    )
+
+    def mock_get(url, **kwargs):
+        resp = MagicMock()
+        if url.endswith("/ccs2/carstatus") and not url.endswith("/latest"):
+            resp.json.return_value = {"retCode": "S", "resCode": "0000"}
+        else:
+            resp.json.return_value = {
+                "retCode": "S",
+                "resMsg": {"status": {"time": fresh_time, "engine": False}},
+            }
+        return resp
+
+    with (
+        patch.object(cn_api.session, "get", side_effect=mock_get),
+        patch("hyundai_kia_connect_api.ApiImplType1.sleep"),
+        patch.object(cn_api, "_update_vehicle_properties") as mock_cn_parser,
+        patch.object(cn_api, "_update_vehicle_properties_ccs2") as mock_ccs2_parser,
+        patch.object(cn_api, "_get_location", return_value=None),
+    ):
+        cn_api._force_refresh_vehicle_state_ccs2(token, ccs2_vehicle)
+
+    mock_cn_parser.assert_called_once()
+    mock_ccs2_parser.assert_not_called()

--- a/tests/test_eu_ccs2_force_refresh.py
+++ b/tests/test_eu_ccs2_force_refresh.py
@@ -1,0 +1,201 @@
+"""Tests for CCS2 force_refresh_vehicle_state polling loop.
+
+CCS2 force refresh: trigger /ccs2/carstatus, then poll /latest
+until Date > trigger_time, max 10 attempts × 2s.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from hyundai_kia_connect_api.KiaUvoApiEU import KiaUvoApiEU
+from hyundai_kia_connect_api.Token import Token
+from hyundai_kia_connect_api.Vehicle import Vehicle
+from hyundai_kia_connect_api.const import DISTANCE_UNITS, ENGINE_TYPES
+
+
+@pytest.fixture
+def eu_api():
+    return KiaUvoApiEU(region=1, brand=2, language="en")
+
+
+@pytest.fixture
+def ccs2_vehicle():
+    v = Vehicle()
+    v.id = "test-vehicle-id"
+    v.engine_type = ENGINE_TYPES.PHEV
+    v.ccu_ccs2_protocol_support = 1
+    v.distance_unit = DISTANCE_UNITS[1]  # km
+    return v
+
+
+@pytest.fixture
+def token():
+    t = Token()
+    t.access_token = "Bearer test-access-token"
+    t.pin = "1234"
+    t.device_id = "test-device-id"
+    return t
+
+
+def test_force_refresh_polls_until_fresh(eu_api, token, ccs2_vehicle):
+    """Trigger + poll until last_updated > trigger_time, then apply."""
+    import datetime as dt
+
+    fresh_date = (dt.datetime.now(dt.timezone.utc) + dt.timedelta(seconds=10)).strftime(
+        "%Y%m%d%H%M%S"
+    )
+    call_log = []
+
+    def mock_get(url, **kwargs):
+        resp = MagicMock()
+        if url.endswith("/ccs2/carstatus") and not url.endswith("/latest"):
+            call_log.append(("trigger", url))
+            resp.json.return_value = {"retCode": "S", "resCode": "0000"}
+        else:
+            call_log.append(("poll", url))
+            resp.json.return_value = {
+                "retCode": "S",
+                "resMsg": {"state": {"Vehicle": {"Date": fresh_date}}},
+            }
+        return resp
+
+    with (
+        patch.object(eu_api.session, "get", side_effect=mock_get),
+        patch("hyundai_kia_connect_api.ApiImplType1.sleep"),
+        patch.object(eu_api, "_apply_ccs2_state") as mock_apply,
+        patch.object(eu_api, "_post_refresh_ccs2_location") as mock_loc,
+    ):
+        eu_api._force_refresh_vehicle_state_ccs2(token, ccs2_vehicle)
+
+    assert len([c for c in call_log if c[0] == "trigger"]) == 1
+    assert len([c for c in call_log if c[0] == "poll"]) >= 1
+    mock_apply.assert_called_once()
+    mock_loc.assert_called_once()
+
+
+def test_force_refresh_timeout_keeps_previous_state(eu_api, token, ccs2_vehicle):
+    """On timeout (all polls stale), _apply_ccs2_state NOT called, state untouched."""
+    stale_date = "20200101120000"  # past -> never > trigger_time
+    ccs2_vehicle.odometer = (12345, 1)  # pre-existing state
+
+    def mock_get(url, **kwargs):
+        resp = MagicMock()
+        if url.endswith("/ccs2/carstatus") and not url.endswith("/latest"):
+            resp.json.return_value = {"retCode": "S", "resCode": "0000"}
+        else:
+            resp.json.return_value = {
+                "retCode": "S",
+                "resMsg": {"state": {"Vehicle": {"Date": stale_date}}},
+            }
+        return resp
+
+    with (
+        patch.object(eu_api.session, "get", side_effect=mock_get),
+        patch("hyundai_kia_connect_api.ApiImplType1.sleep"),
+        patch.object(eu_api, "_apply_ccs2_state") as mock_apply,
+        patch.object(eu_api, "_post_refresh_ccs2_location") as mock_loc,
+    ):
+        eu_api._force_refresh_vehicle_state_ccs2(token, ccs2_vehicle)
+
+    mock_apply.assert_not_called()  # HA: do not mask stale
+    mock_loc.assert_not_called()
+    assert ccs2_vehicle.odometer == 12345  # untouched
+
+
+def test_force_refresh_budget_14_polls_10s(eu_api, token, ccs2_vehicle):
+    """Budget is 14 polls × 10s (~140s window, matches app controlRetrofit
+    readTimeout = backend max wake-to-report)."""
+    stale_date = "20200101120000"
+    sleep_calls = []
+
+    def mock_get(url, **kwargs):
+        resp = MagicMock()
+        if url.endswith("/ccs2/carstatus") and not url.endswith("/latest"):
+            resp.json.return_value = {"retCode": "S", "resCode": "0000"}
+        else:
+            resp.json.return_value = {
+                "retCode": "S",
+                "resMsg": {"state": {"Vehicle": {"Date": stale_date}}},
+            }
+        return resp
+
+    def mock_sleep(secs):
+        sleep_calls.append(secs)
+
+    with (
+        patch.object(eu_api.session, "get", side_effect=mock_get),
+        patch("hyundai_kia_connect_api.ApiImplType1.sleep", side_effect=mock_sleep),
+        patch.object(eu_api, "_apply_ccs2_state"),
+        patch.object(eu_api, "_post_refresh_ccs2_location"),
+    ):
+        eu_api._force_refresh_vehicle_state_ccs2(token, ccs2_vehicle)
+
+    assert len(sleep_calls) == 14
+    assert all(s == 10 for s in sleep_calls)
+
+
+def test_eu_post_refresh_location_uses_park_endpoint(eu_api, token, ccs2_vehicle):
+    """EU _post_refresh_ccs2_location delegates to _set_cached_location_park,
+    NOT base _get_location."""
+    with (
+        patch.object(eu_api, "_set_cached_location_park") as mock_park,
+        patch.object(eu_api, "_get_location") as mock_get_loc,
+    ):
+        eu_api._post_refresh_ccs2_location(token, ccs2_vehicle)
+    mock_park.assert_called_once_with(token, ccs2_vehicle)
+    mock_get_loc.assert_not_called()
+
+
+def test_inspect_ccs2_response_eu_default(eu_api):
+    """Base _inspect_ccs2_response extracts state.Vehicle + Date as UTC datetime."""
+    from datetime import datetime
+
+    # Date 20260101120010 UTC = 13:00:10 CET (Europe/Berlin, +1 winter)
+    response = {
+        "retCode": "S",
+        "resMsg": {"state": {"Vehicle": {"Date": "20260101120010"}}},
+    }
+    state, last_updated = eu_api._inspect_ccs2_response(response)
+    assert state == {"Date": "20260101120010"}
+    assert last_updated == datetime(2026, 1, 1, 13, 0, 10, tzinfo=eu_api.data_timezone)
+
+
+def test_inspect_ccs2_response_missing_state(eu_api):
+    """Missing resMsg.state.Vehicle -> (None, None), no exception."""
+    state, last_updated = eu_api._inspect_ccs2_response({"retCode": "S"})
+    assert state is None
+    assert last_updated is None
+
+
+def test_inspect_ccs2_response_unparseable_date(eu_api):
+    """Bad Date -> (state, None), no exception, state preserved."""
+    response = {
+        "retCode": "S",
+        "resMsg": {"state": {"Vehicle": {"Date": "not-a-date"}}},
+    }
+    state, last_updated = eu_api._inspect_ccs2_response(response)
+    assert state == {"Date": "not-a-date"}
+    assert last_updated is None
+
+
+def test_inspect_ccs2_response_date_with_ms_suffix(eu_api):
+    """Date '20260101120010.000' parsed same as without suffix."""
+    response = {
+        "retCode": "S",
+        "resMsg": {"state": {"Vehicle": {"Date": "20260101120010.000"}}},
+    }
+    state, last_updated = eu_api._inspect_ccs2_response(response)
+    assert state == {"Date": "20260101120010.000"}
+    from datetime import datetime
+
+    assert last_updated == datetime(2026, 1, 1, 13, 0, 10, tzinfo=eu_api.data_timezone)
+
+
+def test_apply_ccs2_state_eu_default_calls_parser(eu_api, token, ccs2_vehicle):
+    """Base _apply_ccs2_state delegates to _update_vehicle_properties_ccs2."""
+    from unittest.mock import patch
+
+    state = {"Date": "20260101120010", "Drivetrain": {}}
+    with patch.object(eu_api, "_update_vehicle_properties_ccs2") as mock_parser:
+        eu_api._apply_ccs2_state(ccs2_vehicle, state)
+    mock_parser.assert_called_once_with(ccs2_vehicle, state)

--- a/tests/test_in_ccs2_force_refresh.py
+++ b/tests/test_in_ccs2_force_refresh.py
@@ -1,0 +1,76 @@
+"""IN CCS2 force_refresh: resMsg root + state.time (IN-specific shape)."""
+
+import datetime as dt
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hyundai_kia_connect_api.KiaUvoApiIN import KiaUvoApiIN
+from hyundai_kia_connect_api.Token import Token
+from hyundai_kia_connect_api.Vehicle import Vehicle
+from hyundai_kia_connect_api.const import DISTANCE_UNITS, ENGINE_TYPES
+
+
+@pytest.fixture
+def in_api():
+    return KiaUvoApiIN(brand=2)
+
+
+@pytest.fixture
+def ccs2_vehicle():
+    v = Vehicle()
+    v.id = "test-vid"
+    v.engine_type = ENGINE_TYPES.EV
+    v.ccu_ccs2_protocol_support = 1
+    v.distance_unit = DISTANCE_UNITS[1]
+    return v
+
+
+@pytest.fixture
+def token():
+    t = Token()
+    t.access_token = "Bearer test"
+    t.pin = "1234"
+    t.device_id = "dev"
+    return t
+
+
+def test_in_inspect_ccs2_response_resmsg_root(in_api):
+    """IN _inspect reads resMsg root + state.time (not state.Vehicle)."""
+    response = {"retCode": "S", "resMsg": {"time": "20260101120010", "engine": False}}
+    state, last_updated = in_api._inspect_ccs2_response(response)
+    assert state == {"time": "20260101120010", "engine": False}
+    assert last_updated is not None
+    assert last_updated.tzinfo is not None
+
+
+def test_in_force_refresh_applies_via_in_parser(in_api, token, ccs2_vehicle):
+    """IN force_refresh uses IN _update_vehicle_properties (not CCS2 parser)."""
+    # NOTE: IN get_last_updated_at parses the string treating wall-clock fields
+    # as data_timezone (India, UTC+5:30), so .timestamp() is offset by -5:30 vs
+    # UTC. Use +6h to keep last_updated.timestamp() > trigger_time despite the
+    # tz interpretation. See task-6 report for details.
+    fresh_time = (dt.datetime.now(dt.timezone.utc) + dt.timedelta(hours=6)).strftime(
+        "%Y%m%d%H%M%S"
+    )
+
+    def mock_get(url, **kwargs):
+        resp = MagicMock()
+        if url.endswith("/ccs2/carstatus") and not url.endswith("/latest"):
+            resp.json.return_value = {"retCode": "S", "resCode": "0000"}
+        else:
+            resp.json.return_value = {
+                "retCode": "S",
+                "resMsg": {"time": fresh_time, "engine": False},
+            }
+        return resp
+
+    with (
+        patch.object(in_api.session, "get", side_effect=mock_get),
+        patch("hyundai_kia_connect_api.ApiImplType1.sleep"),
+        patch.object(in_api, "_update_vehicle_properties") as mock_in_parser,
+        patch.object(in_api, "_update_vehicle_location"),
+    ):
+        in_api._force_refresh_vehicle_state_ccs2(token, ccs2_vehicle)
+
+    mock_in_parser.assert_called_once()


### PR DESCRIPTION
## Problem

`_force_refresh_vehicle_state_ccs2()` (EU/AU/IN/CN) calls `GET /ccs2/carstatus` — the **wake** endpoint (no `/latest`) — and reads `response["resMsg"]["state"]["Vehicle"]` synchronously. That endpoint returns an async command envelope `{retCode, resCode, msgId}`, **not** vehicle state, so it raises `KeyError: 'resMsg'` every time Force Refresh is triggered. Reported in kia_uvo #1786 (3.7.0/3.7.1) and again in **kia_uvo #1806** (IONIQ 5, CCS2, kia_uvo 3.8.0 / hyundai_kia_connect_api 4.25.2 — i.e. still present in the current release). The prior cached-only path (`/latest`) returned stale data and never woke the car.

## Solution

Trigger + poll, refactored into base `ApiImplType1` with 3 polymorphic hooks so EU/AU/IN/CN share one loop:

1. **Trigger** — `GET /ccs2/carstatus` (no `/latest`) wakes the vehicle (same request the current code already makes).
2. **Poll** — `GET /ccs2/carstatus/latest` every 10s, max 14 attempts (~140s window) via `_inspect_ccs2_response`. **Early-exit on fresh** — stops the moment `last_updated > trigger_time`.
3. **Freshness** — apply state only when `last_updated > trigger_time` (HA: do not mask stale).
4. **Timeout** — if no fresh data after 14 polls (~140s), keep previous vehicle state untouched + warning log (no stale masking).
5. **Location** — `_post_refresh_ccs2_location` after a successful refresh.

The **logic and timing mirror what the official app already does**: wake the vehicle, then receive fresh status. The lib polls `/latest` as the HTTP equivalent of that status delivery, with the same ~140s upper bound the app allows for a slow/deep-sleep car to report, and a 10s poll cadence. (All requests use the access token — no PIN/control token per poll.)

## Request budget vs current code (acceptability)

Current code (master / 4.25.2): **1 GET** `/ccs2/carstatus` → `KeyError` (no fresh data returned).

This PR: 1 trigger GET (same as today) + N poll GETs on `/latest`:

| Scenario | Extra GETs vs today | Total | Wall-clock |
|---|---|---|---|
| **Typical (car reachable)** | **+2** | 3 (1 trigger + 2 polls) | ~20s, then early-exit |
| **Max (car unreachable / deep-sleep)** | **+14** | 15 (1 trigger + 14 polls) | ~140s, then timeout |

- **Typical +2 requests** is the actual cost of returning fresh data — today the call returns none (it crashes). The loop stops the instant fresh data arrives (early-exit), so a reachable car costs 2 polls and ~20s, full stop.
- **Max +14 requests** only occurs when the car cannot report at all (the case where today's code fails immediately anyway). 14 polls spread over ~140s = **~0.11 req/s** — a gentle cadence far below any server rate limit; on timeout it keeps the previous state (defined, bounded retry) instead of raising `KeyError`.
- The ~140s cap and 10s cadence match the app's own timing for a slow-to-report vehicle, so the upper bound is not a number invented here — it's what the app already tolerates.

### Hooks per region

| Region | `_inspect_ccs2_response` | `_apply_ccs2_state` | `_post_refresh_ccs2_location` |
|---|---|---|---|
| EU | base (`resMsg.state.Vehicle` + `Date` UTC) | base (CCS2 parser) | override (`/location/park`) |
| AU | base (inherits) | base (inherits) | base (`_get_location` + inline) |
| IN | override (`resMsg` root + `state.time`) | override (IN parser) | override (`_update_vehicle_location`) |
| CN | override (`resMsg` root + `status.time`) | override (CN parser) | base (inherits) |

## Files changed

- `ApiImplType1.py` — base `_force_refresh_vehicle_state_ccs2` + 3 hooks
- `KiaUvoApiEU.py` — remove old override, add `_post_refresh_ccs2_location` (park)
- `KiaUvoApiAU.py` — remove old override (inherits base)
- `KiaUvoApiIN.py` — `_inspect` + `_apply` + `_post_refresh` hooks
- `KiaUvoApiCN.py` — `_inspect` + `_apply` hooks
- `tests/test_{eu,au,in}_ccs2_force_refresh.py`, `tests/test_cn_force_refresh_nonccs2.py` — 4 new test files

## Testing

- Unit tests pass for the polling loop (fresh, timeout-keeps-previous-state, budget 14×10s), hooks, EU park-location, IN resMsg-root, AU inheritance, CN hooks + non-CCS2 characterization.
- **Live-validated on EU Hyundai Santa Fe 2026 (CCS2), car reachable**: trigger a state change (lock, 0.4s) → `force_refresh_vehicle_state` → **fresh `Date > trigger_time` detected after 2 polls = 20.7s** (early-exit; the 140s window is unused for the typical reachable case). State applied.
- IN/CN timezone interpretation of `status.time`/`state.time` is pre-existing and documented in the tests; deferred pending a dump confirming UTC vs wall-clock.

Rebased onto current upstream/master (`65b4464`), 1 commit. Fixes kia_uvo #1786 and the newly-filed duplicate kia_uvo #1806.