### PR TITLE
fix(USA): use GET for action status polling

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
@@ -885,7 +885,7 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
         max_attempts = 1 if not synchronous else max(1, timeout // 2)
 
         for _ in range(max_attempts):
-            response = self.sessions.post(url, headers=headers)
+            response = self.sessions.get(url, headers=headers)
             response_json = _safe_parse_json(response, "check_action_status")
             if response_json is None:
                 if not synchronous:

--- a/tests/us_action_status_test.py
+++ b/tests/us_action_status_test.py
@@ -50,7 +50,7 @@ def _make_api():
 class TestCheckActionStatus:
     def test_success(self):
         api = _make_api()
-        api.sessions.post.return_value = _FakeResponse(json_data={"status": "SUCCESS"})
+        api.sessions.get.return_value = _FakeResponse(json_data={"status": "SUCCESS"})
         vehicle = _make_vehicle()
         token = _make_token()
 
@@ -61,7 +61,7 @@ class TestCheckActionStatus:
 
     def test_failed(self):
         api = _make_api()
-        api.sessions.post.return_value = _FakeResponse(json_data={"status": "ERROR"})
+        api.sessions.get.return_value = _FakeResponse(json_data={"status": "ERROR"})
         vehicle = _make_vehicle()
         token = _make_token()
 
@@ -72,7 +72,7 @@ class TestCheckActionStatus:
 
     def test_pending(self):
         api = _make_api()
-        api.sessions.post.return_value = _FakeResponse(json_data={"status": "PENDING"})
+        api.sessions.get.return_value = _FakeResponse(json_data={"status": "PENDING"})
         vehicle = _make_vehicle()
         token = _make_token()
 
@@ -83,7 +83,7 @@ class TestCheckActionStatus:
 
     def test_empty_response_returns_unknown(self):
         api = _make_api()
-        api.sessions.post.return_value = _FakeResponse(json_data=None)
+        api.sessions.get.return_value = _FakeResponse(json_data=None)
         vehicle = _make_vehicle()
         token = _make_token()
 
@@ -94,7 +94,7 @@ class TestCheckActionStatus:
 
     def test_synchronous_timeout(self):
         api = _make_api()
-        api.sessions.post.return_value = _FakeResponse(json_data={"status": "PENDING"})
+        api.sessions.get.return_value = _FakeResponse(json_data={"status": "PENDING"})
         vehicle = _make_vehicle()
         token = _make_token()
 
@@ -108,7 +108,7 @@ class TestCheckActionStatus:
 
     def test_synchronous_success(self):
         api = _make_api()
-        api.sessions.post.return_value = _FakeResponse(json_data={"status": "SUCCESS"})
+        api.sessions.get.return_value = _FakeResponse(json_data={"status": "SUCCESS"})
         vehicle = _make_vehicle()
         token = _make_token()
 


### PR DESCRIPTION
## Summary

Fixes the HTTP 405 Method Not Allowed error on action status polling reported in #1167 after PR #1180.

## Root cause

`check_action_status` polled `/ac/v2/rmt/getRunningStatus` with **POST**. The native myHyundai iOS app (captured by @ijojog in #1167) uses **GET**:

```
GET https://api.telematics.hyundaiusa.com/ac/v2/rmt/getRunningStatus
```

The server rejects POST with HTTP 405. The endpoint name (`getRunningStatus`) also indicates GET.

## Why it was masked

This affected **all** USA action polling (lock, climate, charge, horn, hazard), not just horn/hazard. It was masked for lock/climate/charge because the kia_uvo coordinator catches polling exceptions silently — the action command itself succeeds, so users never noticed the polling failure. Horn/hazard surfaced it because the issue reporter captured the native app traffic and tested specifically.

## Fix

Change `self.sessions.post` → `self.sessions.get` in `check_action_status`. The `service_type` mapping from #1180 stays — those values (`HORN_AND_LIGHTS`, `LIGHTS_ONLY`, `REMOTE_POLL`) are correct per the capture; only the HTTP method was wrong.

## Testing

- Updated `us_action_status_test.py` to mock `sessions.get`
- All 182 unit tests pass
- @ijojog: needs retest to confirm polling now returns SUCCESS/PENDING instead of 405

Ref #1167