### PR TITLE
fix(EU/AU/IN/CN): resolve drvSeatLoc dynamically instead of hardcoded R

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -965,6 +965,25 @@ class ApiImplType1(ApiImpl):
         token.device_id = self._get_device_id(self._get_stamp())
         return response["msgId"]
 
+    def _get_drv_seat_loc(self, vehicle: Vehicle) -> str:
+        """Return the driver seat location for CCS2 climate payloads.
+
+        "L" for LHD (left-hand drive), "R" for RHD (right-hand drive).
+        Derived from the vehicle's reported odometer unit: mile-based markets
+        (UK, Ireland) are RHD, kilometre-based markets are LHD.
+
+        This base implementation covers EU and CN. RHD regions that use
+        kilometres (AU, IN) override this method to return "R" directly,
+        because the km/miles signal would incorrectly resolve to "L".
+
+        Falls back to "L" when the odometer unit is unavailable (e.g. the
+        cached state response did not include it), which is correct for the
+        LHD majority of EU/CN markets.
+        """
+        if vehicle.odometer_unit in (DISTANCE_UNITS[2], DISTANCE_UNITS[3]):
+            return "R"
+        return "L"
+
     def start_climate(
         self, token: Token, vehicle: Vehicle, options: ClimateRequestOptions
     ) -> str:
@@ -1020,7 +1039,7 @@ class ApiImplType1(ApiImpl):
                 "hvacTempType": 1,
                 "hvacTemp": options.set_temp,
                 "sideRearMirrorHeating": 1,
-                "drvSeatLoc": "R",
+                "drvSeatLoc": self._get_drv_seat_loc(vehicle),
                 "seatClimateInfo": {
                     "drvSeatClimateState": options.front_left_seat,
                     "psgSeatClimateState": options.front_right_seat,

--- a/hyundai_kia_connect_api/KiaUvoApiAU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiAU.py
@@ -662,6 +662,10 @@ class KiaUvoApiAU(ApiImplType1):
         if response["resMsg"] is not None:
             return response["resMsg"]
 
+    def _get_drv_seat_loc(self, vehicle: Vehicle) -> str:
+        """Australia uses RHD vehicles regardless of the odometer unit."""
+        return "R"
+
     def _get_trip_info(
         self,
         token: Token,

--- a/hyundai_kia_connect_api/KiaUvoApiIN.py
+++ b/hyundai_kia_connect_api/KiaUvoApiIN.py
@@ -827,6 +827,10 @@ class KiaUvoApiIN(ApiImplType1):
 
             vehicle.month_trip_info = result
 
+    def _get_drv_seat_loc(self, vehicle: Vehicle) -> str:
+        """India uses RHD vehicles regardless of the odometer unit."""
+        return "R"
+
     def update_day_trip_info(
         self,
         token,

--- a/tests/test_drv_seat_loc.py
+++ b/tests/test_drv_seat_loc.py
@@ -1,0 +1,105 @@
+"""Tests for CCS2 drvSeatLoc resolution (LHD vs RHD).
+
+`start_climate` on the CCS2 path sends a `drvSeatLoc` field ("L" or "R") that
+tells the car which side the driver seat is on. Previously this was hardcoded
+to "R", which is wrong for the LHD majority of EU/CN. It is now resolved per
+region:
+
+- Base ``ApiImplType1._get_drv_seat_loc`` uses the vehicle's odometer unit:
+  mile-based markets (UK, Ireland) -> "R", kilometre-based -> "L".
+- ``KiaUvoApiAU`` and ``KiaUvoApiIN`` override to always return "R" because
+  AU/IN are RHD despite using kilometres.
+- EU and CN use the base implementation.
+
+Mirrors egmp-bluelink-scriptable: ``europe.ts`` uses
+``distanceUnit === 'mi' ? 'R' : 'L'`` while ``australia.ts`` hardcodes
+``drvSeatLoc: 'R'``.
+"""
+
+import pytest
+
+from hyundai_kia_connect_api.ApiImplType1 import ApiImplType1
+from hyundai_kia_connect_api.KiaUvoApiAU import KiaUvoApiAU
+from hyundai_kia_connect_api.KiaUvoApiIN import KiaUvoApiIN
+from hyundai_kia_connect_api.const import DISTANCE_UNITS
+from hyundai_kia_connect_api.Vehicle import Vehicle
+
+
+@pytest.fixture
+def vehicle():
+    v = Vehicle()
+    v.id = "test-vehicle-id"
+    return v
+
+
+def _set_km(v: Vehicle) -> Vehicle:
+    v._odometer_unit = DISTANCE_UNITS[1]  # "km"
+    return v
+
+
+def _set_miles(v: Vehicle) -> Vehicle:
+    v._odometer_unit = DISTANCE_UNITS[2]  # "mi"
+    return v
+
+
+def _set_unit_none(v: Vehicle) -> Vehicle:
+    v._odometer_unit = None
+    return v
+
+
+class TestBaseDrvSeatLoc:
+    """Base ApiImplType1 (used by EU and CN)."""
+
+    def setup_method(self):
+        self.api = ApiImplType1()
+
+    def test_kilometres_resolves_to_lhd(self, vehicle):
+        assert self.api._get_drv_seat_loc(_set_km(vehicle)) == "L"
+
+    def test_miles_resolves_to_rhd(self, vehicle):
+        assert self.api._get_drv_seat_loc(_set_miles(vehicle)) == "R"
+
+    def test_miles_unit_3_also_resolves_to_rhd(self, vehicle):
+        vehicle._odometer_unit = DISTANCE_UNITS[3]  # "mi"
+        assert self.api._get_drv_seat_loc(vehicle) == "R"
+
+    def test_missing_unit_falls_back_to_lhd(self, vehicle):
+        """odometer_unit can be None when the cached state response omits it.
+
+        LHD is the correct fallback for the EU/CN majority.
+        """
+        assert self.api._get_drv_seat_loc(_set_unit_none(vehicle)) == "L"
+
+
+class TestAUDrvSeatLoc:
+    """AU is RHD despite using kilometres — must always return "R"."""
+
+    def setup_method(self):
+        # region=5 (Australia), brand=2 (Hyundai)
+        self.api = KiaUvoApiAU(region=5, brand=2, language="en")
+
+    def test_au_kilometres_still_rhd(self, vehicle):
+        assert self.api._get_drv_seat_loc(_set_km(vehicle)) == "R"
+
+    def test_au_miles_still_rhd(self, vehicle):
+        assert self.api._get_drv_seat_loc(_set_miles(vehicle)) == "R"
+
+    def test_au_missing_unit_still_rhd(self, vehicle):
+        assert self.api._get_drv_seat_loc(_set_unit_none(vehicle)) == "R"
+
+
+class TestINDrvSeatLoc:
+    """IN is RHD despite using kilometres — must always return "R"."""
+
+    def setup_method(self):
+        # brand=2 (Hyundai)
+        self.api = KiaUvoApiIN(brand=2)
+
+    def test_in_kilometres_still_rhd(self, vehicle):
+        assert self.api._get_drv_seat_loc(_set_km(vehicle)) == "R"
+
+    def test_in_miles_still_rhd(self, vehicle):
+        assert self.api._get_drv_seat_loc(_set_miles(vehicle)) == "R"
+
+    def test_in_missing_unit_still_rhd(self, vehicle):
+        assert self.api._get_drv_seat_loc(_set_unit_none(vehicle)) == "R"


### PR DESCRIPTION
## Summary

The CCS2 `start_climate` payload sent `drvSeatLoc: "R"` (RHD) for every region, which is wrong for the LHD majority of EU and CN. This resolves it dynamically per region.

This is the drvSeatLoc half of the closed PR #1183. The CCS2 seat-retry half was dropped — no user has reported the specific `retCode=="F"`-from-`seatClimateInfo` case in either tracker, so I did not add speculative defensive code. The full investigation (issue references, egmp-bluelink-scriptable analysis, the 4005 root cause) is documented on #1183.

## Resolution (mirrors egmp-bluelink-scriptable)

- **`ApiImplType1._get_drv_seat_loc(vehicle)`** — base implementation, used by EU and CN. Uses the vehicle odometer unit: mile-based markets (UK, Ireland) → `"R"`, kilometre-based → `"L"`. Falls back to `"L"` when `odometer_unit` is unavailable (correct for the LHD majority of EU/CN).
- **`KiaUvoApiAU._get_drv_seat_loc`** — override → `"R"`. AU is RHD despite using kilometres.
- **`KiaUvoApiIN._get_drv_seat_loc`** — override → `"R"`. IN is RHD despite using kilometres.
- EU and CN use the base implementation.

This mirrors egmp: `europe.ts` uses `distanceUnit === 'mi' ? 'R' : 'L'`, while `australia.ts` hardcodes `drvSeatLoc: 'R'`.

## Why not `vehicle.distance_unit` (the closed PR #1183 approach)

PR #1183 used `vehicle.distance_unit`, but `Vehicle` has **no `distance_unit` attribute** (that field exists only on `DailyDrivingStats`). Every `start_climate` call after a cached state fetch raised:

```
AttributeError: 'Vehicle' object has no attribute 'distance_unit'
```

This PR uses `vehicle.odometer_unit`, which is a real `Vehicle` property. It is populated by `_update_vehicle_properties` from the cached state `odometer.unit` field (EU/AU/CN) or defaults to the kilometre constant (base/IN). It returns `None` when the response omits the unit, which the base logic handles by falling back to `"L"`.

## Known limitation

For EU UK/Ireland users on the new CCS2 state format where the response does not include `odometer.unit`, `odometer_unit` is `None` and `drvSeatLoc` resolves to `"L"` (should be `"R"` for RHD). This is a rare edge case (UK/IE on CCS2 without the unit field) and the same degradation egmp would have. The previous hardcoded `"R"` was correct for UK but wrong for the rest of EU; this is correct for the rest of EU and degrades only for UK without the signal. A per-vehicle LHD/RHD field from the API would be the proper fix, but no such field is exposed in the cached state response.

## Files changed

- `ApiImplType1.py` — add `_get_drv_seat_loc`, use it in `start_climate` CCS2 payload
- `KiaUvoApiAU.py` — override `_get_drv_seat_loc` → `"R"`
- `KiaUvoApiIN.py` — override `_get_drv_seat_loc` → `"R"`
- `tests/test_drv_seat_loc.py` — 10 unit tests (base km/miles/None + AU/IN overrides)

## Testing

- 10 new unit tests pass
- Full suite: 192 passed (was 177)
- `stop_climate` payload is `{"command": "stop"}` only — no `drvSeatLoc`, unchanged
- Pre-commit hooks pass (ruff, codespell, pyupgrade, etc.)