### PR TITLE
fix(USA): auto-recover get_vehicles/refresh_vehicles on session expiry (1003/1005)

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiUSA.py
@@ -117,13 +117,16 @@ def _retry_on_auth_error(func):
             _LOGGER.debug(
                 f"{DOMAIN} - Session expired during {func.__name__}, re-logging in"
             )
-            new_token = self.login(
-                token.username,
-                token.password,
-                token,
-                getattr(self, "_otp_handler", None),
-            )
-            if not isinstance(new_token, Token):
+            try:
+                new_token = self.login(
+                    token.username,
+                    token.password,
+                    token,
+                    getattr(self, "_otp_handler", None),
+                )
+            except Exception as e:
+                raise AuthenticationError(f"Re-login failed: {e}") from e
+            if isinstance(new_token, OTPRequest):
                 raise AuthenticationOTPRequired("OTP required to refresh token")
             token.access_token = new_token.access_token
             token.refresh_token = new_token.refresh_token

--- a/hyundai_kia_connect_api/KiaUvoApiUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiUSA.py
@@ -370,6 +370,7 @@ class KiaUvoApiUSA(ApiImpl):
         """Refresh the token using the refresh token"""
         return self.login(token.username, token.password, token)
 
+    @_retry_on_auth_error
     def get_vehicles(self, token: Token) -> list[Vehicle]:
         """Return all Vehicle instances for a given Token"""
         url = self.API_URL + "ownr/gvl"
@@ -378,6 +379,13 @@ class KiaUvoApiUSA(ApiImpl):
         response = self.session.get(url, headers=headers)
         _LOGGER.debug(f"{DOMAIN} - Get Vehicles Response {response.text}")
         response = response.json()
+        status = response.get("status") or {}
+        if (
+            status.get("statusCode") == 1
+            and status.get("errorType") == 1
+            and status.get("errorCode") in (1003, 1005)
+        ):
+            raise AuthenticationError("Session invalid")
         if "payload" not in response:
             raise APIError("Missing payload in response")
         result = []

--- a/hyundai_kia_connect_api/KiaUvoApiUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiUSA.py
@@ -411,6 +411,7 @@ class KiaUvoApiUSA(ApiImpl):
             return ENGINE_TYPES.EV
         return None
 
+    @_retry_on_auth_error
     def refresh_vehicles(self, token: Token, vehicles: list[Vehicle] | Vehicle) -> None:
         """
         Refresh the vehicle data provided in get_vehicles.
@@ -424,6 +425,13 @@ class KiaUvoApiUSA(ApiImpl):
         _LOGGER.debug(f"{DOMAIN} - Vehicles Type Passed in: {type(vehicles)}")
         _LOGGER.debug(f"{DOMAIN} - Vehicles Passed in: {vehicles}")
         response = response.json()
+        status = response.get("status") or {}
+        if (
+            status.get("statusCode") == 1
+            and status.get("errorType") == 1
+            and status.get("errorCode") in (1003, 1005)
+        ):
+            raise AuthenticationError("Session invalid")
         if "payload" not in response:
             raise APIError("Missing payload in response")
         if isinstance(vehicles, dict):

--- a/hyundai_kia_connect_api/KiaUvoApiUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiUSA.py
@@ -26,7 +26,7 @@ from .const import (
     VEHICLE_LOCK_ACTION,
     OTP_NOTIFY_TYPE,
 )
-from .exceptions import APIError, AuthenticationError
+from .exceptions import APIError, AuthenticationError, AuthenticationOTPRequired
 from .utils import get_child_value, normalize_battery_soc, parse_datetime
 
 
@@ -100,6 +100,37 @@ def request_with_logging(func):
         raise RequestException
 
     return request_with_logging_wrapper
+
+
+def _retry_on_auth_error(func):
+    """Token-only retry decorator: re-login and retry once on AuthenticationError.
+
+    Symmetric with request_with_active_session but for methods that only take
+    a token (get_vehicles / refresh_vehicles). No threading.Lock, matching
+    request_with_active_session's concurrency behavior.
+    """
+
+    def _retry_on_auth_error_wrapper(self, token, *args, **kwargs):
+        try:
+            return func(self, token, *args, **kwargs)
+        except AuthenticationError:
+            _LOGGER.debug(
+                f"{DOMAIN} - Session expired during {func.__name__}, re-logging in"
+            )
+            new_token = self.login(
+                token.username,
+                token.password,
+                token,
+                getattr(self, "_otp_handler", None),
+            )
+            if not isinstance(new_token, Token):
+                raise AuthenticationOTPRequired("OTP required to refresh token")
+            token.access_token = new_token.access_token
+            token.refresh_token = new_token.refresh_token
+            token.valid_until = new_token.valid_until
+            return func(self, token, *args, **kwargs)
+
+    return _retry_on_auth_error_wrapper
 
 
 class KiaUvoApiUSA(ApiImpl):

--- a/tests/test_usa_session_expiry.py
+++ b/tests/test_usa_session_expiry.py
@@ -178,3 +178,42 @@ def test_get_vehicles_one_retry_only(usa_api):
         usa_api.get_vehicles(token)
     assert usa_api._session.get.call_count == 2
     usa_api.login.assert_called_once()
+
+
+def test_refresh_vehicles_recovers_after_relogin(usa_api):
+    token = _token()
+    usa_api._session = MagicMock()
+    usa_api._session.get.side_effect = [_expired_response(), _vehicles_response()]
+    usa_api.login = MagicMock(return_value=_fresh_token())
+
+    # Pass an empty list — refresh_vehicles iterates payload.vehicleSummary
+    usa_api.refresh_vehicles(token, [])
+
+    assert usa_api._session.get.call_count == 2
+    usa_api.login.assert_called_once()
+    assert token.access_token == "fresh-sid"
+    assert token.refresh_token == "rm2"
+
+
+def test_refresh_vehicles_success_no_retry(usa_api):
+    token = _token()
+    usa_api._session = MagicMock()
+    usa_api._session.get.return_value = _vehicles_response()
+    usa_api.login = MagicMock()
+
+    usa_api.refresh_vehicles(token, [])
+
+    usa_api.login.assert_not_called()
+    assert usa_api._session.get.call_count == 1
+
+
+def test_refresh_vehicles_one_retry_only(usa_api):
+    token = _token()
+    usa_api._session = MagicMock()
+    usa_api._session.get.side_effect = [_expired_response(), _expired_response()]
+    usa_api.login = MagicMock(return_value=_fresh_token())
+
+    with pytest.raises(AuthenticationError):
+        usa_api.refresh_vehicles(token, [])
+    assert usa_api._session.get.call_count == 2
+    usa_api.login.assert_called_once()

--- a/tests/test_usa_session_expiry.py
+++ b/tests/test_usa_session_expiry.py
@@ -1,0 +1,122 @@
+"""Tests for USA session-expiry auto-recovery in get_vehicles / refresh_vehicles."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from hyundai_kia_connect_api.ApiImpl import OTPRequest
+from hyundai_kia_connect_api.KiaUvoApiUSA import KiaUvoApiUSA, _retry_on_auth_error
+from hyundai_kia_connect_api.Token import Token
+from hyundai_kia_connect_api.exceptions import (
+    AuthenticationError,
+    AuthenticationOTPRequired,
+)
+
+
+@pytest.fixture
+def usa_api() -> KiaUvoApiUSA:
+    api = KiaUvoApiUSA.__new__(KiaUvoApiUSA)
+    api.API_URL = "https://example.com/"
+    api._otp_handler = None
+    api.api_headers = lambda: {}
+    return api
+
+
+def _token() -> Token:
+    return Token(
+        username="user@example.com",
+        password="pass",
+        access_token="dead-sid",
+        refresh_token="rm",
+    )
+
+
+def _fresh_token() -> Token:
+    return Token(
+        username="user@example.com",
+        password="pass",
+        access_token="fresh-sid",
+        refresh_token="rm2",
+    )
+
+
+def _expired_response() -> MagicMock:
+    resp = MagicMock()
+    resp.json.return_value = {
+        "status": {
+            "statusCode": 1,
+            "errorType": 1,
+            "errorCode": 1003,
+            "errorMessage": "Session Key is either invalid or expired",
+        }
+    }
+    resp.text = "{}"
+    return resp
+
+
+def _vehicles_response() -> MagicMock:
+    resp = MagicMock()
+    resp.json.return_value = {
+        "status": {"statusCode": 0},
+        "payload": {"vehicleSummary": []},
+    }
+    resp.text = "{}"
+    return resp
+
+
+def test_decorator_retries_once_and_mutates_token(usa_api):
+    calls = {"n": 0}
+
+    @_retry_on_auth_error
+    def do_thing(self, token):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise AuthenticationError("expired")
+        return "ok"
+
+    token = _token()
+    usa_api.login = MagicMock(return_value=_fresh_token())
+
+    result = do_thing(usa_api, token)
+
+    assert result == "ok"
+    assert calls["n"] == 2
+    usa_api.login.assert_called_once()
+    assert token.access_token == "fresh-sid"
+    assert token.refresh_token == "rm2"
+
+
+def test_decorator_raises_otp_when_login_needs_otp(usa_api):
+    @_retry_on_auth_error
+    def do_thing(self, token):
+        raise AuthenticationError("expired")
+
+    token = _token()
+    otp = OTPRequest(
+        otp_key="k",
+        request_id="r",
+        email="e",
+        sms="s",
+        has_email=True,
+        has_sms=False,
+    )
+    usa_api.login = MagicMock(return_value=otp)
+
+    with pytest.raises(AuthenticationOTPRequired):
+        do_thing(usa_api, token)
+
+
+def test_decorator_one_retry_only(usa_api):
+    calls = {"n": 0}
+
+    @_retry_on_auth_error
+    def do_thing(self, token):
+        calls["n"] += 1
+        raise AuthenticationError("expired")
+
+    token = _token()
+    usa_api.login = MagicMock(return_value=_fresh_token())
+
+    with pytest.raises(AuthenticationError):
+        do_thing(usa_api, token)
+    assert calls["n"] == 2
+    usa_api.login.assert_called_once()

--- a/tests/test_usa_session_expiry.py
+++ b/tests/test_usa_session_expiry.py
@@ -120,3 +120,61 @@ def test_decorator_one_retry_only(usa_api):
         do_thing(usa_api, token)
     assert calls["n"] == 2
     usa_api.login.assert_called_once()
+
+
+def test_get_vehicles_recovers_after_relogin(usa_api):
+    token = _token()
+    usa_api._session = MagicMock()
+    usa_api._session.get.side_effect = [_expired_response(), _vehicles_response()]
+    usa_api.login = MagicMock(return_value=_fresh_token())
+
+    result = usa_api.get_vehicles(token)
+
+    assert result == []
+    assert usa_api._session.get.call_count == 2
+    usa_api.login.assert_called_once()
+    assert token.access_token == "fresh-sid"
+    assert token.refresh_token == "rm2"
+
+
+def test_get_vehicles_success_no_retry(usa_api):
+    token = _token()
+    usa_api._session = MagicMock()
+    usa_api._session.get.return_value = _vehicles_response()
+    usa_api.login = MagicMock()
+
+    result = usa_api.get_vehicles(token)
+
+    assert result == []
+    usa_api.login.assert_not_called()
+    assert usa_api._session.get.call_count == 1
+
+
+def test_get_vehicles_raises_otp_when_login_needs_otp(usa_api):
+    token = _token()
+    usa_api._session = MagicMock()
+    usa_api._session.get.return_value = _expired_response()
+    otp = OTPRequest(
+        otp_key="k",
+        request_id="r",
+        email="e",
+        sms="s",
+        has_email=True,
+        has_sms=False,
+    )
+    usa_api.login = MagicMock(return_value=otp)
+
+    with pytest.raises(AuthenticationOTPRequired):
+        usa_api.get_vehicles(token)
+
+
+def test_get_vehicles_one_retry_only(usa_api):
+    token = _token()
+    usa_api._session = MagicMock()
+    usa_api._session.get.side_effect = [_expired_response(), _expired_response()]
+    usa_api.login = MagicMock(return_value=_fresh_token())
+
+    with pytest.raises(AuthenticationError):
+        usa_api.get_vehicles(token)
+    assert usa_api._session.get.call_count == 2
+    usa_api.login.assert_called_once()

--- a/tests/test_usa_session_expiry.py
+++ b/tests/test_usa_session_expiry.py
@@ -124,14 +124,14 @@ def test_decorator_one_retry_only(usa_api):
 
 def test_get_vehicles_recovers_after_relogin(usa_api):
     token = _token()
-    usa_api._session = MagicMock()
-    usa_api._session.get.side_effect = [_expired_response(), _vehicles_response()]
+    usa_api.session = MagicMock()
+    usa_api.session.get.side_effect = [_expired_response(), _vehicles_response()]
     usa_api.login = MagicMock(return_value=_fresh_token())
 
     result = usa_api.get_vehicles(token)
 
     assert result == []
-    assert usa_api._session.get.call_count == 2
+    assert usa_api.session.get.call_count == 2
     usa_api.login.assert_called_once()
     assert token.access_token == "fresh-sid"
     assert token.refresh_token == "rm2"
@@ -139,21 +139,21 @@ def test_get_vehicles_recovers_after_relogin(usa_api):
 
 def test_get_vehicles_success_no_retry(usa_api):
     token = _token()
-    usa_api._session = MagicMock()
-    usa_api._session.get.return_value = _vehicles_response()
+    usa_api.session = MagicMock()
+    usa_api.session.get.return_value = _vehicles_response()
     usa_api.login = MagicMock()
 
     result = usa_api.get_vehicles(token)
 
     assert result == []
     usa_api.login.assert_not_called()
-    assert usa_api._session.get.call_count == 1
+    assert usa_api.session.get.call_count == 1
 
 
 def test_get_vehicles_raises_otp_when_login_needs_otp(usa_api):
     token = _token()
-    usa_api._session = MagicMock()
-    usa_api._session.get.return_value = _expired_response()
+    usa_api.session = MagicMock()
+    usa_api.session.get.return_value = _expired_response()
     otp = OTPRequest(
         otp_key="k",
         request_id="r",
@@ -170,26 +170,26 @@ def test_get_vehicles_raises_otp_when_login_needs_otp(usa_api):
 
 def test_get_vehicles_one_retry_only(usa_api):
     token = _token()
-    usa_api._session = MagicMock()
-    usa_api._session.get.side_effect = [_expired_response(), _expired_response()]
+    usa_api.session = MagicMock()
+    usa_api.session.get.side_effect = [_expired_response(), _expired_response()]
     usa_api.login = MagicMock(return_value=_fresh_token())
 
     with pytest.raises(AuthenticationError):
         usa_api.get_vehicles(token)
-    assert usa_api._session.get.call_count == 2
+    assert usa_api.session.get.call_count == 2
     usa_api.login.assert_called_once()
 
 
 def test_refresh_vehicles_recovers_after_relogin(usa_api):
     token = _token()
-    usa_api._session = MagicMock()
-    usa_api._session.get.side_effect = [_expired_response(), _vehicles_response()]
+    usa_api.session = MagicMock()
+    usa_api.session.get.side_effect = [_expired_response(), _vehicles_response()]
     usa_api.login = MagicMock(return_value=_fresh_token())
 
     # Pass an empty list — refresh_vehicles iterates payload.vehicleSummary
     usa_api.refresh_vehicles(token, [])
 
-    assert usa_api._session.get.call_count == 2
+    assert usa_api.session.get.call_count == 2
     usa_api.login.assert_called_once()
     assert token.access_token == "fresh-sid"
     assert token.refresh_token == "rm2"
@@ -197,23 +197,23 @@ def test_refresh_vehicles_recovers_after_relogin(usa_api):
 
 def test_refresh_vehicles_success_no_retry(usa_api):
     token = _token()
-    usa_api._session = MagicMock()
-    usa_api._session.get.return_value = _vehicles_response()
+    usa_api.session = MagicMock()
+    usa_api.session.get.return_value = _vehicles_response()
     usa_api.login = MagicMock()
 
     usa_api.refresh_vehicles(token, [])
 
     usa_api.login.assert_not_called()
-    assert usa_api._session.get.call_count == 1
+    assert usa_api.session.get.call_count == 1
 
 
 def test_refresh_vehicles_one_retry_only(usa_api):
     token = _token()
-    usa_api._session = MagicMock()
-    usa_api._session.get.side_effect = [_expired_response(), _expired_response()]
+    usa_api.session = MagicMock()
+    usa_api.session.get.side_effect = [_expired_response(), _expired_response()]
     usa_api.login = MagicMock(return_value=_fresh_token())
 
     with pytest.raises(AuthenticationError):
         usa_api.refresh_vehicles(token, [])
-    assert usa_api._session.get.call_count == 2
+    assert usa_api.session.get.call_count == 2
     usa_api.login.assert_called_once()

--- a/tests/test_usa_session_expiry.py
+++ b/tests/test_usa_session_expiry.py
@@ -105,6 +105,24 @@ def test_decorator_raises_otp_when_login_needs_otp(usa_api):
         do_thing(usa_api, token)
 
 
+def test_decorator_re_raises_login_failure_as_authentication_error(usa_api):
+    """A failed re-login (e.g. wrong password) must surface as AuthenticationError,
+    not the generic Exception that KiaUvoApiUSA.login raises, and not as OTP."""
+
+    @_retry_on_auth_error
+    def do_thing(self, token):
+        raise AuthenticationError("expired")
+
+    token = _token()
+    usa_api.login = MagicMock(side_effect=Exception("No session id returned in login"))
+
+    with pytest.raises(AuthenticationError) as exc_info:
+        do_thing(usa_api, token)
+    assert not isinstance(exc_info.value, AuthenticationOTPRequired)
+    assert "Re-login failed" in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, Exception)
+
+
 def test_decorator_one_retry_only(usa_api):
     calls = {"n": 0}
 
@@ -178,6 +196,19 @@ def test_get_vehicles_one_retry_only(usa_api):
         usa_api.get_vehicles(token)
     assert usa_api.session.get.call_count == 2
     usa_api.login.assert_called_once()
+
+
+def test_get_vehicles_relogin_failure_raises_authentication_error(usa_api):
+    token = _token()
+    usa_api.session = MagicMock()
+    usa_api.session.get.return_value = _expired_response()
+    usa_api.login = MagicMock(side_effect=Exception("No session id returned in login"))
+
+    with pytest.raises(AuthenticationError) as exc_info:
+        usa_api.get_vehicles(token)
+    assert not isinstance(exc_info.value, AuthenticationOTPRequired)
+    assert "Re-login failed" in str(exc_info.value)
+    assert usa_api.session.get.call_count == 1
 
 
 def test_refresh_vehicles_recovers_after_relogin(usa_api):


### PR DESCRIPTION
## Summary

`KiaUvoApiUSA.get_vehicles` and `refresh_vehicles` called `self.session.get()` without the `@request_with_logging` / `@request_with_active_session` decorators, so an expired-session response (errorCode 1003) raised a generic `APIError("Missing payload in response")` instead of `AuthenticationError`. With `test_token` a no-op for USA and `check_and_refresh_token` driven only by the `valid_until` timestamp, a server-side session expiry before `valid_until` left the integration looping `ConfigEntryNotReady` with a dead token — the user had to delete and re-add the account (kia_uvo#1685).

This adds a token-only `_retry_on_auth_error` decorator (symmetric with `request_with_active_session`, which requires `vehicle` / `json_body` these methods don't have) and makes both methods raise `AuthenticationError` on errorCode 1003/1005. The decorator re-logs in, mutates the token in place, and retries once.

This is the USA analog of #1136 (which fixed the same class of bug for EU / `ApiImplType1`).

Fixes kia_uvo#1685

## Test plan

- [x] `get_vehicles` with 1003 response raises `AuthenticationError` and recovers after re-login
- [x] `get_vehicles` success path does not retry
- [x] `get_vehicles` raises `AuthenticationOTPRequired` when re-login needs OTP
- [x] `get_vehicles` retries exactly once (second failure propagates)
- [x] `refresh_vehicles` equivalent coverage
- [x] `pytest tests/ -q` passes (204 passed; 5 pre-existing live-integration errors unrelated)
- [x] `pre-commit run --all-files` passes
