### PR TITLE
feat: add HyundaiBlueLinkApiUSA.refresh_access_token override

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
@@ -222,6 +222,66 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
             pin=pin,
         )
 
+    def refresh_access_token(self, token: Token) -> Token:
+        """Refresh the access token using the stored refresh token.
+
+        Calls the same /v2/ac/oauth/token endpoint as login, but sends
+        username + password + grant_type=refresh_token + refresh_token
+        together in a JSON body. The endpoint validates username/password
+        presence before inspecting grant_type, so all four fields must be
+        sent (sending grant_type + refresh_token alone returns 400
+        "password required"). Falls back to full login if the refresh
+        token is missing or the exchange fails.
+
+        Confirmed working live (2026-06-22, issue #1186): ~0.02s refresh
+        vs ~0.74s full login, refresh_token rotates, expires_in ~1800s.
+        """
+        if token.refresh_token:
+            try:
+                url = self.LOGIN_API + "oauth/token"
+                data = {
+                    "username": token.username,
+                    "password": token.password,
+                    "grant_type": "refresh_token",
+                    "refresh_token": token.refresh_token,
+                }
+                response = self.session.post(url, json=data, headers=self.API_HEADERS)
+                response_json = response.json()
+                _check_response_for_errors(response_json)
+                if response_json.get("access_token") is None:
+                    raise APIError(
+                        f"{DOMAIN} - refresh_access_token: no access_token "
+                        f"in response {response_json}"
+                    )
+                access_token = response_json["access_token"]
+                new_refresh_token = response_json.get(
+                    "refresh_token", token.refresh_token
+                )
+                expires_in = float(response_json["expires_in"])
+                valid_until = dt.datetime.now(dt.timezone.utc) + dt.timedelta(
+                    seconds=expires_in
+                )
+                _LOGGER.debug(
+                    f"{DOMAIN} - Access token refreshed successfully, "
+                    f"expires in {expires_in}s"
+                )
+                return Token(
+                    username=token.username,
+                    password=token.password,
+                    access_token=access_token,
+                    refresh_token=new_refresh_token,
+                    valid_until=valid_until,
+                    pin=token.pin,
+                )
+            except Exception:
+                _LOGGER.warning(
+                    f"{DOMAIN} - Refresh token exchange failed, "
+                    f"falling back to full login"
+                )
+                return self.login(token.username, token.password, token.pin)
+        # No refresh_token available — full login.
+        return self.login(token.username, token.password, token.pin)
+
     def _get_vehicle_details(self, token: Token, vehicle: Vehicle):
         url = self.API_URL + "enrollment/details/" + token.username
         headers = self._get_authenticated_headers(token)

--- a/tests/us_refresh_access_token_test.py
+++ b/tests/us_refresh_access_token_test.py
@@ -1,0 +1,229 @@
+"""Tests for HyundaiBlueLinkApiUSA.refresh_access_token().
+
+The USA /v2/ac/oauth/token endpoint honors grant_type=refresh_token only when
+username + password + grant_type + refresh_token are sent together in a JSON
+body (the endpoint validates username/password presence before inspecting
+grant_type). These tests lock in that contract and the fallback-to-login
+behaviour. Confirmed live 2026-06-22: ~0.02s refresh vs ~0.74s full login,
+refresh_token rotates, expires_in ~1800s.
+"""
+
+import datetime as dt
+from unittest.mock import MagicMock, patch
+
+from hyundai_kia_connect_api.HyundaiBlueLinkApiUSA import HyundaiBlueLinkApiUSA
+from hyundai_kia_connect_api.Token import Token
+
+
+def _make_usa_api() -> HyundaiBlueLinkApiUSA:
+    """Create a HyundaiBlueLinkApiUSA instance for testing (no network)."""
+    return HyundaiBlueLinkApiUSA(region=3, brand=2, language="en")
+
+
+def _make_token(**overrides) -> Token:
+    """Create a Token instance with sensible defaults for testing."""
+    defaults = dict(
+        username="user@test.com",
+        password="MyPassword123!",
+        access_token="old-access-token",
+        refresh_token="OLDREFRESHTOKEN1234567890123456789012345678",
+        valid_until=dt.datetime.now(dt.timezone.utc) + dt.timedelta(hours=1),
+        pin="1234",
+    )
+    defaults.update(overrides)
+    return Token(**defaults)
+
+
+def _mock_refresh_response(
+    access_token: str = "new-access-token",
+    refresh_token: str | None = "new-refresh-token",
+    expires_in: str = "1799",
+) -> MagicMock:
+    """Build a mock response object for a successful refresh POST."""
+    body = {"access_token": access_token, "expires_in": expires_in}
+    if refresh_token is not None:
+        body["refresh_token"] = refresh_token
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = body
+    return mock_resp
+
+
+def test_refresh_access_token_uses_stored_refresh_token() -> None:
+    """refresh_access_token returns a new Token with rotated credentials."""
+    api = _make_usa_api()
+
+    with patch.object(
+        api.session, "post", return_value=_mock_refresh_response()
+    ) as mock_post:
+        token = _make_token()
+        result = api.refresh_access_token(token)
+
+    assert result.access_token == "new-access-token"
+    assert result.refresh_token == "new-refresh-token"
+    assert result.username == "user@test.com"
+    assert result.password == "MyPassword123!"
+    assert result.pin == "1234"
+    mock_post.assert_called_once()
+
+
+def test_refresh_access_token_sends_grant_type_and_credentials() -> None:
+    """The POST body must include username, password, grant_type, refresh_token.
+
+    This is the key contract: the USA endpoint validates username/password
+    presence before honoring grant_type, so all four fields must be sent
+    together (confirmed live in issue #1186 round-2 diagnostic, T1).
+    """
+    api = _make_usa_api()
+
+    with patch.object(
+        api.session, "post", return_value=_mock_refresh_response()
+    ) as mock_post:
+        token = _make_token()
+        api.refresh_access_token(token)
+
+    call = mock_post.call_args
+    url = call.args[0]
+    body = call.kwargs["json"]
+    assert url == api.LOGIN_API + "oauth/token"
+    assert body["username"] == "user@test.com"
+    assert body["password"] == "MyPassword123!"
+    assert body["grant_type"] == "refresh_token"
+    assert body["refresh_token"] == token.refresh_token
+
+
+def test_refresh_access_token_rotates_refresh_token() -> None:
+    """A rotated refresh_token in the response replaces the old one."""
+    api = _make_usa_api()
+
+    with patch.object(
+        api.session,
+        "post",
+        return_value=_mock_refresh_response(refresh_token="ROTATED"),
+    ):
+        token = _make_token(refresh_token="ORIGINAL")
+        result = api.refresh_access_token(token)
+
+    assert result.refresh_token == "ROTATED"
+
+
+def test_refresh_access_token_keeps_old_refresh_token_when_missing() -> None:
+    """When the response omits refresh_token, keep the original (no rotation)."""
+    api = _make_usa_api()
+
+    with patch.object(
+        api.session, "post", return_value=_mock_refresh_response(refresh_token=None)
+    ):
+        token = _make_token(refresh_token="ORIGINAL")
+        result = api.refresh_access_token(token)
+
+    assert result.access_token == "new-access-token"
+    assert result.refresh_token == "ORIGINAL"
+
+
+def test_refresh_access_token_sets_valid_until_from_expires_in() -> None:
+    """valid_until is now + expires_in seconds."""
+    api = _make_usa_api()
+
+    with patch.object(
+        api.session, "post", return_value=_mock_refresh_response(expires_in="3600")
+    ):
+        before = dt.datetime.now(dt.timezone.utc)
+        token = _make_token()
+        result = api.refresh_access_token(token)
+        after = dt.datetime.now(dt.timezone.utc)
+
+    assert result.valid_until >= before + dt.timedelta(seconds=3599)
+    assert result.valid_until <= after + dt.timedelta(seconds=3601)
+
+
+def test_refresh_access_token_falls_back_on_missing_refresh_token() -> None:
+    """When token has no refresh_token, fall back to full login."""
+    api = _make_usa_api()
+
+    with (
+        patch.object(
+            api, "login", return_value=_make_token(access_token="from-login")
+        ) as mock_login,
+        patch.object(api.session, "post") as mock_post,
+    ):
+        token = _make_token(refresh_token="")
+        result = api.refresh_access_token(token)
+
+    mock_login.assert_called_once_with("user@test.com", "MyPassword123!", "1234")
+    mock_post.assert_not_called()
+    assert result.access_token == "from-login"
+
+
+def test_refresh_access_token_falls_back_on_none_refresh_token() -> None:
+    """When token.refresh_token is None, fall back to full login."""
+    api = _make_usa_api()
+
+    with (
+        patch.object(
+            api, "login", return_value=_make_token(access_token="from-login")
+        ) as mock_login,
+        patch.object(api.session, "post") as mock_post,
+    ):
+        token = _make_token(refresh_token=None)
+        api.refresh_access_token(token)
+
+    mock_login.assert_called_once_with("user@test.com", "MyPassword123!", "1234")
+    mock_post.assert_not_called()
+
+
+def test_refresh_access_token_falls_back_on_exchange_failure() -> None:
+    """When the refresh POST raises, fall back to full login."""
+    api = _make_usa_api()
+
+    with (
+        patch.object(api.session, "post", side_effect=Exception("Network error")),
+        patch.object(
+            api, "login", return_value=_make_token(access_token="from-login")
+        ) as mock_login,
+    ):
+        token = _make_token()
+        result = api.refresh_access_token(token)
+
+    mock_login.assert_called_once_with("user@test.com", "MyPassword123!", "1234")
+    assert result.access_token == "from-login"
+
+
+def test_refresh_access_token_falls_back_on_error_response() -> None:
+    """When the response carries an errorCode, fall back to full login.
+
+    _check_response_for_errors raises APIError when errorCode is present;
+    refresh_access_token must catch that and fall back rather than propagate.
+    """
+    api = _make_usa_api()
+
+    error_resp = MagicMock()
+    error_resp.json.return_value = {
+        "errorCode": "400",
+        "errorMessage": "refresh rejected",
+    }
+
+    with (
+        patch.object(api.session, "post", return_value=error_resp),
+        patch.object(
+            api, "login", return_value=_make_token(access_token="from-login")
+        ) as mock_login,
+    ):
+        token = _make_token()
+        result = api.refresh_access_token(token)
+
+    mock_login.assert_called_once_with("user@test.com", "MyPassword123!", "1234")
+    assert result.access_token == "from-login"
+
+
+def test_refresh_access_token_does_not_call_login_on_success() -> None:
+    """On a successful refresh, the full login path is not taken."""
+    api = _make_usa_api()
+
+    with (
+        patch.object(api.session, "post", return_value=_mock_refresh_response()),
+        patch.object(api, "login") as mock_login,
+    ):
+        token = _make_token()
+        api.refresh_access_token(token)
+
+    mock_login.assert_not_called()


### PR DESCRIPTION
## What

Adds `HyundaiBlueLinkApiUSA.refresh_access_token`, so the USA Hyundai (BlueLink) integration can renew the access token without a full re-login when it expires.

## Why

`HyundaiBlueLinkApiUSA` had no `refresh_access_token` override, so `ApiImpl.refresh_access_token` fell back to a full `self.login()` on every token expiry. The login response already includes a `refresh_token`, but it was unused.

Issue #1186 was previously closed as wontfix because a first diagnostic concluded the refresh grant was unsupported. That conclusion was premature: every refresh attempt returned a **field-validation** error (`C400_1` "Parameter {password} field [Required]") — the endpoint validates `username`+`password` presence **before** inspecting `grant_type`, so the combination `username + password + grant_type=refresh_token + refresh_token` was never sent.

## How — confirmed live

A second diagnostic (issue #1186, @ijojog re-run 2026-06-22) tested a 3-call matrix against `POST /v2/ac/oauth/token`:

| Variant | Result |
|---|---|
| **T1** JSON: `{username, password, grant_type:"refresh_token", refresh_token}` + standard `API_HEADERS` | **HTTP 200 ✅** |
| T2 form-urlencoded, same fields | HTTP 400 `username required` |
| T3 `Authorization: Basic` + form, no username/password | HTTP 403 `client_id required` |

T1 wins. The refreshed `access_token` was verified against `GET /enrollment/details` → HTTP 200. Measured: **0.02s refresh vs 0.74s full login (44.6x faster)**, `refresh_token` rotates, `expires_in` ~1800s (30 min).

So the USA endpoint **does** honor `grant_type=refresh_token`, but only when sent as JSON with username + password + grant_type + refresh_token together, and with the custom `client_id`/`clientSecret` headers (not Basic auth, not form-urlencoded).

## Implementation

`refresh_access_token` POSTs to `/v2/ac/oauth/token` with the four-field JSON body and `self.API_HEADERS`, parses the new tokens, and returns a new `Token` preserving `username`/`password`/`pin`. `valid_until` is `now + expires_in`. Falls back to `self.login()` when:
- `token.refresh_token` is missing/empty
- the POST raises (network error)
- the response carries an `errorCode` (`_check_response_for_errors` raises `APIError`)
- the response has no `access_token`

This mirrors `KiaUvoApiEU.refresh_access_token` fallback behaviour.

## Tests

10 unit tests in `tests/us_refresh_access_token_test.py` (mocked `sessions.post`, no network):
- success path returns rotated credentials, preserves username/password/pin
- **body contract**: POST body contains `username`, `password`, `grant_type:"refresh_token"`, `refresh_token` (locks in the four-field requirement)
- `refresh_token` rotation and preservation when response omits it
- `valid_until` derived from `expires_in`
- fallback to `login` on: missing/None refresh_token, POST exception, error response
- `login` not called on success

## Closes

Closes #1186.

## Notes

- No `kia_uvo` manifest bump needed here — the release pipeline bumps the API requirement automatically.
- Cross-region check: PIN is not used in refresh by any region (PIN is only for vehicle commands), so no PIN field is involved.