### PR TITLE
fix: migrate refresh_access_token to ApiImplSession (F821 on master after #1160)

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -1205,7 +1205,7 @@ class ApiImplType1(ApiImpl):
                     "User-Agent": USER_AGENT_OK_HTTP,
                 }
                 data = "grant_type=refresh_token&refresh_token=" + token.refresh_token
-                response = requests.post(url, data=data, headers=headers)
+                response = self.session.post(url, data=data, headers=headers)
                 response_json = response.json()
                 _check_response_for_errors(response_json)
 

--- a/tests/test_type1_refresh_access_token.py
+++ b/tests/test_type1_refresh_access_token.py
@@ -74,7 +74,7 @@ class TestType1RefreshAccessTokenNoStamp:
             return _FakeResponse(_ok_payload())
 
         with patch(
-            "hyundai_kia_connect_api.ApiImplType1.requests.post", side_effect=fake_post
+            "hyundai_kia_connect_api.ApiImpl.ApiImplSession.post", side_effect=fake_post
         ):
             self.api.refresh_access_token(_make_token())
 
@@ -94,7 +94,7 @@ class TestType1RefreshAccessTokenNoStamp:
             return _FakeResponse(_ok_payload())
 
         with patch(
-            "hyundai_kia_connect_api.ApiImplType1.requests.post", side_effect=fake_post
+            "hyundai_kia_connect_api.ApiImpl.ApiImplSession.post", side_effect=fake_post
         ):
             self.api.refresh_access_token(_make_token())
 
@@ -104,7 +104,7 @@ class TestType1RefreshAccessTokenNoStamp:
 
     def test_returns_new_token_preserving_device_id(self):
         with patch(
-            "hyundai_kia_connect_api.ApiImplType1.requests.post",
+            "hyundai_kia_connect_api.ApiImpl.ApiImplSession.post",
             return_value=_FakeResponse(_ok_payload()),
         ):
             result = self.api.refresh_access_token(_make_token(device_id="keep-this"))
@@ -118,7 +118,7 @@ class TestType1RefreshAccessTokenNoStamp:
     def test_falls_back_to_login_on_exchange_failure(self):
         with (
             patch(
-                "hyundai_kia_connect_api.ApiImplType1.requests.post",
+                "hyundai_kia_connect_api.ApiImpl.ApiImplSession.post",
                 return_value=_FakeResponse(
                     {"retCode": "F", "resCode": "7501", "resMsg": "auth"}
                 ),
@@ -144,7 +144,7 @@ class TestType1RefreshAccessTokenNoStamp:
         payload = _ok_payload()
         del payload["refresh_token"]
         with patch(
-            "hyundai_kia_connect_api.ApiImplType1.requests.post",
+            "hyundai_kia_connect_api.ApiImpl.ApiImplSession.post",
             return_value=_FakeResponse(payload),
         ):
             result = self.api.refresh_access_token(
@@ -175,7 +175,7 @@ class TestRegionsUseBaseRefreshAccessToken:
             return _FakeResponse(_ok_payload())
 
         with patch(
-            "hyundai_kia_connect_api.ApiImplType1.requests.post", side_effect=fake_post
+            "hyundai_kia_connect_api.ApiImpl.ApiImplSession.post", side_effect=fake_post
         ):
             api.refresh_access_token(_make_token())
 


### PR DESCRIPTION
Fixes the post-#1160 master breakage: ruff \`F821 Undefined name 'requests'\` at \`ApiImplType1.py:1208\` (pre-commit.ci red) + 6 failures in \`tests/test_type1_refresh_access_token.py\` (\`AttributeError: module 'ApiImplType1' has no attribute 'requests'\`).

## Root cause

- **#1188** (merged first — \`e55fa7e\`) added \`ApiImplType1.refresh_access_token\` using bare \`requests.post(...)\` + tests patching \`hyundai_kia_connect_api.ApiImplType1.requests.post\`, relying on \`import requests\`.
- **#1160** (merged after — \`9662958\`) removed \`import requests\` from \`ApiImplType1\` and migrated all other HTTP call sites to \`self.session.*\`, but **missed the #1188 call site** (#1160's rebase base predated #1188, so its diff never saw line 1208). Squash-merge onto #1188-containing master orphaned the bare \`requests.post\`.

## Fix

Migrate \`refresh_access_token\` to \`self.session.post(...)\` — consistent with #1160, so the refresh-token grant now gets the default timeout (10s connect / 30s read) + connection pooling like every other call. Retarget the tests to patch \`hyundai_kia_connect_api.ApiImpl.ApiImplSession.post\`. No assertion-logic changes: the tests capture \`url\`/\`data\`/\`headers\` via \`side_effect\` and use \`return_value\`; none inspect \`call_args\`, so the patch-target swap is the only test change.

## Verification

- \`ruff check\` clean (F821 resolved)
- \`pytest tests/test_type1_refresh_access_token.py\` — 10/10 pass
- full suite — 234 pass, 8 snapshots pass

This is my regression from #1160 not accounting for #1188's concurrent call site. Apologies for the master breakage.