### PR TITLE
fix: migrate USA horn/hazard to self.session (AttributeError after #1160)

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
@@ -1115,7 +1115,7 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
         headers["APPCLOUD-VIN"] = vehicle.VIN
 
         data = {"userName": token.username, "vin": vehicle.VIN}
-        response = self.sessions.post(url, headers=headers, json=data)
+        response = self.session.post(url, headers=headers, json=data)
         response_json = _safe_parse_json(response, "start_hazard_lights")
         if response_json is not None:
             _check_response_for_errors(response_json)
@@ -1138,7 +1138,7 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
         headers["APPCLOUD-VIN"] = vehicle.VIN
 
         data = {"userName": token.username, "vin": vehicle.VIN}
-        response = self.sessions.post(url, headers=headers, json=data)
+        response = self.session.post(url, headers=headers, json=data)
         response_json = _safe_parse_json(response, "start_hazard_lights_and_horn")
         if response_json is not None:
             _check_response_for_errors(response_json)


### PR DESCRIPTION
Fixes a second #1160 regression (runtime, not lint): \`HyundaiBlueLinkApiUSA.start_hazard_lights\` (line 1118) and \`start_hazard_lights_and_horn\` (line 1141) still use \`self.sessions\` (the pre-#1160 USA attribute name), which #1160 did not migrate. \`self.sessions\` is no longer defined (USA Hyundai was unified to \`self.session = ApiImplSession()\`), so invoking horn/hazard raises \`AttributeError: 'HyundaiBlueLinkApiUSA' object has no attribute 'sessions'\` at runtime.

## Root cause

Same concurrent-PR collision pattern as the #1188 \`refresh_access_token\` site fixed in #1200: #1180 (merged first) added these methods with \`self.sessions\`; #1160 (merged after) unified the attribute to \`self.session\` but its rebase base predated #1180, so the two horn/hazard call sites were missed. Unlike the Type1 case, **ruff does not flag it** (\`self.sessions\` is syntactically valid attribute access) and there are **no unit tests** for these methods, so it stayed latent until a user (ijojog, testing #1167) invoked horn/hazard.

## Fix

Migrate both call sites to \`self.session.post\`. Two-line change, no test changes (no horn/hazard tests exist — flagged as a follow-up gap).

Note: \`KiaUvoApiCA\`'s \`self.sessions\` (21 sites) is intentionally untouched — it is the \`RetrySession\` property, deliberately kept in #1160.

## Verification

- \`ruff check\` clean
- full suite 234 pass, 8 snapshots pass

This is my regression from #1160. Apologies — it was blocking ijojog's #1167 testing.