### PR TITLE
feat: add valet capability flag and status attribute

### DIFF
--- a/hyundai_kia_connect_api/ApiImpl.py
+++ b/hyundai_kia_connect_api/ApiImpl.py
@@ -163,6 +163,7 @@ class ApiImpl:
     previous_latitude: float = None
     previous_longitude: float = None
     supports_window_control: bool = False
+    supports_valet_mode: bool = False
 
     def __init__(self) -> None:
         """Initialize."""

--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -116,6 +116,7 @@ class ApiImplType1(ApiImpl):
     """ApiImplType1"""
 
     supports_window_control: bool = True
+    supports_valet_mode: bool = True
 
     def __init__(self) -> None:
         """Initialize."""

--- a/hyundai_kia_connect_api/Vehicle.py
+++ b/hyundai_kia_connect_api/Vehicle.py
@@ -146,6 +146,10 @@ class Vehicle:
     back_right_window_is_open: bool = None
     sunroof_is_open: bool = None
     supports_window_control: bool = None
+    supports_valet_mode: bool = None
+
+    # Valet Status
+    valet_mode_active: bool = None
 
     # Tire Pressure
     tire_pressure_all_warning_is_on: bool = None

--- a/hyundai_kia_connect_api/VehicleManager.py
+++ b/hyundai_kia_connect_api/VehicleManager.py
@@ -129,6 +129,7 @@ class VehicleManager:
         vehicles = self.api.get_vehicles(self.token)
         for vehicle in vehicles:
             vehicle.supports_window_control = self.api.supports_window_control
+            vehicle.supports_valet_mode = self.api.supports_valet_mode
             self.vehicles[vehicle.id] = vehicle
 
     def get_vehicle(self, vehicle_id: str) -> Vehicle:

--- a/tests/test_valet_capability.py
+++ b/tests/test_valet_capability.py
@@ -1,0 +1,47 @@
+"""Tests for valet mode capability flag and status attribute."""
+
+from unittest.mock import MagicMock
+
+from hyundai_kia_connect_api.ApiImpl import ApiImpl
+from hyundai_kia_connect_api.ApiImplType1 import ApiImplType1
+from hyundai_kia_connect_api.Token import Token
+from hyundai_kia_connect_api.Vehicle import Vehicle
+from hyundai_kia_connect_api.VehicleManager import VehicleManager
+
+
+def test_vehicle_has_valet_mode_active_attribute():
+    vehicle = Vehicle()
+    assert hasattr(vehicle, "valet_mode_active")
+    assert vehicle.valet_mode_active is None
+
+
+def test_vehicle_has_supports_valet_mode_attribute():
+    vehicle = Vehicle()
+    assert hasattr(vehicle, "supports_valet_mode")
+    assert vehicle.supports_valet_mode is None
+
+
+def test_base_api_impl_does_not_support_valet_mode():
+    assert ApiImpl.supports_valet_mode is False
+
+
+def test_type1_api_impl_supports_valet_mode():
+    assert ApiImplType1.supports_valet_mode is True
+
+
+def test_vehicle_manager_copies_supports_valet_mode():
+    vehicle = Vehicle()
+    vehicle.id = "test-vehicle"
+
+    fake_api = MagicMock()
+    fake_api.supports_valet_mode = True
+    fake_api.get_vehicles.return_value = [vehicle]
+
+    manager = VehicleManager.__new__(VehicleManager)
+    manager.api = fake_api
+    manager.token = Token(access_token="x", refresh_token="y", device_id="z")
+    manager.vehicles = {}
+
+    manager.initialize_vehicles()
+
+    assert manager.vehicles["test-vehicle"].supports_valet_mode is True


### PR DESCRIPTION
Adds `Vehicle.valet_mode_active`, `Vehicle.supports_valet_mode`, `ApiImpl.supports_valet_mode`, and `ApiImplType1.supports_valet_mode`. `VehicleManager` copies the capability flag to each vehicle during initialization.

This supports the kia_uvo v3.5.0 regression fix for valet (#1748 / #1747) by giving the integration a safe attribute to read and a capability flag to gate valet buttons.