### PR TITLE
refactor(ApiImplType1): drop redundant float() on temperature values

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -297,13 +297,13 @@ class ApiImplType1(ApiImpl):
         )
 
         if air_temp not in (None, "OFF") and unit in TEMPERATURE_UNITS:
-            vehicle.air_temperature = (float(air_temp), TEMPERATURE_UNITS[unit])
+            vehicle.air_temperature = (air_temp, TEMPERATURE_UNITS[unit])
 
         outside_temp = get_child_value(state, "Cabin.HVAC.OutsideTemperature.Value")
         outside_temp_unit = get_child_value(state, "Cabin.HVAC.OutsideTemperature.Unit")
         if outside_temp is not None and outside_temp_unit is not None:
             vehicle.outside_temperature = (
-                float(outside_temp),
+                outside_temp,
                 TEMPERATURE_UNITS[outside_temp_unit],
             )
 


### PR DESCRIPTION
## Summary

Follow-up cleanup to #1209. Now that the `Vehicle.air_temperature` and `Vehicle.outside_temperature` setters coerce their value through `float_or_none()`, the explicit `float(...)` wrappers in `ApiImplType1._update_vehicle_properties_ccs2` are dead code. Remove them.

## Changes

`hyundai_kia_connect_api/ApiImplType1.py` — two sites only:

```python
# air_temperature — was (float(air_temp), ...), now (air_temp, ...)
vehicle.air_temperature = (air_temp, TEMPERATURE_UNITS[unit])

# outside_temperature — was (float(outside_temp), ...), now (outside_temp, ...)
vehicle.outside_temperature = (
    outside_temp,
    TEMPERATURE_UNITS[outside_temp_unit],
)
```

## Guards left untouched

The surrounding guards are **not** redundant and stay verbatim:

- `if air_temp not in (None, "OFF") and unit in TEMPERATURE_UNITS:` — the `unit in TEMPERATURE_UNITS` part protects `TEMPERATURE_UNITS[unit]` from a KeyError on an invalid unit; the value-filter part preserves the existing "no value → no unit assigned" behavior (the setter would coerce the value to `None` but would still set the unit, which would be a behavior change for HA's "unknown" state).
- `if outside_temp is not None and outside_temp_unit is not None:` — gates the unit lookup the same way.

## Behavior

Identical. Values that pass the guards are numeric, so `float(air_temp)` and `float_or_none(air_temp)` (in the setter) produce the same result. `None`/`"OFF"` are filtered by the guards before the setter; the setter also handles them as a backstop. No observable difference for any CCS2/EU/CA/AU/CN fixture.

## Testing

Behavior-preserving refactor — no new tests.
- `tests/test_vehicle_snapshots.py` — 8 snapshots pass, **byte-identical** (setter still emits floats; no `--snapshot-update` needed).
- Full suite: 271 passed, 11 skipped, 0 failed.
- `ruff check . && ruff format .` clean; pre-commit hooks pass.

## Out of scope

- Guard simplification (would change unit-assignment behavior when the value is absent).
- Other backend files (AU/CN/EU/IN/USA/BR/CA do not wrap temperature in `float()`; only `ApiImplType1` did).
- The unrelated `float(...)` on `total_driving_range` at `ApiImplType1.py:521`.