### PR TITLE
feat(ca): persist device_id to stop OTP-on-refresh reauth loop (kia_uvo#1715)

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -289,6 +289,7 @@ class KiaUvoApiCA(ApiImpl):
             password=password,
             access_token=access_token,
             refresh_token=refresh_token,
+            device_id=self._device_id,
             valid_until=valid_until,
             pin=pin,
         )
@@ -401,6 +402,7 @@ class KiaUvoApiCA(ApiImpl):
             password=password,
             access_token=access_token,
             refresh_token=refresh_token,
+            device_id=self._device_id,
             valid_until=valid_until,
             pin=pin,
         )

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -137,14 +137,25 @@ class KiaUvoApiCA(ApiImpl):
             "client_secret": "CLISCR01AHSPA",
         }
         self._sessions = None
+        # Cached device_id. Seeded from the persisted Token by refresh_access_token
+        # (so re-login reuses it), or computed once from MAC+hostname on first login.
+        self._device_id: str | None = None
 
     def _get_device_id(self) -> str:
-        """Generate a deterministic device ID based on MAC address and hostname.
-        This ensures the same device ID is used across sessions, avoiding OTP triggers."""
-        device_uuid = uuid.uuid5(
-            uuid.NAMESPACE_DNS, f"{uuid.getnode():x}-{platform.node() or ''}"
-        )
-        return base64.b64encode(device_uuid.hex.encode()).decode()
+        """Return a stable device ID, persisted across re-logins.
+
+        Reuse the cached device_id if set (seeded from the persisted Token by
+        refresh_access_token, or computed on first login). Otherwise derive it
+        deterministically from MAC+hostname (uuid5) and cache it. Caching means
+        a Docker restart with a changed MAC/hostname no longer produces a new
+        device_id the server does not recognize (kia_uvo#1715).
+        """
+        if self._device_id is None:
+            device_uuid = uuid.uuid5(
+                uuid.NAMESPACE_DNS, f"{uuid.getnode():x}-{platform.node() or ''}"
+            )
+            self._device_id = base64.b64encode(device_uuid.hex.encode()).decode()
+        return self._device_id
 
     def get_implementation_by_region_brand(self, region, brand, language):
         return KiaUvoApiCA(region, brand, language)

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -294,6 +294,20 @@ class KiaUvoApiCA(ApiImpl):
             pin=pin,
         )
 
+    def refresh_access_token(self, token: Token) -> Token | OTPRequest:
+        """Refresh the token. CA has no refresh endpoint, so this re-logs-in.
+
+        Carry forward the persisted device_id so the server still recognizes
+        the device and does not trigger OTP (kia_uvo#1715). When the Token has
+        no device_id (first run after upgrade from a pre-fix install), fall back
+        to the deterministic uuid5(MAC+hostname) computed inside login().
+        """
+        if token.device_id:
+            self._device_id = token.device_id
+        return self.login(
+            username=token.username, password=token.password, pin=token.pin
+        )
+
     def send_otp(self, otp_request: OTPRequest, notify_type: OTP_NOTIFY_TYPE) -> None:
         """Sends OTP to the user via selected destination"""
         url = self.API_URL + "mfa/sendotp"

--- a/tests/test_ca_device_id_persistence.py
+++ b/tests/test_ca_device_id_persistence.py
@@ -11,8 +11,9 @@ persists it.
 
 import base64
 import uuid
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+from hyundai_kia_connect_api.ApiImpl import OTPRequest
 from hyundai_kia_connect_api.KiaUvoApiCA import KiaUvoApiCA
 
 
@@ -56,3 +57,52 @@ def test_get_device_id_caches_first_computation():
     assert first == second
     assert mock_uuid5.call_count == 1
     assert first == base64.b64encode(sentinel.hex.encode()).decode()
+
+
+def test_login_persists_device_id_in_token():
+    api = KiaUvoApiCA(region=2, brand=1, language="en")
+    api._sessions = MagicMock()
+    api._sessions.post.return_value = _FakeResponse(_login_ok_payload())
+    token = api.login(username="user@test.com", password="pw", pin="1234")
+    assert token.device_id is not None
+    assert token.device_id == api._device_id
+
+
+def test_verify_otp_and_complete_login_persists_device_id_in_token():
+    api = KiaUvoApiCA(region=2, brand=1, language="en")
+    validate_resp = {
+        "responseHeader": {"responseCode": 0},
+        "result": {"verifiedOtp": True, "otpValidationKey": "OVK"},
+    }
+    genmfatkn_resp = {
+        "responseHeader": {"responseCode": 0},
+        "result": {
+            "token": {
+                "expireIn": 86400,
+                "accessToken": "AT",
+                "refreshToken": "RT",
+            }
+        },
+    }
+    api._sessions = MagicMock()
+    api._sessions.post.side_effect = [
+        _FakeResponse(validate_resp),
+        _FakeResponse(genmfatkn_resp),
+    ]
+    otp_request = OTPRequest(
+        request_id="user-info-uuid",
+        otp_key="OTPKEY",
+        has_email=True,
+        has_sms=False,
+        email="user@test.com",
+        sms=None,
+    )
+    token = api.verify_otp_and_complete_login(
+        username="user@test.com",
+        password="pw",
+        otp_code="9999",
+        otp_request=otp_request,
+        pin="1234",
+    )
+    assert token.device_id is not None
+    assert token.device_id == api._device_id

--- a/tests/test_ca_device_id_persistence.py
+++ b/tests/test_ca_device_id_persistence.py
@@ -1,0 +1,58 @@
+"""Tests for KiaUvoApiCA device_id persistence (kia_uvo#1715).
+
+CA has no refresh endpoint, so token refresh re-logs-in. Previously device_id
+was regenerated from uuid5(MAC+hostname) on every login and never stored in
+the Token — a Docker restart with a changed MAC/hostname produced a new
+device_id the server did not recognize, triggering 7110 OTP. These tests lock
+in the fix: device_id is cached on the instance, seeded from the persisted
+Token on refresh, and written into the returned Token so the HA coordinator
+persists it.
+"""
+
+import base64
+import uuid
+from unittest.mock import patch
+
+from hyundai_kia_connect_api.KiaUvoApiCA import KiaUvoApiCA
+
+
+class _FakeResponse:
+    """Minimal stand-in for requests.Response used by CA login/OTP flows."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+    @property
+    def text(self):
+        import json
+
+        return json.dumps(self._payload)
+
+
+def _login_ok_payload():
+    return {
+        "responseHeader": {"responseCode": 0},
+        "result": {
+            "token": {
+                "expireIn": 86400,
+                "accessToken": "AT",
+                "refreshToken": "RT",
+            }
+        },
+    }
+
+
+def test_get_device_id_caches_first_computation():
+    api = KiaUvoApiCA(region=2, brand=1, language="en")
+    sentinel = uuid.UUID("11111111-2222-3333-4444-555566667777")
+    with patch(
+        "hyundai_kia_connect_api.KiaUvoApiCA.uuid.uuid5", return_value=sentinel
+    ) as mock_uuid5:
+        first = api._get_device_id()
+        second = api._get_device_id()
+    assert first == second
+    assert mock_uuid5.call_count == 1
+    assert first == base64.b64encode(sentinel.hex.encode()).decode()

--- a/tests/test_ca_device_id_persistence.py
+++ b/tests/test_ca_device_id_persistence.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock, patch
 
 from hyundai_kia_connect_api.ApiImpl import OTPRequest
 from hyundai_kia_connect_api.KiaUvoApiCA import KiaUvoApiCA
+from hyundai_kia_connect_api.Token import Token
 
 
 class _FakeResponse:
@@ -106,3 +107,61 @@ def test_verify_otp_and_complete_login_persists_device_id_in_token():
     )
     assert token.device_id is not None
     assert token.device_id == api._device_id
+
+
+def test_refresh_access_token_reuses_persisted_device_id():
+    """The #1715 regression test: refresh must reuse the device_id from the
+    persisted Token, not regenerate it from MAC/hostname — even when those
+    have drifted since the Token was stored."""
+    api = KiaUvoApiCA(region=2, brand=1, language="en")
+    api._sessions = MagicMock()
+    api._sessions.post.return_value = _FakeResponse(_login_ok_payload())
+    token_in = Token(
+        username="u",
+        password="p",
+        pin="1234",
+        access_token="old",
+        refresh_token="oldrt",
+        device_id="PERSISTED-X",
+    )
+    # Patch the MAC/hostname inputs to DIFFERENT values to prove they are
+    # not consulted when the Token already carries a device_id.
+    with (
+        patch("hyundai_kia_connect_api.KiaUvoApiCA.uuid.getnode", return_value=999999),
+        patch(
+            "hyundai_kia_connect_api.KiaUvoApiCA.platform.node",
+            return_value="drifted-host",
+        ),
+        patch("hyundai_kia_connect_api.KiaUvoApiCA.uuid.uuid5") as mock_uuid5,
+    ):
+        token_out = api.refresh_access_token(token_in)
+    assert api._device_id == "PERSISTED-X"
+    assert token_out.device_id == "PERSISTED-X"
+    sent_headers = api._sessions.post.call_args.kwargs["headers"]
+    assert sent_headers["Deviceid"] == "PERSISTED-X"
+    mock_uuid5.assert_not_called()
+
+
+def test_refresh_access_token_computes_device_id_when_token_has_none():
+    """Upgrade path: an old persisted Token has device_id=None (CA never wrote
+    it before this fix). refresh must then fall back to uuid5(MAC+hostname)."""
+    api = KiaUvoApiCA(region=2, brand=1, language="en")
+    api._sessions = MagicMock()
+    api._sessions.post.return_value = _FakeResponse(_login_ok_payload())
+    token_in = Token(
+        username="u",
+        password="p",
+        pin="1234",
+        access_token="old",
+        refresh_token="oldrt",
+        device_id=None,
+    )
+    sentinel = uuid.UUID("22222222-3333-4444-5555-666677778888")
+    with patch(
+        "hyundai_kia_connect_api.KiaUvoApiCA.uuid.uuid5", return_value=sentinel
+    ) as mock_uuid5:
+        token_out = api.refresh_access_token(token_in)
+    mock_uuid5.assert_called_once()
+    expected = base64.b64encode(sentinel.hex.encode()).decode()
+    assert token_out.device_id == expected
+    assert api._device_id == expected


### PR DESCRIPTION
## What

CA (Hyundai Canada / Kia Canada / Genesis Canada) currently requires re-authentication (email + password + PIN) every few days, surfacing as **"OTP required to refresh token"** (resCode `7110`). Fixes [kia_uvo#1715](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/pull/1212).

## Root cause

CA has no refresh endpoint, so `VehicleManager.check_and_refresh_token` calls `refresh_access_token` → (no CA override) the base `ApiImpl.refresh_access_token` calls `login(username, password, pin)` with **no device_id**.

`KiaUvoApiCA.login()` generates `device_id` via `uuid.uuid5(NAMESPACE_DNS, f"{uuid.getnode():x}-{platform.node()}")` (deterministic from MAC + hostname) and puts it **only in request headers** — it is **never assigned to `token.device_id`**.

If MAC (`uuid.getnode()`) or hostname (`platform.node()`) drifts across an HA restart (common with Docker), `uuid5` produces a different value → the server does not recognize the device → `7110` → OTP → reauth flow.

The kia_uvo coordinator already persists the whole `Token` (including `device_id` via `asdict`), but CA never wrote `device_id` into the token, so the persisted token always had `device_id = None` — saving/reloading bought nothing. (This matches @cdnninja's read: _"token is saved to ha and reloaded. However not sure that buys anything. Not sure we save and load device ids portion of token."_ — the persistence mechanism was fine; CA just never populated the field.)

## Fix (CA-only, surgical)

1. `KiaUvoApiCA.__init__`: cache `self._device_id: str | None = None`.
2. `_get_device_id()`: return the cached value if set; otherwise derive `uuid5(MAC+hostname)` once and cache it.
3. Both `Token(...)` return sites (`login()` no-OTP success + `verify_otp_and_complete_login()` OTP completion): add `device_id=self._device_id` so the coordinator persists it.
4. New `KiaUvoApiCA.refresh_access_token(token)` override: seed `self._device_id` from `token.device_id` before delegating to `login()`. When the persisted token carries a device_id (the steady state), re-login **reuses** it instead of recomputing from MAC/hostname — so a Docker restart with drifted MAC/hostname no longer triggers OTP.

No base-class contract change, no other regions touched, no kia_uvo change (its persistence already works). CA is the only region with this fragility — AU/IN/CN get a server-assigned device_id via `notifications/register` (already persisted); BR already uses `token.device_id or ccsp_device_id`; USA has no device_id.

## Data flow

- **First login:** cache empty → `uuid5(MAC+hostname)` computed once, cached, written into the `Token` → coordinator persists it. Identical to today for stable-MAC users.
- **Token expiry (~24h), same process:** `refresh_access_token` seeds cache from persisted `token.device_id` → `login()` reuses it → no recompute, no OTP even if MAC/hostname drifted meanwhile.
- **HA restart with drifted MAC/hostname:** `Token.from_dict` reloads the persisted `device_id`; `refresh_access_token` seeds the cache from it → `login()` uses the persisted value, **MAC/hostname are not consulted** → no OTP.
- **Upgrade from a pre-fix install:** old persisted token has `device_id=None` → `refresh_access_token` skips the seed → `login()` computes `uuid5(current MAC)` (today's value) → smooth upgrade; device_id henceforth persisted.

## Scope / honesty

This fixes the **MAC/hostname drift on restart** path — the primary suspected cause. If the real cause is a **server-side shortened "remember" window** (a secondary hypothesis from kia_uvo#1715 diagnostics), persistence alone will not eliminate OTP, but it is a strict improvement (a more stable device_id across the remember window) and never makes things worse. Deliberately **not** adding regenerate-and-retry on `7110`: auto-regenerating to dodge OTP could be read as circumventing a security gate.

## Tests

New `tests/test_ca_device_id_persistence.py` (5 tests, mocked `sessions`):
- `test_get_device_id_caches_first_computation` — `uuid5` called once across multiple calls.
- `test_login_persists_device_id_in_token` — `login()` success path returns `Token.device_id` populated.
- `test_verify_otp_and_complete_login_persists_device_id_in_token` — OTP-completion path persists `device_id`.
- `test_refresh_access_token_reuses_persisted_device_id` — the #1715 regression test: with MAC/hostname patched to **different** values, `refresh_access_token(Token(device_id="PERSISTED-X"))` reuses `PERSISTED-X` (header `Deviceid == "PERSISTED-X"`, `uuid5` not called).
- `test_refresh_access_token_computes_device_id_when_token_has_none` — upgrade path: `device_id=None` → `uuid5(MAC+hostname)` fallback.

Full suite: 256 passed, 8 snapshots passed. ruff clean. pre-commit green.

## Out of scope

- #1177 CA Cloudflare `__cf_bm` cookie (separate PR).
- CA HTTP timeout gap (#1151) — deferred until CA migrates to `ApiImplSession`.
- Other regions (already persist server-assigned device_id).
- kia_uvo manifest bump (automatic on API lib release).