### PR TITLE
chore: drop Python 3.10/3.11 support, align tooling to py312

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ["3.12"]
+                python-version: ["3.12", "3.13", "3.14"]
 
         steps:
             - uses: actions/checkout@v7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,8 @@ repos:
       rev: v3.21.2
       hooks:
           - id: pyupgrade
+            args:
+                - --py312-plus
     - repo: https://github.com/adrienverge/yamllint.git
       rev: v1.38.0
       hooks:
@@ -50,7 +52,7 @@ repos:
           - id: python-typing-update
             stages: [manual]
             args:
-                - --py311-plus
+                - --py312-plus
                 - --force
                 - --keep-updates
             files: ^(/.+)?[^/]+\.py$

--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -5,7 +5,6 @@ import functools
 import logging
 import math
 import threading
-from typing import Optional
 
 import time
 from time import sleep
@@ -240,7 +239,7 @@ class ApiImplType1(ApiImpl):
         return value
 
     def _get_authenticated_headers(
-        self, token: Token, ccs2_support: Optional[int] = None
+        self, token: Token, ccs2_support: int | None = None
     ) -> dict:
         return {
             "Authorization": token.access_token,

--- a/hyundai_kia_connect_api/KiaUvoApiCN.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCN.py
@@ -8,7 +8,6 @@ import math
 import typing as ty
 import uuid
 from time import sleep
-from typing import Optional
 from urllib.parse import parse_qs, urlparse
 from zoneinfo import ZoneInfo
 
@@ -128,7 +127,7 @@ class KiaUvoApiCN(ApiImplType1):
         self.GCM_SENDER_ID = 199360397125
 
     def _get_authenticated_headers(
-        self, token: Token, ccs2_support: Optional[int] = None
+        self, token: Token, ccs2_support: int | None = None
     ) -> dict:
         return {
             "Authorization": token.access_token,

--- a/hyundai_kia_connect_api/KiaUvoApiIN.py
+++ b/hyundai_kia_connect_api/KiaUvoApiIN.py
@@ -11,7 +11,6 @@ import re
 import time
 import typing as ty
 import uuid
-from typing import Optional
 from urllib.parse import parse_qs, urlparse
 from zoneinfo import ZoneInfo
 
@@ -112,7 +111,7 @@ class KiaUvoApiIN(ApiImplType1):
         self.CLIENT_ID: str = self.CCSP_SERVICE_ID
 
     def _get_authenticated_headers(
-        self, token: Token, ccs2_support: Optional[int] = None
+        self, token: Token, ccs2_support: int | None = None
     ) -> dict:
         return {
             "Authorization": token.access_token,

--- a/hyundai_kia_connect_api/KiaUvoApiUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiUSA.py
@@ -5,7 +5,6 @@ import datetime as dt
 import logging
 import ssl
 import time
-import typing as ty
 from datetime import datetime
 
 import certifi
@@ -364,7 +363,7 @@ class KiaUvoApiUSA(ApiImpl):
         return result
 
     @staticmethod
-    def _engine_type_from_fuel_type(fuel_type) -> ty.Optional[ENGINE_TYPES]:
+    def _engine_type_from_fuel_type(fuel_type) -> ENGINE_TYPES | None:
         # Only fuelType=4 (EV) is confirmed against a live Kia USA account
         # (2020 Niro EV). Mappings for ICE/PHEV/HEV are unknown, so leave
         # engine_type as None for those and let _update_vehicle_properties
@@ -373,9 +372,7 @@ class KiaUvoApiUSA(ApiImpl):
             return ENGINE_TYPES.EV
         return None
 
-    def refresh_vehicles(
-        self, token: Token, vehicles: ty.Union[list[Vehicle], Vehicle]
-    ) -> None:
+    def refresh_vehicles(self, token: Token, vehicles: list[Vehicle] | Vehicle) -> None:
         """
         Refresh the vehicle data provided in get_vehicles.
         Required for Kia USA as key is session specific

--- a/hyundai_kia_connect_api/Vehicle.py
+++ b/hyundai_kia_connect_api/Vehicle.py
@@ -3,7 +3,6 @@
 
 import logging
 import datetime
-import typing
 from dataclasses import dataclass, field
 
 from .utils import float_or_none, get_float, get_safe_local_datetime
@@ -98,10 +97,10 @@ class Vehicle:
 
     _last_updated_at: datetime.datetime = None
     _last_scanned_at: datetime.datetime = None
-    timezone: datetime.timezone = datetime.timezone.utc  # default UTC
+    timezone: datetime.timezone = datetime.UTC  # default UTC
 
-    dtc_count: typing.Union[int, None] = None
-    dtc_descriptions: typing.Union[dict, None] = None
+    dtc_count: int | None = None
+    dtc_descriptions: dict | None = None
 
     smart_key_battery_warning_is_on: bool = None
     washer_fluid_warning_is_on: bool = None
@@ -173,18 +172,18 @@ class Vehicle:
 
     # EV fields (EV/PHEV)
 
-    ev_charge_port_door_is_open: typing.Union[bool, None] = None
-    ev_charging_power: typing.Union[float, None] = None  # Charging power in kW
+    ev_charge_port_door_is_open: bool | None = None
+    ev_charging_power: float | None = None  # Charging power in kW
 
-    ev_charge_limits_dc: typing.Union[int, None] = None
-    ev_charge_limits_ac: typing.Union[int, None] = None
-    ev_charging_current: typing.Union[int, None] = (
+    ev_charge_limits_dc: int | None = None
+    ev_charge_limits_ac: int | None = None
+    ev_charging_current: int | None = (
         None  # Europe feature only, ac charging current limit
     )
-    ev_v2l_discharge_limit: typing.Union[int, None] = None
+    ev_v2l_discharge_limit: int | None = None
 
-    ev_v2l_status: typing.Union[bool, None] = None
-    ev_v2x_status: typing.Union[bool, None] = None
+    ev_v2l_status: bool | None = None
+    ev_v2x_status: bool | None = None
 
     # energy consumed and regenerated since the vehicle was paired with the account
     # (so not necessarily for the vehicle's lifetime)
@@ -317,46 +316,46 @@ class Vehicle:
     _ev_estimated_station_charge_duration_value: int = None
     _ev_estimated_station_charge_duration_unit: str = None
 
-    _ev_target_range_charge_AC: typing.Union[float, None] = None
-    _ev_target_range_charge_AC_value: typing.Union[float, None] = None
-    _ev_target_range_charge_AC_unit: typing.Union[str, None] = None
+    _ev_target_range_charge_AC: float | None = None
+    _ev_target_range_charge_AC_value: float | None = None
+    _ev_target_range_charge_AC_unit: str | None = None
 
-    _ev_target_range_charge_DC: typing.Union[float, None] = None
-    _ev_target_range_charge_DC_value: typing.Union[float, None] = None
-    _ev_target_range_charge_DC_unit: typing.Union[str, None] = None
+    _ev_target_range_charge_DC: float | None = None
+    _ev_target_range_charge_DC_value: float | None = None
+    _ev_target_range_charge_DC_unit: str | None = None
 
-    ev_power_consumption_battery_cooling: typing.Union[float, None] = None
-    ev_power_consumption_battery_heater: typing.Union[float, None] = None
-    ev_power_consumption_air_conditioning: typing.Union[float, None] = None
+    ev_power_consumption_battery_cooling: float | None = None
+    ev_power_consumption_battery_heater: float | None = None
+    ev_power_consumption_air_conditioning: float | None = None
 
-    ev_first_departure_enabled: typing.Union[bool, None] = None
-    ev_second_departure_enabled: typing.Union[bool, None] = None
+    ev_first_departure_enabled: bool | None = None
+    ev_second_departure_enabled: bool | None = None
 
-    ev_first_departure_days: typing.Union[list, None] = None
-    ev_second_departure_days: typing.Union[list, None] = None
+    ev_first_departure_days: list | None = None
+    ev_second_departure_days: list | None = None
 
-    ev_first_departure_time: typing.Union[datetime.time, None] = None
-    ev_second_departure_time: typing.Union[datetime.time, None] = None
+    ev_first_departure_time: datetime.time | None = None
+    ev_second_departure_time: datetime.time | None = None
 
-    ev_first_departure_climate_enabled: typing.Union[bool, None] = None
-    ev_second_departure_climate_enabled: typing.Union[bool, None] = None
+    ev_first_departure_climate_enabled: bool | None = None
+    ev_second_departure_climate_enabled: bool | None = None
 
-    _ev_first_departure_climate_temperature: typing.Union[float, None] = None
-    _ev_first_departure_climate_temperature_value: typing.Union[float, None] = None
-    _ev_first_departure_climate_temperature_unit: typing.Union[str, None] = None
+    _ev_first_departure_climate_temperature: float | None = None
+    _ev_first_departure_climate_temperature_value: float | None = None
+    _ev_first_departure_climate_temperature_unit: str | None = None
 
-    _ev_second_departure_climate_temperature: typing.Union[float, None] = None
-    _ev_second_departure_climate_temperature_value: typing.Union[float, None] = None
-    _ev_second_departure_climate_temperature_unit: typing.Union[str, None] = None
+    _ev_second_departure_climate_temperature: float | None = None
+    _ev_second_departure_climate_temperature_value: float | None = None
+    _ev_second_departure_climate_temperature_unit: str | None = None
 
-    ev_first_departure_climate_defrost: typing.Union[bool, None] = None
-    ev_second_departure_climate_defrost: typing.Union[bool, None] = None
+    ev_first_departure_climate_defrost: bool | None = None
+    ev_second_departure_climate_defrost: bool | None = None
 
-    ev_off_peak_start_time: typing.Union[datetime.time, None] = None
-    ev_off_peak_end_time: typing.Union[datetime.time, None] = None
-    ev_off_peak_charge_only_enabled: typing.Union[bool, None] = None
+    ev_off_peak_start_time: datetime.time | None = None
+    ev_off_peak_end_time: datetime.time | None = None
+    ev_off_peak_charge_only_enabled: bool | None = None
 
-    ev_schedule_charge_enabled: typing.Union[bool, None] = None
+    ev_schedule_charge_enabled: bool | None = None
 
     # IC fields (PHEV/HEV/IC)
     _fuel_driving_range: float = None

--- a/hyundai_kia_connect_api/utils.py
+++ b/hyundai_kia_connect_api/utils.py
@@ -4,7 +4,7 @@
 import datetime
 import re
 from enum import IntEnum
-from typing import Optional, TypeVar
+from typing import TypeVar
 
 
 T = TypeVar("T", bound=IntEnum)
@@ -95,7 +95,7 @@ def parse_datetime(value, timezone) -> datetime.datetime:
 
         if timezone:
             # First, make it aware of UTC since 'GMT' implies UTC
-            utc_dt = dt_object.replace(tzinfo=datetime.timezone.utc)
+            utc_dt = dt_object.replace(tzinfo=datetime.UTC)
             # Then convert to the target timezone
             return utc_dt.astimezone(timezone)
         else:
@@ -131,7 +131,7 @@ def detect_timezone_for_date(
     date: datetime.datetime,
     ref_date: datetime.datetime,
     timezones: list[datetime.timezone],
-) -> Optional[datetime.timezone]:
+) -> datetime.timezone | None:
     """
     Guess an appropriate timezone given a date with an unknown timezone and a
     nearby reference time in any valid timezone.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.ruff]
+target-version = "py312"

--- a/setup.py
+++ b/setup.py
@@ -24,14 +24,12 @@ test_requirements = [
 setup(
     author="Fuat Akgun",
     author_email="fuatakgun@gmail.com",
-    python_requires=">=3.10",
+    python_requires=">=3.12",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: 3.14",

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -8,9 +8,7 @@ def test_detect_timezone_for_date():
     eastern = ZoneInfo("Canada/Eastern")
     # apiStartDate 20221214192418 and lastStatusDate 20221214112426 are from
     # https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/488#issuecomment-1352038594
-    apiStartDate = datetime.datetime(
-        2022, 12, 14, 19, 24, 18, tzinfo=datetime.timezone.utc
-    )
+    apiStartDate = datetime.datetime(2022, 12, 14, 19, 24, 18, tzinfo=datetime.UTC)
     lastStatusDate = datetime.datetime(2022, 12, 14, 11, 24, 26)
     assert detect_timezone_for_date(lastStatusDate, apiStartDate, [pacific]) == pacific
     assert detect_timezone_for_date(lastStatusDate, apiStartDate, [eastern]) is None
@@ -19,7 +17,7 @@ def test_detect_timezone_for_date():
 def test_detect_timezone_for_date_newfoundland():
     # Newfoundland NDT is UTC-0230 (NST is UTC-0330). Yes, half an hour.
     tz = ZoneInfo("Canada/Newfoundland")
-    now_utc = datetime.datetime(2025, 9, 21, 23, 4, 30, tzinfo=datetime.timezone.utc)
+    now_utc = datetime.datetime(2025, 9, 21, 23, 4, 30, tzinfo=datetime.UTC)
     early = datetime.datetime(2025, 9, 21, 20, 34, 0)
     after = datetime.datetime(2025, 9, 21, 20, 34, 59)
     assert detect_timezone_for_date(early, now_utc, [tz]) == tz

--- a/tests/vehicle_snapshot_serializer.py
+++ b/tests/vehicle_snapshot_serializer.py
@@ -63,10 +63,10 @@ def _serialize_value(value):
     if isinstance(value, datetime.datetime):
         # Normalize to UTC for consistent snapshots across timezones
         if value.tzinfo is not None:
-            value = value.astimezone(datetime.timezone.utc)
+            value = value.astimezone(datetime.UTC)
         else:
             # Assume naive datetimes are in UTC
-            value = value.replace(tzinfo=datetime.timezone.utc)
+            value = value.replace(tzinfo=datetime.UTC)
         return value.isoformat()
     if isinstance(value, datetime.time):
         return value.isoformat()


### PR DESCRIPTION
## Motivation

The library currently declares three disagreeing Python-version stories:

- `setup.py`: `python_requires=">=3.10"` (declared floor 3.10)
- `.pre-commit-config.yaml`: `python-typing-update --py311-plus` (tooling target 3.11)
- `.github/workflows/python-tests.yml`: matrix `["3.12"]` (tested floor 3.12)
- ruff: no `target-version` set anywhere (runs on default)

This PR drops 3.10/3.11 and aligns everything to a single floor: **3.12**.

## Changes

Two commits:

1. **Config** — `setup.py` (`python_requires=">=3.12"`, drop 3.10/3.11 classifiers), new `pyproject.toml` (`[tool.ruff] target-version = "py312"`), `.pre-commit-config.yaml` (`pyupgrade --py312-plus`, `python-typing-update --py312-plus`), `python-tests.yml` matrix `["3.12", "3.13", "3.14"]`.
2. **Mechanical modernization** — generated by `pre-commit run pyupgrade --all-files` + `ruff check --fix` + `ruff format` + `python-typing-update --py312-plus`. `Optional[X]`->`X | None`, `Union[A,B]`->`A | B`, `Dict[K,V]`->`dict[K,V]`, `List[X]`->`list[X]`, `Tuple`->`tuple`, `Set`->`set`; unused `from typing import ...` removed. One manual touch in `KiaUvoApiUSA.py`: `ty.Optional`/`ty.Union` (via `import typing as ty`) -> `|` syntax, dropping the now-unused alias import (pyupgrade does not rewrite the `ty.`-prefixed forms). No behavior change — the existing 276-passed / 11-skipped test suite with syrupy snapshots stays green with zero snapshot regen.

The code diff in commit 2 is purely generated; a reviewer can verify it by re-running the same tool commands against commit 1.

## Verification

- `pytest tests/` — 276 passed, 11 skipped, 8 snapshots valid (zero regen)
- `ruff check .` / `ruff format --check .` — green
- `pre-commit run --all-files` — green (includes `mypy --strict --ignore-missing-imports`)
- Residual legacy typing (`Optional[` / `Union[` / `typing.Dict` / `ty.Optional` / ...) — 0

## Scope

- `hyundai_kia_connect_api` only. `kia_uvo` is already aligned (PR #1754 bumped its only Python pin to 3.14).
- Out of scope (separate follow-up PRs): the dead try/except + lone `# fmt: skip` in `HyundaiBlueLinkApiBR.py:294`; `# noqa` E501 on long JSON-key/User-Agent strings; `.DS_Store` missing from `.gitignore`.