### PR TITLE
fix(us): fail-fast timeout on findMyCar location request

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
@@ -350,7 +350,7 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
         url = self.API_URL + "rcs/rfc/findMyCar"
         headers = self._get_vehicle_headers(token, vehicle)
         try:
-            response = self.session.get(url, headers=headers)
+            response = self.session.get(url, headers=headers, timeout=(5, 10))
             response_json = response.json()
             _check_response_for_errors(response_json)
             _LOGGER.debug(f"{DOMAIN} - Get Vehicle Location {response_json}")

--- a/tests/us_findmycar_timeout_test.py
+++ b/tests/us_findmycar_timeout_test.py
@@ -1,0 +1,66 @@
+"""Tests for findMyCar per-call timeout in HyundaiBlueLinkApiUSA.
+
+_get_vehicle_location should pass a short per-call timeout so a hanging
+findMyCar endpoint fails fast (returning None) instead of blocking the
+coordinator update for up to 30s (session default read timeout).
+"""
+
+import datetime as dt
+import json
+from unittest.mock import MagicMock, patch
+
+from hyundai_kia_connect_api.HyundaiBlueLinkApiUSA import HyundaiBlueLinkApiUSA
+from hyundai_kia_connect_api.Vehicle import Vehicle
+
+
+class _FakeResponse:
+    def __init__(self, text=""):
+        self.text = text
+
+    def json(self):
+        return json.loads(self.text)
+
+
+def _make_api():
+    api = object.__new__(HyundaiBlueLinkApiUSA)
+    api.API_URL = "https://api.telematics.hyundaiusa.com/ac/v2/"
+    api.session = MagicMock()
+    return api
+
+
+def _make_vehicle():
+    return Vehicle(
+        id="test-id",
+        name="Tucson",
+        model="Tucson",
+        key="test-key",
+        timezone=dt.timezone.utc,
+    )
+
+
+class TestFindMyCarTimeout:
+    def test_findmycar_uses_short_timeout(self):
+        """session.get for findMyCar must be called with timeout=(5, 10)."""
+        api = _make_api()
+        token = MagicMock()
+        vehicle = _make_vehicle()
+        api.session.get = MagicMock(
+            return_value=_FakeResponse(text='{"coord": {"lat": 1.0, "lon": 2.0}}')
+        )
+        with patch.object(api, "_get_vehicle_headers", return_value={"X": "y"}):
+            api._get_vehicle_location(token, vehicle)
+        api.session.get.assert_called_once()
+        _, kwargs = api.session.get.call_args
+        assert kwargs.get("timeout") == (5, 10)
+
+    def test_findmycar_timeout_failure_returns_none(self):
+        """On timeout, _get_vehicle_location returns None (graceful)."""
+        from requests.exceptions import Timeout
+
+        api = _make_api()
+        token = MagicMock()
+        vehicle = _make_vehicle()
+        api.session.get = MagicMock(side_effect=Timeout("read timeout"))
+        with patch.object(api, "_get_vehicle_headers", return_value={"X": "y"}):
+            result = api._get_vehicle_location(token, vehicle)
+        assert result is None


### PR DESCRIPTION
## Problem

`HyundaiBlueLinkApiUSA._get_vehicle_location` called `self.session.get(url, headers=headers)` with the session default timeout `(connect=10, read=30)`. If the `rcs/rfc/findMyCar` endpoint hangs, the coordinator update blocks for up to 30s on read timeout.

The method already has `try/except Exception` returning `None` on failure, and the coordinator already falls back to cached `vehicleLocation` when location is `None`. So this is purely a fail-faster concern, not a correctness fix.

## Fix

Pass a per-call timeout on the findMyCar request only:

```python
response = self.session.get(url, headers=headers, timeout=(5, 10))
```

- `connect=5` (vs session 10), `read=10` (vs session 30).
- Only this one call. Other `session.get` calls in the file keep the session default.
- On timeout, `requests.exceptions.Timeout` is caught by the existing `except Exception` → returns `None` → coordinator uses cached `vehicleLocation`.
- **No retry added** — retrying would wake the vehicle and risk 12V battery drain. Fail-faster only.

## Tests

New `tests/us_findmycar_timeout_test.py` (2 tests): asserts `session.get` is called with `timeout=(5, 10)`; asserts a `Timeout` exception results in `None` (graceful). Full suite green. Ruff + pre-commit green.