### PR TITLE
perf(us): cache enrollment/details response across refresh cycles

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
@@ -128,6 +128,12 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
     # the default REMOTE_POLL.
     _action_service_types: dict[str, str] = {}
 
+    # Cached enrollment/details response. Capabilities, seat configs,
+    # generation and model rarely change, so the response is cached for
+    # the instance lifetime. get_vehicles force-refreshes (vehicle list
+    # can change); _get_vehicle_details uses the cache.
+    _enrollment_details_cache: dict | None = None
+
     def __init__(self, region: int, brand: int, language: str):
         self.LANGUAGE: str = language
         self.BASE_URL: str = "api.telematics.hyundaiusa.com"
@@ -282,13 +288,31 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
         # No refresh_token available — full login.
         return self.login(token.username, token.password, token.pin)
 
-    def _get_vehicle_details(self, token: Token, vehicle: Vehicle):
+    def _get_enrollment_details(
+        self, token: Token, force_refresh: bool = False
+    ) -> dict:
+        """Return enrollment details for the account, cached on the instance.
+
+        Capabilities, seat configs, generation and model change rarely, so
+        the response is cached for the instance lifetime. ``get_vehicles``
+        forces a refresh (the vehicle list can change); ``_get_vehicle_details``
+        uses the cache.
+        """
+        if self._enrollment_details_cache is not None and not force_refresh:
+            return self._enrollment_details_cache
         url = self.API_URL + "enrollment/details/" + token.username
         headers = self._get_authenticated_headers(token)
         response = self.session.get(url, headers=headers)
         _LOGGER.debug(f"{DOMAIN} - Get Vehicles Response {response.text}")
-        response = response.json()
-        _check_response_for_errors(response)
+        response_json = response.json()
+        _check_response_for_errors(response_json)
+        if "enrolledVehicleDetails" not in response_json:
+            raise AuthenticationError("Missing enrolledVehicleDetails in response")
+        self._enrollment_details_cache = response_json
+        return response_json
+
+    def _get_vehicle_details(self, token: Token, vehicle: Vehicle):
+        response = self._get_enrollment_details(token)
         for entry in response["enrolledVehicleDetails"]:
             entry = entry["vehicleDetails"]
             if entry["regid"] == vehicle.id:
@@ -885,14 +909,7 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
         self._update_vehicle_properties(vehicle, state)
 
     def get_vehicles(self, token: Token):
-        url = self.API_URL + "enrollment/details/" + token.username
-        headers = self._get_authenticated_headers(token)
-        response = self.session.get(url, headers=headers)
-        _LOGGER.debug(f"{DOMAIN} - Get Vehicles Response {response.text}")
-        response = response.json()
-        _check_response_for_errors(response)
-        if "enrolledVehicleDetails" not in response:
-            raise AuthenticationError("Missing enrolledVehicleDetails in response")
+        response = self._get_enrollment_details(token, force_refresh=True)
         result = []
         for entry in response["enrolledVehicleDetails"]:
             entry = entry["vehicleDetails"]

--- a/tests/us_enrollment_cache_test.py
+++ b/tests/us_enrollment_cache_test.py
@@ -1,0 +1,105 @@
+"""Tests for enrollment/details caching in HyundaiBlueLinkApiUSA.
+
+_get_vehicle_details is called every refresh cycle by
+update_vehicle_with_cached_state, but enrollment data (capabilities,
+seat configs, generation) rarely changes. Cache the response on the
+instance and reuse it; force-refresh only from get_vehicles (where the
+vehicle list can change).
+"""
+
+import datetime as dt
+import json
+from unittest.mock import MagicMock, patch
+
+from hyundai_kia_connect_api.HyundaiBlueLinkApiUSA import HyundaiBlueLinkApiUSA
+from hyundai_kia_connect_api.Vehicle import Vehicle
+
+
+class _FakeResponse:
+    def __init__(self, text=""):
+        self.text = text
+
+    def json(self):
+        return json.loads(self.text)
+
+
+def _enrollment_body(regid="rid1", nick="Test"):
+    return {
+        "enrolledVehicleDetails": [
+            {
+                "vehicleDetails": {
+                    "regid": regid,
+                    "nickName": nick,
+                    "vin": "VIN123",
+                    "evStatus": "E",
+                    "modelCode": "TMU",
+                    "enrollmentDate": "2024-01-01",
+                    "enrollmentStatus": "ACTIVE",
+                    "vehicleGeneration": "3",
+                }
+            }
+        ]
+    }
+
+
+def _make_api(response_text=None):
+    api = object.__new__(HyundaiBlueLinkApiUSA)
+    api.API_URL = "https://api.telematics.hyundaiusa.com/ac/v2/"
+    api.session = MagicMock()
+    api.data_timezone = dt.timezone.utc
+    if response_text is not None:
+        api.session.get = MagicMock(return_value=_FakeResponse(text=response_text))
+    return api
+
+
+def _make_vehicle(vid="rid1"):
+    return Vehicle(
+        id=vid,
+        name="Test",
+        model="TMU",
+        key="key1",
+        timezone=dt.timezone.utc,
+    )
+
+
+class TestEnrollmentCache:
+    def test_initial_cache_is_none(self):
+        api = _make_api()
+        assert api._enrollment_details_cache is None
+
+    def test_get_vehicle_details_caches_response(self):
+        """Second _get_vehicle_details call must not hit session.get again."""
+        body = json.dumps(_enrollment_body())
+        api = _make_api(response_text=body)
+        token = MagicMock()
+        vehicle = _make_vehicle()
+        with patch.object(api, "_get_authenticated_headers", return_value={}):
+            api._get_vehicle_details(token, vehicle)
+            api._get_vehicle_details(token, vehicle)
+        assert api.session.get.call_count == 1
+
+    def test_get_vehicles_force_refreshes_cache(self):
+        """get_vehicles must hit session.get even when cache is populated."""
+        body = json.dumps(_enrollment_body())
+        api = _make_api(response_text=body)
+        token = MagicMock()
+        with patch.object(api, "_get_authenticated_headers", return_value={}):
+            api._get_vehicle_details(token, _make_vehicle())
+            assert api._enrollment_details_cache is not None
+            api.get_vehicles(token)
+        assert api.session.get.call_count == 2
+
+    def test_get_vehicles_populates_cache_used_by_get_vehicle_details(self):
+        """After get_vehicles refreshes cache, _get_vehicle_details reuses it."""
+        body = json.dumps(_enrollment_body(regid="rid1", nick="Latest"))
+        api = _make_api(response_text=body)
+        token = MagicMock()
+        with patch.object(api, "_get_authenticated_headers", return_value={}):
+            api.get_vehicles(token)
+            assert api._enrollment_details_cache is not None
+            details = api._get_vehicle_details(token, _make_vehicle())
+        # _get_vehicle_details used the cache populated by get_vehicles
+        assert details["nickName"] == "Latest"
+        # Only one session.get call (from get_vehicles); _get_vehicle_details
+        # was a cache hit
+        assert api.session.get.call_count == 1


### PR DESCRIPTION
## Problem

`HyundaiBlueLinkApiUSA._get_vehicle_details` and `get_vehicles` both fetch `GET enrollment/details/{username}` independently. `update_vehicle_with_cached_state` calls `_get_vehicle_details` every refresh cycle (default 10 min), so enrollment data is re-fetched on every poll even though capabilities, seat configs, generation and model rarely change post-factory.

This is specific to the Hyundai Blue Link USA backend, which splits enrollment metadata from live vehicle status. Other regions (Kia USA `cmm/gvi`, EU CCS2) return everything in one combined call.

## Fix

Cache the enrollment/details response on the instance and reuse it:

```python
_enrollment_details_cache: dict | None = None

def _get_enrollment_details(self, token, force_refresh=False) -> dict:
    if self._enrollment_details_cache is not None and not force_refresh:
        return self._enrollment_details_cache
    # ... fetch + cache ...
    return response_json
```

- `_get_vehicle_details` -> `_get_enrollment_details(token)` (cache hit, no network).
- `get_vehicles` -> `_get_enrollment_details(token, force_refresh=True)` (vehicle list can change).
- Cache lives on the `HyundaiBlueLinkApiUSA` instance (held by `VehicleManager`). Re-login does not create a new instance; `get_vehicles` is called on setup/reauth and force-refreshes the cache.
- No TTL - simple invalidation via `get_vehicles`.

## Side benefit

Halves backend calls per refresh cycle for Hyundai USA (1 call - cached enrollment + live status - instead of 2).

## Tests

New `tests/us_enrollment_cache_test.py` (4 tests): initial cache `None`; second `_get_vehicle_details` call does not hit `session.get` (cache hit); `get_vehicles` force-refreshes even when cache populated; after `get_vehicles` populates cache, `_get_vehicle_details` reuses it (1 total `session.get` call). Full suite green. Ruff + pre-commit green.