### PR TITLE
fix: return None instead of 2000-01-01 sentinel for missing timestamps

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -657,9 +657,9 @@ class ApiImplType1(ApiImpl):
                 vehicle.ev_battery_is_charging = True
 
         if get_child_value(state, "Location.GeoCoord.Latitude"):
-            location_last_updated_at = dt.datetime(
-                2000, 1, 1, tzinfo=self.data_timezone
-            )
+            # Missing Location.TimeStamp must surface as None (HA "unknown")
+            # rather than a 2000-01-01 sentinel that renders as "27 years ago".
+            # See kia_uvo #1771 sidetask.
             timestamp = get_child_value(state, "Location.TimeStamp")
             if timestamp is not None:
                 location_last_updated_at = dt.datetime(
@@ -671,6 +671,8 @@ class ApiImplType1(ApiImpl):
                     second=int(get_child_value(timestamp, "Sec")),
                     tzinfo=self.data_timezone,
                 )
+            else:
+                location_last_updated_at = None
 
             vehicle.location = (
                 get_child_value(state, "Location.GeoCoord.Latitude"),

--- a/hyundai_kia_connect_api/utils.py
+++ b/hyundai_kia_connect_api/utils.py
@@ -102,9 +102,11 @@ def get_index_into_hex_temp(value):
         return None
 
 
-def parse_datetime(value, timezone) -> datetime.datetime:
+def parse_datetime(value, timezone) -> datetime.datetime | None:
+    # Missing timestamp must surface as None (HA renders "unknown") rather than
+    # a 2000-01-01 sentinel that renders as "27 years ago". See kia_uvo #1771.
     if value is None:
-        return datetime.datetime(2000, 1, 1, tzinfo=timezone)
+        return None
 
     # Try parsing the new format: Tue, 24 Jun 2025 16:18:10 GMT
     try:

--- a/tests/test_ccs2_vehicle_properties.py
+++ b/tests/test_ccs2_vehicle_properties.py
@@ -145,3 +145,25 @@ class TestCCS2WindowOpenLevel:
         ccs2_api._update_vehicle_properties_ccs2(vehicle, data)
         assert vehicle.front_left_window_is_open is None
         assert vehicle.back_right_window_is_open is None
+
+
+class TestCCS2LocationTimestampNone:
+    """kia_uvo #1771 sidetask: missing Location.TimeStamp must yield
+    location_last_updated_at None, not a 2000-01-01 sentinel ("27 years ago").
+    """
+
+    def test_location_timestamp_none_yields_none(self, ccs2_api, vehicle):
+        data = load_fixture(CCS2_FIXTURE_FILES[0])
+        del data["Location"]["TimeStamp"]
+        ccs2_api._update_vehicle_properties_ccs2(vehicle, data)
+        assert vehicle.location_latitude == 48.8566
+        assert vehicle.location_longitude == 2.3522
+        assert vehicle.location_last_updated_at is None
+
+    def test_location_timestamp_present_yields_datetime(self, ccs2_api, vehicle):
+        data = load_fixture(CCS2_FIXTURE_FILES[0])
+        ccs2_api._update_vehicle_properties_ccs2(vehicle, data)
+        ts = vehicle.location_last_updated_at
+        assert ts is not None
+        assert ts.year == 2024 and ts.month == 9 and ts.day == 15
+        assert ts.hour == 14 and ts.minute == 0 and ts.second == 0

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,6 +1,12 @@
 import datetime
+
+import pytest
 from zoneinfo import ZoneInfo
-from hyundai_kia_connect_api.utils import detect_timezone_for_date, float_or_none
+from hyundai_kia_connect_api.utils import (
+    detect_timezone_for_date,
+    float_or_none,
+    parse_datetime,
+)
 
 
 def test_detect_timezone_for_date():
@@ -52,3 +58,36 @@ def test_float_or_none_non_numeric():
 
 def test_float_or_none_empty_string():
     assert float_or_none("") is None
+
+
+def test_parse_datetime_none_returns_none():
+    # The fix: None input must return None, not a 2000-01-01 sentinel.
+    # Previously this returned datetime(2000, 1, 1) which HA rendered as
+    # "27 years ago" for location_last_updated_at (kia_uvo #1771 sidetask).
+    assert parse_datetime(None, datetime.UTC) is None
+
+
+def test_parse_datetime_none_no_timezone_returns_none():
+    # timezone=None path must also return None for None input.
+    assert parse_datetime(None, None) is None
+
+
+def test_parse_datetime_new_format_gmt():
+    tz = ZoneInfo("Europe/Warsaw")
+    result = parse_datetime("Tue, 24 Jun 2025 16:18:10 GMT", tz)
+    assert result == datetime.datetime(2025, 6, 24, 18, 18, 10, tzinfo=tz)
+
+
+def test_parse_datetime_old_compact_format():
+    result = parse_datetime("20250624161810", datetime.UTC)
+    assert result == datetime.datetime(2025, 6, 24, 16, 18, 10, tzinfo=datetime.UTC)
+
+
+def test_parse_datetime_old_iso_format_with_separators():
+    result = parse_datetime("2025-06-24T16:18:10Z", datetime.UTC)
+    assert result == datetime.datetime(2025, 6, 24, 16, 18, 10, tzinfo=datetime.UTC)
+
+
+def test_parse_datetime_invalid_raises():
+    with pytest.raises(ValueError):
+        parse_datetime("garbage", datetime.UTC)


### PR DESCRIPTION
## Root cause

`parse_datetime()` in `utils.py` returned `datetime(2000, 1, 1)` when `value` was `None`. Home Assistant rendered this sentinel as **"27 years ago"** for `location_last_updated_at` (and latently `last_updated_at`) across all regions. Reported in kia_uvo #1771 sidetask by LiveForToday (USA region).

From 2026, "27 years ago" ≈ 1999/2000 — the sentinel is `2000-01-01`, not the Unix epoch (which would be "56 years ago").

## Fix

Two changes:

1. `parse_datetime(value, tz)` returns `None` when `value is None` (return type widened to `datetime | None`). Affects 17 call sites across USA/EU/CA/AU/CN for both `last_updated_at` and `location_last_updated_at`.
2. `ApiImplType1._update_vehicle_properties_ccs2` drops its own hardcoded `datetime(2000, 1, 1)` fallback when `Location.TimeStamp` is absent. Affects EU+AU CCS2 location path.

Missing timestamp → `None` → HA shows "unknown" instead of "27 years ago".

## Safety

Audited all 17 `parse_datetime` callers. The only sentinel-dependent logic is `VehicleManager` force-refresh decision (`VehicleManager.py:169-181`): both the `is not None` branch (sentinel → very old → force refresh) and the `else` branch (`None` → force refresh) converge on the same force-refresh outcome. kia_uvo HA sensors (`last_updated_at`, `location_last_updated_at`) are display-only with no comparisons — `None` renders as "unknown". `get_safe_local_datetime` and the `Vehicle.last_updated_at` #931 workaround both short-circuit on `None`.

## Scope

Broader than just location: also fixes latent `last_updated_at` "27 years ago" when a region response omits the Date field (rare, since Date is usually present). Separate from PR #1218 (aux battery 255 — different sentinel, different code).

## Tests

- 6 new unit tests for `parse_datetime` (None→None, new GMT format, old compact, old ISO, invalid raises; with and without timezone).
- 2 new CCS2 location tests (`TimeStamp` absent → `None`; `TimeStamp` present → correct datetime).
- Full `pytest tests/` green (288 passed, 11 skipped, 8 snapshots). ruff + mypy --strict + pre-commit green.

Ref: kia_uvo #1771 sidetask.