### PR TITLE
fix(EU/AU/IN/CN): read CCS2 preconditioning from BatteryPreCondition.Status with WinterModeOperation fallback

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -553,12 +553,30 @@ class ApiImplType1(ApiImpl):
             TEMPERATURE_UNITS[0],
         )
 
-        battery_winter_mode = get_child_value(
+        winter_mode = get_child_value(
             state, "Green.BatteryManagement.WinterModeOperation"
         )
-        if battery_winter_mode is not None:
-            vehicle.ev_battery_winter_mode = bool(battery_winter_mode)
-            vehicle.ev_battery_precondition_enabled = bool(battery_winter_mode)
+        if winter_mode is not None:
+            vehicle.ev_battery_winter_mode = bool(winter_mode)
+
+        # EV battery preconditioning toggle.
+        # EV (e.g. IONIQ 5) reports Green.BatteryManagement.BatteryPreCondition.Status
+        # — a configuration setting (stable across ignition/climate state), not a
+        # runtime flag (BatteryConditioning is the runtime flag). HEV (e.g. Santa
+        # Fe) reports only WinterModeOperation; "winter mode" is itself the
+        # battery preconditioning/winter-heating toggle there, so keep it as the
+        # fallback (preserves existing HEV behaviour, no regression).
+        # Status enum confirmed via reporter dumps (kia_uvo #1652, 2026-07-12):
+        #   0 = disabled in vehicle settings, 2 = enabled in vehicle settings.
+        # Pre-#1205 this sensor aliased WinterModeOperation, which is absent on
+        # EVs -> the sensor never appeared (see API #1187).
+        battery_precondition_status = get_child_value(
+            state, "Green.BatteryManagement.BatteryPreCondition.Status"
+        )
+        if battery_precondition_status is not None:
+            vehicle.ev_battery_precondition_enabled = battery_precondition_status != 0
+        elif winter_mode is not None:
+            vehicle.ev_battery_precondition_enabled = bool(winter_mode)
 
         if get_child_value(state, "Green.Electric.SmartGrid.RealTimePower") is not None:
             vehicle.ev_charging_power = get_child_value(

--- a/tests/test_ccs2_precondition_status.py
+++ b/tests/test_ccs2_precondition_status.py
@@ -1,65 +1,139 @@
-"""Tests for CCS2 ev_battery_precondition_enabled sensor.
+"""Tests for CCS2 ev_battery_precondition_enabled read mapping.
 
-The CCS2 response field Green.BatteryManagement.WinterModeOperation
-is now mapped to both ev_battery_winter_mode and
-ev_battery_precondition_enabled, matching USA Kia and CA behaviour.
+EV (IONIQ 5) reports Green.BatteryManagement.BatteryPreCondition.Status —
+a configuration setting (stable across ignition/climate state), not a runtime
+flag (BatteryConditioning is the runtime flag). HEV (Santa Fe) reports only
+WinterModeOperation; "winter mode" is itself the battery preconditioning /
+winter-heating toggle there, so it is used as a fallback. This preserves
+existing HEV behaviour (no regression) while making the precondition sensor
+appear on EVs that report BatteryPreCondition.
+
+Status enum (confirmed via reporter dumps, kia_uvo #1652, 2026-07-12):
+  Status = 0 -> preconditioning disabled in vehicle settings
+  Status = 2 -> preconditioning enabled in vehicle settings
+Both dumps (disabled and enabled) have no WinterModeOperation key -> the
+#1187 alias (precondition = bool(WinterModeOperation)) never produced a
+sensor on EVs.
+
+The CCS2 states below are inlined (not loaded from tests/fixtures/) because
+they are minimal, target-specific, and derived from live reporter dumps that
+must not be committed verbatim (PII). Envelope fields (Date/Offset/Drivetrain)
+are present only where _update_vehicle_properties_ccs2 reads them
+unconditionally (DTE.Total/Unit are coerced with float()/indexed without a
+None guard).
 """
 
 import pytest
 
+from hyundai_kia_connect_api.ApiImplType1 import ApiImplType1
 from hyundai_kia_connect_api.Vehicle import Vehicle
-from hyundai_kia_connect_api.const import ENGINE_TYPES
+
+# Minimal CCS2 state envelope shared by all cases. Drivetrain.FuelSystem.DTE is
+# read unconditionally (float() + DISTANCE_UNITS index), so it must be present.
+_BASE_ENVELOPE = {
+    "Drivetrain": {
+        "Odometer": 5352.6,
+        "FuelSystem": {"DTE": {"Unit": 1, "Total": 225}},
+    },
+    "DrivingReady": 1,
+    "Date": "20260712120000",
+    "Offset": 120,
+}
+
+
+def _state(battery_management: dict) -> dict:
+    state = dict(_BASE_ENVELOPE)
+    state["Green"] = {
+        "DrivingReady": 1,
+        "BatteryManagement": battery_management,
+    }
+    return state
+
+
+# EV (IONIQ 5): preconditioning ENABLED in vehicle settings (kia_uvo #1652,
+# 2026-07-12). BatteryPreCondition.Status = 2, no WinterModeOperation.
+_IONIQ5_ENABLED = _state(
+    {
+        "SoH": {"Ratio": 100},
+        "BatteryRemain": {"Value": 109843.2, "Ratio": 42, "Unit": "kJ"},
+        "BatteryConditioning": 0,
+        "BatteryPreCondition": {"Status": 2, "TemperatureLevel": 2},
+        "BatteryCapacity": {"Value": 302400, "Unit": "kJ"},
+    }
+)
+
+# EV (IONIQ 5): preconditioning DISABLED in vehicle settings (kia_uvo #1652,
+# 2026-07-12). BatteryPreCondition.Status = 0, no WinterModeOperation.
+_IONIQ5_DISABLED = _state(
+    {
+        "SoH": {"Ratio": 100},
+        "BatteryRemain": {"Value": 125107.2, "Ratio": 47.5, "Unit": "kJ"},
+        "BatteryConditioning": 0,
+        "BatteryPreCondition": {"Status": 0, "TemperatureLevel": 2},
+        "BatteryCapacity": {"Value": 302400, "Unit": "kJ"},
+    }
+)
+
+# HEV (Santa Fe): WinterModeOperation = 0, no BatteryPreCondition. This is the
+# no-regression case — the fallback path must reproduce today's behaviour.
+_HEV_WINTER_MODE_OFF = _state(
+    {
+        "SoH": {"Ratio": 100},
+        "WinterModeOperation": 0,
+        "BatteryRemain": {"Value": 0, "Ratio": 49.5, "Unit": "kJ"},
+    }
+)
 
 
 @pytest.fixture
-def vehicle():
-    v = Vehicle()
-    v.id = "test-vehicle-id"
-    v.engine_type = ENGINE_TYPES.PHEV
-    return v
+def ccs2_api() -> ApiImplType1:
+    api = ApiImplType1.__new__(ApiImplType1)
+    api.data_timezone = None
+    api.temperature_range = [x * 0.5 for x in range(28, 60)]
+    return api
 
 
 class TestCCS2PreconditionSensor:
-    """Test that ev_battery_precondition_enabled mirrors ev_battery_winter_mode.
+    """Precondition read from BatteryPreCondition.Status (EV) with
+    WinterModeOperation fallback (HEV)."""
 
-    Both fields should be set from the same CCS2 source field
-    (Green.BatteryManagement.WinterModeOperation). This matches
-    USA Kia (batteryPrecondition) and CA (batteryPreconditiong).
-    """
-
-    def test_winter_mode_true_sets_precondition_true(self, vehicle):
-        """When winter_mode is True, precondition_enabled should also be True."""
-        vehicle.ev_battery_winter_mode = True
-        # In _update_vehicle_properties_ccs2, the code does:
-        #   vehicle.ev_battery_precondition_enabled = bool(battery_winter_mode)
-        # Simulate what the code does:
-        vehicle.ev_battery_precondition_enabled = bool(vehicle.ev_battery_winter_mode)
-
-        assert vehicle.ev_battery_winter_mode is True
+    def test_ioniq5_precondition_enabled_from_battery_precondition_status(
+        self, ccs2_api
+    ):
+        """EV (IONIQ 5): BatteryPreCondition.Status=2 -> precondition enabled."""
+        vehicle = Vehicle()
+        ccs2_api._update_vehicle_properties_ccs2(vehicle, _IONIQ5_ENABLED)
         assert vehicle.ev_battery_precondition_enabled is True
-
-    def test_winter_mode_false_sets_precondition_false(self, vehicle):
-        """When winter_mode is False, precondition_enabled should also be False."""
-        vehicle.ev_battery_winter_mode = False
-        vehicle.ev_battery_precondition_enabled = bool(vehicle.ev_battery_winter_mode)
-
-        assert vehicle.ev_battery_winter_mode is False
-        assert vehicle.ev_battery_precondition_enabled is False
-
-    def test_winter_mode_none_keeps_precondition_none(self, vehicle):
-        """When winter_mode is None (field absent), precondition_enabled stays None."""
-        # Both fields start as None in the Vehicle dataclass
+        # IONIQ 5 does not report WinterModeOperation -> winter_mode stays None.
         assert vehicle.ev_battery_winter_mode is None
-        assert vehicle.ev_battery_precondition_enabled is None
+
+    def test_ioniq5_precondition_disabled_from_battery_precondition_status(
+        self, ccs2_api
+    ):
+        """EV (IONIQ 5): BatteryPreCondition.Status=0 -> precondition disabled.
+
+        Confirmed via reporter dump (kia_uvo #1652, 2026-07-12): with
+        preconditioning turned OFF in the myHyundai app, Status reads 0.
+        """
+        vehicle = Vehicle()
+        ccs2_api._update_vehicle_properties_ccs2(vehicle, _IONIQ5_DISABLED)
+        assert vehicle.ev_battery_precondition_enabled is False
+        assert vehicle.ev_battery_winter_mode is None
+
+    def test_hev_precondition_falls_back_to_winter_mode(self, ccs2_api):
+        """HEV: no BatteryPreCondition -> fallback to WinterModeOperation=0 ->
+        False. No-regression guarantee: existing HEV behaviour is unchanged."""
+        vehicle = Vehicle()
+        ccs2_api._update_vehicle_properties_ccs2(vehicle, _HEV_WINTER_MODE_OFF)
+        assert vehicle.ev_battery_precondition_enabled is False
+        assert vehicle.ev_battery_winter_mode is False
 
     def test_precondition_field_exists_in_vehicle(self):
-        """Verify the field exists in Vehicle dataclass with correct type."""
         v = Vehicle()
         assert hasattr(v, "ev_battery_precondition_enabled")
         assert v.ev_battery_precondition_enabled is None
 
     def test_winter_mode_field_exists_in_vehicle(self):
-        """Verify the winter_mode field exists in Vehicle dataclass."""
         v = Vehicle()
         assert hasattr(v, "ev_battery_winter_mode")
         assert v.ev_battery_winter_mode is None


### PR DESCRIPTION
## Summary

- Read `ev_battery_precondition_enabled` from `Green.BatteryManagement.BatteryPreCondition.Status` (EV, e.g. IONIQ 5) with `WinterModeOperation` as a fallback (HEV, e.g. Santa Fe).
- Fixes #1187 follow-up: #1187 aliased precondition to `WinterModeOperation` and was never live-validated. On EVs `WinterModeOperation` is absent → the precondition sensor never appeared.

## Why

`GreenBatteryManagementApiResponse` has two distinct fields:
- `WinterModeOperation` (integer) — present on HEV (Santa Fe: `0`), absent on EV (IONIQ 5).
- `BatteryPreCondition` (`{Status, TemperatureLevel}`) — present on EV (IONIQ 5), absent on HEV.

Two IONIQ 5 dumps (kia_uvo #1730, car off and car on) show `BatteryPreCondition.Status=2` stable across ignition/climate state → it is a **configuration setting** (the thing a preconditioning switch would toggle), while `BatteryConditioning` is the runtime flag.

## Status enum — confirmed

The `Status` enum is **not decoded** in the myHyundai RE (`BatteryPreConditionStatusResponse(status=...)` appears only as a field name). It was confirmed via two additional reporter dumps (kia_uvo [#1652](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1652#issuecomment-4950168254), 2026-07-12):

| Vehicle setting | `BatteryPreCondition.Status` |
|---|---|
| Preconditioning **disabled** | `0` |
| Preconditioning **enabled** | `2` |

Both dumps have **no** `WinterModeOperation` key — confirming the #1187 alias never produced a sensor on EVs. Mapping: `Status != 0` → enabled.

## Behavioural changes

- **IONIQ 5 (EV):** `ev_battery_precondition_enabled` goes `None → True/False` (sensor appears; `Status=2 != 0` → `True`, `Status=0` → `False`).
- **Santa Fe (HEV):** **no change** — `BatteryPreCondition` absent → fallback to `bool(WinterModeOperation=0) = False` (same as today). No regression.
- `ev_battery_winter_mode` stays on `WinterModeOperation` only (decoupled from precondition).

## Out of scope

The switch/control side (kia_uvo #1652) is separate.

## Testing

- Rewrote `tests/test_ccs2_precondition_status.py` with inlined CCS2 states derived from the reporter dumps (enabled `Status=2`, disabled `Status=0`, HEV `WinterModeOperation=0`). States are inlined rather than committed as fixtures because they are derived from PII-bearing live dumps.
- 5 tests: EV enabled → `True`, EV disabled → `False`, HEV fallback → `False` (no-regression), plus two field-existence tests.
- `ruff check` + `ruff format` clean; pre-commit green.