### PR TITLE
fix(CCS2): tire pressure robustness — unknown unit + 255 sentinel

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -486,9 +486,21 @@ class ApiImplType1(ApiImpl):
         # See const.PRESSURE_UNITS / PRESSURE_SCALES. Per-tire *_unit labels are
         # read-only properties on Vehicle deriving from tire_pressure_unit.
         _pu_raw = get_child_value(state, "Chassis.Axle.Tire.PressureUnit")
-        vehicle.tire_pressure_unit = (
-            PressureUnit(_pu_raw) if _pu_raw is not None else None
-        )
+        if _pu_raw is None:
+            vehicle.tire_pressure_unit = None
+        else:
+            try:
+                vehicle.tire_pressure_unit = PressureUnit(_pu_raw)
+            except ValueError:
+                # Some vehicles return a PressureUnit not in the enum (e.g. 3,
+                # see API #1230 / kia_uvo #1784 #1785). Degrade gracefully instead
+                # of crashing the whole vehicle update / integration setup.
+                _LOGGER.warning(
+                    "%s - Unknown tire PressureUnit %r; tire pressure values ignored",
+                    DOMAIN,
+                    _pu_raw,
+                )
+                vehicle.tire_pressure_unit = None
         _scale = PRESSURE_SCALES.get(vehicle.tire_pressure_unit)
         _pfl = get_child_value(state, "Chassis.Axle.Row1.Left.Tire.Pressure")
         _pfr = get_child_value(state, "Chassis.Axle.Row1.Right.Tire.Pressure")

--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -502,10 +502,28 @@ class ApiImplType1(ApiImpl):
                 )
                 vehicle.tire_pressure_unit = None
         _scale = PRESSURE_SCALES.get(vehicle.tire_pressure_unit)
-        _pfl = get_child_value(state, "Chassis.Axle.Row1.Left.Tire.Pressure")
-        _pfr = get_child_value(state, "Chassis.Axle.Row1.Right.Tire.Pressure")
-        _prl = get_child_value(state, "Chassis.Axle.Row2.Left.Tire.Pressure")
-        _prr = get_child_value(state, "Chassis.Axle.Row2.Right.Tire.Pressure")
+
+        # 255 (0xFF) is the TPMS "no reading" sentinel, returned for all tires
+        # when the sensors haven't reported yet (car off / before driving). With
+        # any unit's scale it yields an impossible value (25.5 bar / 255 psi /
+        # 1275 kPa), so treat it as unknown. See kia_uvo #1783, API #1232.
+        def _pressure_or_none(raw: float | int | None) -> float | int | None:
+            if raw is None or raw == 255:
+                return None
+            return raw
+
+        _pfl = _pressure_or_none(
+            get_child_value(state, "Chassis.Axle.Row1.Left.Tire.Pressure")
+        )
+        _pfr = _pressure_or_none(
+            get_child_value(state, "Chassis.Axle.Row1.Right.Tire.Pressure")
+        )
+        _prl = _pressure_or_none(
+            get_child_value(state, "Chassis.Axle.Row2.Left.Tire.Pressure")
+        )
+        _prr = _pressure_or_none(
+            get_child_value(state, "Chassis.Axle.Row2.Right.Tire.Pressure")
+        )
         vehicle.tire_pressure_front_left = (
             round(_pfl * _scale, 1) if _pfl is not None and _scale is not None else None
         )

--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -23,9 +23,10 @@ from .Vehicle import Vehicle
 from .utils import (
     bool_or_none,
     get_child_value,
-    normalize_battery_soc,
     get_index_into_hex_temp,
+    normalize_battery_soc,
     parse_datetime,
+    pressure_or_none,
     window_is_open,
 )
 
@@ -502,26 +503,19 @@ class ApiImplType1(ApiImpl):
                 )
                 vehicle.tire_pressure_unit = None
         _scale = PRESSURE_SCALES.get(vehicle.tire_pressure_unit)
-
-        # 255 (0xFF) is the TPMS "no reading" sentinel, returned for all tires
-        # when the sensors haven't reported yet (car off / before driving). With
-        # any unit's scale it yields an impossible value (25.5 bar / 255 psi /
-        # 1275 kPa), so treat it as unknown. See kia_uvo #1783, API #1232.
-        def _pressure_or_none(raw: float | int | None) -> float | int | None:
-            if raw is None or raw == 255:
-                return None
-            return raw
-
-        _pfl = _pressure_or_none(
+        # 255 (0xFF) is the TPMS "no reading" sentinel (car off / before
+        # driving) -> pressure_or_none returns None so the entity shows
+        # unavailable instead of an impossible value. See kia_uvo #1783, #1232.
+        _pfl = pressure_or_none(
             get_child_value(state, "Chassis.Axle.Row1.Left.Tire.Pressure")
         )
-        _pfr = _pressure_or_none(
+        _pfr = pressure_or_none(
             get_child_value(state, "Chassis.Axle.Row1.Right.Tire.Pressure")
         )
-        _prl = _pressure_or_none(
+        _prl = pressure_or_none(
             get_child_value(state, "Chassis.Axle.Row2.Left.Tire.Pressure")
         )
-        _prr = _pressure_or_none(
+        _prr = pressure_or_none(
             get_child_value(state, "Chassis.Axle.Row2.Right.Tire.Pressure")
         )
         vehicle.tire_pressure_front_left = (

--- a/hyundai_kia_connect_api/utils.py
+++ b/hyundai_kia_connect_api/utils.py
@@ -95,6 +95,26 @@ def bool_or_none(value: Any) -> bool | None:
     return None if value is None else bool(value)
 
 
+# TPMS "no reading" sentinel: the CCS2 status returns raw tire Pressure = 255
+# (0xFF) for all tires when the sensors haven't reported yet (car off / before
+# driving). With any unit's scale that yields an impossible value (25.5 bar /
+# 255 psi / 1275 kPa), so it must surface as unknown, not a real pressure.
+# See kia_uvo #1783, API #1232.
+_TPMS_NO_READING_SENTINEL = 255
+
+
+def pressure_or_none(value: int | float | None) -> int | float | None:
+    """Return a tire pressure raw value, or None if it's the no-reading sentinel.
+
+    None passes through; 255 (0xFF, TPMS "no reading") -> None; everything else
+    is returned as-is for the caller to scale. ``PressureLow`` already flags
+    actual low/flat tires, so 0 is NOT treated as a sentinel here.
+    """
+    if value is None or value == _TPMS_NO_READING_SENTINEL:
+        return None
+    return value
+
+
 def normalize_battery_soc(
     value: int | float | None,
     sensor_reliability: int | None = None,

--- a/tests/test_ccs2_vehicle_properties.py
+++ b/tests/test_ccs2_vehicle_properties.py
@@ -234,6 +234,28 @@ def test_tire_pressure_missing_leaves_none(ccs2_api, vehicle, ccs2_state_new_fie
     assert vehicle.tire_pressure_front_left_unit is None
 
 
+def test_tire_pressure_unknown_unit_does_not_crash(
+    ccs2_api, vehicle, ccs2_state_new_fields
+):
+    # Some vehicles return a PressureUnit not in the enum (e.g. 3 — see API #1230,
+    # kia_uvo #1784/#1785). An unknown unit must NOT raise ValueError and break the
+    # whole vehicle update; it degrades gracefully: unit None, values None, no
+    # entities created.
+    ccs2_state_new_fields["Chassis"]["Axle"]["Tire"]["PressureUnit"] = 3
+    ccs2_state_new_fields["Chassis"]["Axle"]["Row1"]["Left"]["Tire"]["Pressure"] = 27
+    ccs2_state_new_fields["Chassis"]["Axle"]["Row1"]["Right"]["Tire"]["Pressure"] = 27
+    ccs2_state_new_fields["Chassis"]["Axle"]["Row2"]["Left"]["Tire"]["Pressure"] = 27
+    ccs2_state_new_fields["Chassis"]["Axle"]["Row2"]["Right"]["Tire"]["Pressure"] = 26
+    # Must not raise.
+    ccs2_api._update_vehicle_properties_ccs2(vehicle, ccs2_state_new_fields)
+    assert vehicle.tire_pressure_unit is None
+    assert vehicle.tire_pressure_front_left is None
+    assert vehicle.tire_pressure_front_right is None
+    assert vehicle.tire_pressure_rear_left is None
+    assert vehicle.tire_pressure_rear_right is None
+    assert vehicle.tire_pressure_front_left_unit is None
+
+
 def test_drive_mode(ccs2_api, vehicle, ccs2_state_new_fields):
     ccs2_api._update_vehicle_properties_ccs2(vehicle, ccs2_state_new_fields)
     assert vehicle.drive_mode == "Eco"

--- a/tests/test_ccs2_vehicle_properties.py
+++ b/tests/test_ccs2_vehicle_properties.py
@@ -256,7 +256,25 @@ def test_tire_pressure_unknown_unit_does_not_crash(
     assert vehicle.tire_pressure_front_left_unit is None
 
 
-def test_drive_mode(ccs2_api, vehicle, ccs2_state_new_fields):
+def test_tire_pressure_sensor_sentinel_is_unknown(
+    ccs2_api, vehicle, ccs2_state_new_fields
+):
+    # When the TPMS hasn't reported (car off / before driving), the API returns
+    # raw Pressure = 255 (0xFF) for all tires — a "no reading" sentinel, NOT a
+    # real pressure. Applying the scale gives impossible values (25.5 bar /
+    # 255 psi / 1275 kPa). Treat 255 as unknown -> None, no entity value.
+    # See kia_uvo #1783, API #1232 (live-confirmed on EU Santa Fe + Kia EV3).
+    axle = ccs2_state_new_fields["Chassis"]["Axle"]
+    axle["Tire"]["PressureUnit"] = 2  # bar
+    for row in ("Row1", "Row2"):
+        for side in ("Left", "Right"):
+            axle[row][side]["Tire"]["Pressure"] = 255
+    ccs2_api._update_vehicle_properties_ccs2(vehicle, ccs2_state_new_fields)
+    assert vehicle.tire_pressure_unit == PressureUnit.BAR
+    assert vehicle.tire_pressure_front_left is None
+    assert vehicle.tire_pressure_front_right is None
+    assert vehicle.tire_pressure_rear_left is None
+    assert vehicle.tire_pressure_rear_right is None
     ccs2_api._update_vehicle_properties_ccs2(vehicle, ccs2_state_new_fields)
     assert vehicle.drive_mode == "Eco"
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -7,6 +7,7 @@ from hyundai_kia_connect_api.utils import (
     detect_timezone_for_date,
     float_or_none,
     parse_datetime,
+    pressure_or_none,
 )
 
 
@@ -69,6 +70,23 @@ def test_bool_or_none_truthy():
 def test_bool_or_none_falsy():
     assert bool_or_none(0) is False
     assert bool_or_none("") is False
+
+
+def test_pressure_or_none_none():
+    assert pressure_or_none(None) is None
+
+
+def test_pressure_or_none_sentinel_255():
+    # 255 (0xFF) is the TPMS "no reading" sentinel (car off / before driving).
+    assert pressure_or_none(255) is None
+
+
+def test_pressure_or_none_real_value_passthrough():
+    # Known-good raw values pass through unchanged for the caller to scale.
+    assert pressure_or_none(27) == 27  # bar (raw 27 -> 2.7)
+    assert pressure_or_none(38) == 38  # psi
+    assert pressure_or_none(51) == 51  # kPa
+    assert pressure_or_none(0) == 0  # 0 is NOT a sentinel (could be a flat)
 
 
 def test_float_or_none_empty_string():


### PR DESCRIPTION
## Problems

After #1205 shipped in v4.24.0, several EU Hyundai/Kia users report tire-pressure issues ranging from a setup crash to impossible values.

### 1. Setup crash: `ValueError: 3 is not a valid PressureUnit`
- API #1230
- kia_uvo #1784
- kia_uvo #1785

`PressureUnit` is an `IntEnum` with only `PSI=0, KPA=1, BAR=2` (live-confirmed on my EU Santa Fe). Some vehicles return `PressureUnit=3`, so `PressureUnit(_pu_raw)` raises `ValueError`. That propagates out of `_update_vehicle_properties_ccs2` → `update_vehicle_with_cached_state` → `_async_update_data` → `UpdateFailed` → `ConfigEntryNotReady` — the **whole integration fails to load**, not just the tire entities.

This is a regression from my own review fix in #1205: the prior code used `PRESSURE_UNITS.get(_pu_raw)` (a dict), which returned `None` gracefully for unknown keys. Making the field a strict `IntEnum` turned graceful degradation into a hard crash. One unknown sensor value must not break the entire vehicle update.

**Fix:** construct `PressureUnit` inside `try/except ValueError` → `None` + warning. Unknown unit → no tire entities, no crash. Known units (0/1/2) unchanged.

### 2. Impossible values: `255 psi` / `25.5 bar` / `1275 kPa`
- kia_uvo #1783
- API #1232 (Kia EV3, raw 255/bar → 25.5)
- also kia_uvo #1730 (IONIQ 5, raw 255/bar)

When the TPMS hasn't reported yet (car off / before driving — the dashboard shows the same "unavailable" state until you drive some distance), the API returns raw `Pressure = 255` (0xFF) for all tires. The parser applied the scale blindly → impossible values (bar ×0.1 → 25.5 bar, psi ×1 → 255 psi, kPa ×5 → 1275 kPa).

**Live-confirmed** on my EU Santa Fe 2026: car off, `PressureUnit=2` (bar), all four tires raw `Pressure=255`, `PressureLow=0` → parser produced `25.5 bar` (matches the #1232 / #1783 reports).

**Fix:** treat raw `255` (0xFF) as a no-reading sentinel → `None` (entity shows unavailable instead of an impossible value). Applied per-tire, independent of unit. `PressureLow=0` already confirms it's not a flat. Known-good readings (e.g. raw 27 → 2.7 bar) unchanged.

## Out of scope
- What `PressureUnit = 3` actually maps to (kgf/cm²? a different encoding?) is being confirmed via reporter dumps (requested in #1230 / kia_uvo #1784). Once a dump confirms the unit + raw scale, a follow-up can add the enum member + scale. This PR makes the unknown case safe regardless.
- kia_uvo #1783 also mentions an AC/DC target-range screenshot item — separate, not addressed here.
- Force-refresh `KeyError: 'resMsg'` (kia_uvo #1786) is a pre-existing bug fixed by open PR #1184, not addressed here.

## Testing (TDD)
- `test_tire_pressure_unknown_unit_does_not_crash`: `PressureUnit=3` does not raise; `tire_pressure_unit is None`; all four `tire_pressure_*` `None`. (RED with the exact #1230 `ValueError`, GREEN after fix.)
- `test_tire_pressure_sensor_sentinel_is_unknown`: raw `Pressure=255` (bar) → all four `tire_pressure_*` `None` (not 25.5). (RED gave 25.5, GREEN after fix.)
- Full suite: 405 passed / 21 skipped. ruff + pre-commit clean.

Closes #1230. Relates to kia_uvo #1783, #1784, #1785, API #1232.
