### PR TITLE
refactor: inline TPMS 255 sentinel in pressure_or_none (no module var)

### DIFF
--- a/hyundai_kia_connect_api/utils.py
+++ b/hyundai_kia_connect_api/utils.py
@@ -95,22 +95,18 @@ def bool_or_none(value: Any) -> bool | None:
     return None if value is None else bool(value)
 
 
-# TPMS "no reading" sentinel: the CCS2 status returns raw tire Pressure = 255
-# (0xFF) for all tires when the sensors haven't reported yet (car off / before
-# driving). With any unit's scale that yields an impossible value (25.5 bar /
-# 255 psi / 1275 kPa), so it must surface as unknown, not a real pressure.
-# See kia_uvo #1783, API #1232.
-_TPMS_NO_READING_SENTINEL = 255
-
-
 def pressure_or_none(value: int | float | None) -> int | float | None:
     """Return a tire pressure raw value, or None if it's the no-reading sentinel.
 
-    None passes through; 255 (0xFF, TPMS "no reading") -> None; everything else
-    is returned as-is for the caller to scale. ``PressureLow`` already flags
-    actual low/flat tires, so 0 is NOT treated as a sentinel here.
+    None passes through; 255 (0xFF, TPMS "no reading" — the CCS2 status returns
+    it for all tires when the sensors haven't reported yet, e.g. car off / before
+    driving) -> None; everything else is returned as-is for the caller to scale.
+    With any unit's scale 255 yields an impossible value (25.5 bar / 255 psi /
+    1275 kPa), so it must surface as unknown. ``PressureLow`` already flags
+    actual low/flat tires, so 0 is NOT treated as a sentinel. See kia_uvo #1783,
+    API #1232.
     """
-    if value is None or value == _TPMS_NO_READING_SENTINEL:
+    if value is None or value == 255:
         return None
     return value
 


### PR DESCRIPTION
Follow-up to #1231 per review comment on `utils.py`:

> I don't love having this variable here in Utils however I will merge for now.

Drop the `_TPMS_NO_READING_SENTINEL = 255` module-level constant and inline `value == 255` in `pressure_or_none`, matching the existing `normalize_battery_soc` pattern (which inlines its sentinel checks — `value > 100`, `sensor_reliability == 1` — with a docstring rather than a named constant).

Behavior unchanged — the docstring keeps the full sentinel explanation (0xFF, "no reading" when TPMS hasn't reported, impossible after scaling, `PressureLow` covers flats) + issue refs (#1783, #1232). Existing tests (`test_pressure_or_none_sentinel_255`, `test_tire_pressure_sensor_sentinel_is_unknown`) still pass.

408 passed / 21 skipped, ruff + pre-commit clean.