### PR TITLE
feat(CCS2): map accessory_on / ign3 / sleep_mode_check (gap vs CA/IN)

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -543,6 +543,16 @@ class ApiImplType1(ApiImpl):
         vehicle.battery_auxiliary_fail_warning_is_on = bool_or_none(
             get_child_value(state, "Electronics.Battery.Auxiliary.FailWarning")
         )
+        # Power/ignition/sleep — gap vs CA/IN flat format.
+        vehicle.accessory_on = bool_or_none(
+            get_child_value(state, "Electronics.PowerSupply.Accessory")
+        )
+        vehicle.ign3 = bool_or_none(
+            get_child_value(state, "Electronics.PowerSupply.Ignition3")
+        )
+        vehicle.sleep_mode_check = bool_or_none(
+            get_child_value(state, "RemoteControl.SleepMode")
+        )
         vehicle.trunk_is_open = get_child_value(state, "Body.Trunk.Open")
 
         vehicle.ev_battery_percentage = get_child_value(

--- a/tests/test_ccs2_vehicle_properties.py
+++ b/tests/test_ccs2_vehicle_properties.py
@@ -168,6 +168,10 @@ def ccs2_state_new_fields():
     state.setdefault("Electronics", {}).setdefault("Battery", {}).setdefault(
         "Auxiliary", {}
     )["FailWarning"] = 0
+    # Car-ON overlay: Accessory/Ignition3=1, SleepMode=0 (asleep=False).
+    state.setdefault("Electronics", {}).setdefault("PowerSupply", {})["Accessory"] = 1
+    state.setdefault("Electronics", {}).setdefault("PowerSupply", {})["Ignition3"] = 1
+    state.setdefault("RemoteControl", {})["SleepMode"] = 0
     return state
 
 
@@ -307,6 +311,25 @@ def test_battery_auxiliary_fail_warning_missing_leaves_none(
     del ccs2_state_new_fields["Electronics"]["Battery"]["Auxiliary"]["FailWarning"]
     ccs2_api._update_vehicle_properties_ccs2(vehicle, ccs2_state_new_fields)
     assert vehicle.battery_auxiliary_fail_warning_is_on is None
+
+
+def test_power_supply_sleep_mapped(ccs2_api, vehicle, ccs2_state_new_fields):
+    # CCS2 gap vs CA/IN flat: accessory_on/ign3/sleep_mode_check mapped.
+    ccs2_api._update_vehicle_properties_ccs2(vehicle, ccs2_state_new_fields)
+    assert vehicle.accessory_on is True
+    assert vehicle.ign3 is True
+    assert vehicle.sleep_mode_check is False
+
+
+def test_power_supply_sleep_missing_leaves_none(
+    ccs2_api, vehicle, ccs2_state_new_fields
+):
+    ccs2_state_new_fields.pop("Electronics", None)
+    ccs2_state_new_fields.pop("RemoteControl", None)
+    ccs2_api._update_vehicle_properties_ccs2(vehicle, ccs2_state_new_fields)
+    assert vehicle.accessory_on is None
+    assert vehicle.ign3 is None
+    assert vehicle.sleep_mode_check is None
 
 
 class TestCCS2LocationTimestampNone:


### PR DESCRIPTION
## Summary

CCS2 status exposes `Electronics.PowerSupply.Accessory` / `Ignition3` and `RemoteControl.SleepMode`, but `_update_vehicle_properties_ccs2` never mapped them to `Vehicle` — so the `accessory_on` / `ign3` / `sleep_mode_check` binary sensors (already defined in kia_uvo and populated by the CA/IN flat-format parser) stayed `None` for EU/AU/CN CCS2 vehicles. This fills that gap.

## Change

Three mappings in `_update_vehicle_properties_ccs2`, via the existing `bool_or_none` helper (None when the field is absent — entity not created for vehicles without the sensor):

```python
vehicle.accessory_on = bool_or_none(get_child_value(state, "Electronics.PowerSupply.Accessory"))
vehicle.ign3 = bool_or_none(get_child_value(state, "Electronics.PowerSupply.Ignition3"))
vehicle.sleep_mode_check = bool_or_none(get_child_value(state, "RemoteControl.SleepMode"))
```

`transmission_condition` (str) is intentionally **not** mapped — the CCS2 dump only exposes `Drivetrain.Transmission.ParkingPosition` (int "in park"), no gear/transmission string, so there is no source for it. It stays `None` (no regression).

kia_uvo side: no change — the entities already exist and read these `Vehicle` attrs.

## Live confirmation

Confirmed across two powertrains:
- **HEV** (EU Santa Fe 2026, my car): Accessory/Ignition3/SleepMode track car on/off.
- **EV** (IONIQ 5, @Dolphine80 diagnostic dumps): same — Accessory/Ignition3 = 0 off / 1 on, SleepMode = 1 asleep / 0 awake.

So the mapping is correct for both HEV and EV.

## Testing

TDD: `test_power_supply_sleep_mapped` (RED before the mapping, GREEN after) + `test_power_supply_sleep_missing_leaves_none` (None when fields absent). Full suite 410 passed / 21 skipped; ruff + pre-commit clean.