### PR TITLE
refactor(ccs2): downgrade unknown PressureUnit log to debug

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -493,11 +493,13 @@ class ApiImplType1(ApiImpl):
             try:
                 vehicle.tire_pressure_unit = PressureUnit(_pu_raw)
             except ValueError:
-                # Some vehicles return a PressureUnit not in the enum (e.g. 3,
-                # see API #1230 / kia_uvo #1784 #1785). Degrade gracefully instead
-                # of crashing the whole vehicle update / integration setup.
-                _LOGGER.warning(
-                    "%s - Unknown tire PressureUnit %r; tire pressure values ignored",
+                # PressureUnit outside {0:psi,1:kpa,2:bar}; e.g. 3 on
+                # indirect-TPMS vehicles (no direct sensor, kia_uvo #1786) ->
+                # the car reports no per-tire pressure, so unavailable is
+                # correct. Expected on some vehicles, so debug, not warning.
+                _LOGGER.debug(
+                    "%s - Tire PressureUnit %r not in {0:psi,1:kpa,2:bar}; "
+                    "tire pressure values ignored",
                     DOMAIN,
                     _pu_raw,
                 )


### PR DESCRIPTION
## Problem

`PressureUnit` outside the known set {0:psi,1:kpa,2:bar} (e.g. `3` on indirect-TPMS vehicles — kia_uvo #1786, KONA EV) logged a `WARNING` on every cached state update. For vehicles without direct TPMS this is expected and permanent, so the warning spammed user logs for a benign condition.

## Change

Downgrade to `debug`. Behaviour unchanged — unknown unit still degrades gracefully (`tire_pressure_unit = None` → entities `unavailable`), which is correct for indirect-TPMS vehicles that report no per-tire pressure. Comment updated to record that unit 3 = indirect TPMS (no direct sensor).

## Testing

`tests/test_ccs2_vehicle_properties.py` — 30 passed (incl. `test_tire_pressure_unknown_unit_does_not_crash`, which asserts graceful None, not log level).

## Related

kia_uvo #1786 (dump confirmed unit 3 = indirect TPMS, all pressures 0 / PressureLow 0).