### PR TITLE
fix(USA): skip airTemp OFF instead of masking (#1790)

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
@@ -465,7 +465,7 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
             air_temp = self.temperature_range[0]
         if air_temp == "HI":
             air_temp = self.temperature_range[-1]
-        if air_temp:
+        if air_temp not in (None, "OFF"):
             vehicle.air_temperature = (air_temp, TEMPERATURE_UNITS[1])
         vehicle.defrost_is_on = get_child_value(state, "vehicleStatus.defrost")
         vehicle.steering_wheel_heater_is_on = get_child_value(

--- a/hyundai_kia_connect_api/KiaUvoApiUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiUSA.py
@@ -477,7 +477,7 @@ class KiaUvoApiUSA(ApiImpl):
             air_temp = self.temperature_range[0]
         if air_temp == "HIGH":
             air_temp = self.temperature_range[-1]
-        if air_temp:
+        if air_temp not in (None, "OFF"):
             vehicle.air_temperature = (air_temp, TEMPERATURE_UNITS[1])
         vehicle.defrost_is_on = get_child_value(
             state, "lastVehicleInfo.vehicleStatusRpt.vehicleStatus.climate.defrost"

--- a/tests/test_bluelink_usa_vehicle_properties.py
+++ b/tests/test_bluelink_usa_vehicle_properties.py
@@ -85,3 +85,37 @@ class TestBlueLinkUSAUpdateVehicleProperties:
         data = load_fixture(fixture_file)
         bluelink_api._update_vehicle_properties(vehicle, data)
         assert vehicle.data is data
+
+
+# ---------------------------------------------------------------------------
+# Regression: kia_uvo #1790 — airTemp "OFF" (climate off) must not mask
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def bluelink_status_with_air_temp_off():
+    """Minimal Hyundai USA cached-status payload with airTemp.value == OFF."""
+    return {
+        "vehicleStatus": {
+            "airTemp": {"value": "OFF", "unit": 1, "hvacTempType": 1},
+        },
+    }
+
+
+def test_bluelink_air_temp_off_yields_none(
+    bluelink_api, bluelink_status_with_air_temp_off
+):
+    """Regression for kia_uvo #1790: when climate is off, the USA backend
+    returns airTemp.value == "OFF". The setter must NOT be called with a
+    non-numeric string; air_temperature and the raw value slot stay None so
+    the kia_uvo sensor reports `unknown` (data unknown), not a fake setpoint.
+
+    Note: float_or_none("OFF") already yields None, so asserting only on
+    air_temperature would pass before the fix. The behavioral difference
+    the conformance fixes is that the setter is not called at all — so the
+    raw value slot (_air_temperature_value) stays None instead of holding
+    the string "OFF". Assert on that side effect as the real TDD gate."""
+    vehicle = Vehicle()
+    bluelink_api._update_vehicle_properties(vehicle, bluelink_status_with_air_temp_off)
+    assert vehicle.air_temperature is None
+    assert vehicle._air_temperature_value is None

--- a/tests/test_usa_vehicle_properties.py
+++ b/tests/test_usa_vehicle_properties.py
@@ -139,3 +139,39 @@ def test_usa_air_temperature_string_becomes_float(us_kia_status_with_air_temp):
     assert vehicle.air_temperature is not None
     assert isinstance(vehicle.air_temperature, float)
     assert vehicle.air_temperature == 72.0
+
+
+# ---------------------------------------------------------------------------
+# Regression: kia_uvo #1790 — Kia USA airTemp "OFF" (climate off) must not mask
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def us_kia_status_with_air_temp_off():
+    """Minimal USA cached-status payload with airTemp.value == OFF."""
+    return {
+        "lastVehicleInfo": {
+            "vehicleStatusRpt": {
+                "vehicleStatus": {
+                    "climate": {
+                        "airTemp": {"value": "OFF"},
+                    },
+                },
+            },
+        },
+    }
+
+
+def test_usa_air_temperature_off_yields_none(us_kia_status_with_air_temp_off):
+    """Regression for kia_uvo #1790: Kia USA airTemp "OFF" (climate off) must
+    leave air_temperature and the raw value slot as None, matching the Hyundai
+    USA / Type1 / CA skip-OFF conformance. float_or_none("OFF") already yields
+    None, so the real TDD gate is _air_temperature_value staying None (setter
+    not called)."""
+    api = KiaUvoApiUSA.__new__(KiaUvoApiUSA)
+    api.data_timezone = None
+    api.temperature_range = [62, 64, 66, 68, 70, 72, 74, 76, 78, 80, 82]
+    vehicle = Vehicle()
+    api._update_vehicle_properties(vehicle, us_kia_status_with_air_temp_off)
+    assert vehicle.air_temperature is None
+    assert vehicle._air_temperature_value is None


### PR DESCRIPTION
## Summary

Conforms `HyundaiBlueLinkApiUSA` and `KiaUvoApiUSA` to the established skip-`OFF` pattern (`ApiImplType1.py:319`, `KiaUvoApiCA.py:562`): guard `if air_temp not in (None, "OFF")` so the setter is not invoked with the truthy string `"OFF"` when climate is off. `air_temperature` stays `None` cleanly.

## Why

When climate is off, the USA backend returns `airTemp.value == "OFF"`:

```json
"airTemp": {"unit": 1, "hvacTempType": 1, "value": "OFF"}
```

Both USA handlers used `if air_temp:` — the string `"OFF"` is truthy, so the setter was called with a non-numeric value (`float_or_none("OFF")` → `None`). The rest of the codebase already handles `OFF` by skipping the setter entirely (`ApiImplType1.py:319` `not in (None, "OFF")`, `KiaUvoApiCA.py:562` `!= "OFF"`). The two USA handlers were the lone non-conformant ones.

This is the **API-side companion** to the kia_uvo entity-creation fix. Together they resolve kia_uvo #1790, where the `set_temperature` sensor became permanently `unavailable` (`restored: True`) after a Home Assistant restart when climate was off, because the kia_uvo sensor entity-creation gate only creates the entity when `air_temperature is not None` at startup and `async_setup_entry` runs once.

## What changed

- `HyundaiBlueLinkApiUSA.py`: `if air_temp:` → `if air_temp not in (None, "OFF"):` (sentinels `LO`/`HI` unchanged)
- `KiaUvoApiUSA.py`: same guard (sentinels `LOW`/`HIGH` unchanged) — defensive, no dump confirms Kia USA returns `OFF`, but the guard is no worse if it never does and removes the pointless `float_or_none("OFF")` path

## Not done (deliberate)

- **No masking:** the API returns `"OFF"` (it does not preserve the last setpoint in this field), so the setpoint is genuinely unknown while climate is off. The kia_uvo companion PR makes the sensor report HA `unknown` (data unknown) — not a fake 62°F. Mapping `OFF`→`LO`/62 would be a fake setpoint.
- **No `manifest.json` bump** — this is the API repo; the kia_uvo bump pipeline picks up the release.

## Tests

- `test_bluelink_air_temp_off_yields_none` (new): `airTemp.value == "OFF"` → `vehicle.air_temperature is None` and `vehicle._air_temperature_value is None` (setter not called — the real TDD gate, since `float_or_none("OFF")` already yields `None`).
- `test_usa_air_temperature_off_yields_none` (new): same for Kia USA path.
- `test_usa_air_temperature_string_becomes_float` (#1755 regression): still green (`"72"` → `72.0`).
- 24/24 USA test file cases pass; ruff clean. Pre-existing `.ambr` snapshot failures (Tier 1 #1205 field) are unrelated and untouched by this change.

Refs: Hyundai-Kia-Connect/kia_uvo#1790