### PR TITLE
fix(BR): read cached status from the CCS2 endpoint (fixes 503 resCode 5031)

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
@@ -10,25 +10,23 @@ from time import sleep
 from urllib.parse import parse_qs, urljoin, urlparse
 
 from .ApiImpl import (
-    ApiImpl,
     ApiImplSession,
     ClimateRequestOptions,
     WindowRequestOptions,
 )
+from .ApiImplType1 import ApiImplType1
 from .const import (
     BRAND_HYUNDAI,
     BRANDS,
-    DISTANCE_UNITS,
     DOMAIN,
     ENGINE_TYPES,
     ORDER_STATUS,
-    SEAT_STATUS,
     VEHICLE_LOCK_ACTION,
     WINDOW_STATE,
 )
 from .exceptions import APIError, AuthenticationError
 from .Token import Token
-from .utils import get_index_into_hex_temp, normalize_battery_soc, parse_date_br
+from .utils import get_index_into_hex_temp
 from .Vehicle import DayTripCounts, DayTripInfo, MonthTripInfo, TripInfo, Vehicle
 
 _LOGGER = logging.getLogger(__name__)
@@ -53,11 +51,24 @@ _SIGNIN_STEP_MESSAGES = {
 }
 
 
-class HyundaiBlueLinkApiBR(ApiImpl):
-    """Brazilian Hyundai BlueLink API implementation."""
+class HyundaiBlueLinkApiBR(ApiImplType1):
+    """Brazilian Hyundai BlueLink API implementation.
+
+    Extends ApiImplType1 to reuse its CCS2 status parser
+    (``_update_vehicle_properties_ccs2``). BR overrides all of its own auth,
+    headers, endpoint selection and force-refresh flow below; only the CCS2
+    parsing is inherited.
+    """
 
     supports_window_control: bool = True
+    # BR does not implement valet mode; keep it off (ApiImplType1 defaults True).
+    supports_valet_mode: bool = False
     data_timezone = dt.timezone(dt.timedelta(hours=-3))  # Brazil (BRT/BRST)
+
+    # Async force-refresh polling: how long to wait for the vehicle to report
+    # a fresh snapshot to /ccs2/carstatus/latest after triggering /ccs2/carstatus.
+    _FORCE_REFRESH_POLL_INTERVAL = 5  # seconds between polls
+    _FORCE_REFRESH_MAX_POLLS = 12  # ~60s total
 
     def __init__(self, region: int, brand: int, language: str = "pt-BR"):
         if BRANDS[brand] != BRAND_HYUNDAI:
@@ -235,7 +246,7 @@ class HyundaiBlueLinkApiBR(ApiImpl):
         response = self.session.get(url, headers=headers)
         response.raise_for_status()
         response_data = response.json()
-        _LOGGER.debug(f"{DOMAIN} - Got vehicles response")
+        _LOGGER.debug(f"{DOMAIN} - Got vehicles response: {response_data}")
         if "resMsg" not in response_data or "vehicles" not in response_data.get(
             "resMsg", {}
         ):
@@ -269,195 +280,72 @@ class HyundaiBlueLinkApiBR(ApiImpl):
 
         return result
 
-    def _get_vehicle_state(
-        self, token: Token, vehicle: Vehicle, force_refresh: bool = False
-    ) -> dict:
-        """Get vehicle state (cached or forced refresh)."""
-        url = self._build_api_url(f"/spa/vehicles/{vehicle.id}")
+    def _get_cached_vehicle_state(self, token: Token, vehicle: Vehicle) -> dict:
+        """Return the server-cached vehicle status (does not wake the car).
 
-        if not vehicle.ccu_ccs2_protocol_support:
-            url = url + "/status/latest"
-        else:
-            url = url + "/ccs2/carstatus/latest"
-
+        Despite BR vehicles reporting ccuCCS2ProtocolSupport=0, the cached
+        status is served in CCS2 format at /ccs2/carstatus/latest, including
+        location. The legacy /status/latest endpoint returns HTTP 503
+        (resCode 5031, "Unavailable remote control") on BR — it is the
+        remote-control result endpoint, not a status read.
+        """
+        url = self._build_api_url(f"/spa/vehicles/{vehicle.id}/ccs2/carstatus/latest")
         headers = self._get_authenticated_headers(token)
-        if force_refresh:
-            headers["REFRESH"] = "true"
-
-        _LOGGER.debug(f"{DOMAIN} - Getting vehicle state (force={force_refresh})")
         response = self.session.get(url, headers=headers)
         response.raise_for_status()
-        return response.json()["resMsg"]
-
-    def _get_vehicle_location(self, token: Token, vehicle: Vehicle) -> dict:
-        """Get vehicle location."""
-        url = self._build_api_url(f"/spa/vehicles/{vehicle.id}/location/park")
-        headers = self._get_authenticated_headers(token)
-
-        try:
-            response = self.session.get(url, headers=headers)
-            response.raise_for_status()
-            location_data = response.json()["resMsg"]
-            _LOGGER.debug(f"{DOMAIN} - Got vehicle location")
-            return location_data
-        except Exception as e:
-            _LOGGER.warning(f"{DOMAIN} - Failed to get vehicle location: {e}")
-            return None
-
-    def _update_vehicle_properties(self, vehicle: Vehicle, state: dict) -> None:
-        """Update vehicle properties from state."""
-        # Parse timestamp
-        if state.get("time"):
-            vehicle.last_updated_at = parse_date_br(state["time"], self.data_timezone)
-        else:
-            vehicle.last_updated_at = dt.datetime.now(self.data_timezone)
-
-        # Basic vehicle status
-        vehicle.engine_is_running = state.get("engine", False)
-        vehicle.air_control_is_on = state.get("airCtrlOn", False)
-
-        # Battery (12V car battery, not EV battery)
-        if battery := state.get("battery"):
-            vehicle.car_battery_percentage = normalize_battery_soc(
-                battery.get("batSoc")
-            )
-
-        # Temperature
-        if air_temp := state.get("airTemp"):
-            temp_value = air_temp.get("value")
-            temp_unit = air_temp.get("unit")
-            # Handle special values: "00H" means off, or hex temperature values
-            # For now, only set if it's a valid numeric value
-            if temp_value and temp_value != "00H":
-                try:
-                    # Try to parse as hex if it contains 'H'
-                    if "H" in str(temp_value):
-                        # Will be handled in future if needed
-                        pass
-                    else:
-                        vehicle.air_temperature = (temp_value, temp_unit)
-                except (ValueError, TypeError, KeyError):  # fmt: skip
-                    pass
-
-        # Fuel information
-        vehicle.fuel_level = state.get("fuelLevel")
-        vehicle.fuel_level_is_low = state.get("lowFuelLight", False)
-
-        # Driving range (DTE = Distance To Empty)
-        if dte := state.get("dte"):
-            vehicle.fuel_driving_range = (
-                dte.get("value"),
-                DISTANCE_UNITS.get(dte.get("unit")),
-            )
-
-        # Doors
-        door_state = state.get("doorOpen", {})
-        vehicle.is_locked = state.get("doorLock", True)
-        vehicle.front_left_door_is_open = bool(door_state.get("frontLeft"))
-        vehicle.front_right_door_is_open = bool(door_state.get("frontRight"))
-        vehicle.back_left_door_is_open = bool(door_state.get("backLeft"))
-        vehicle.back_right_door_is_open = bool(door_state.get("backRight"))
-        vehicle.hood_is_open = state.get("hoodOpen", False)
-        vehicle.trunk_is_open = state.get("trunkOpen", False)
-
-        # Windows
-        window_state = state.get("windowOpen", {})
-        vehicle.front_left_window_is_open = bool(window_state.get("frontLeft"))
-        vehicle.front_right_window_is_open = bool(window_state.get("frontRight"))
-        vehicle.back_left_window_is_open = bool(window_state.get("backLeft"))
-        vehicle.back_right_window_is_open = bool(window_state.get("backRight"))
-
-        # Climate control
-        vehicle.defrost_is_on = state.get("defrost", False)
-
-        # Steering wheel heat: 0=off, 1=on, 2=unknown/not available
-        steer_heat = state.get("steerWheelHeat", 0)
-        vehicle.steering_wheel_heater_is_on = steer_heat == 1
-
-        # Side/back window heat: 0=off, 1=on, 2=unknown
-        side_heat = state.get("sideBackWindowHeat", 0)
-        vehicle.back_window_heater_is_on = side_heat == 1
-
-        # Seat heater/ventilation status
-        # Values: 0=off, 1=level1, 2=level2, 3=level3, etc.
-        seat_state = state.get("seatHeaterVentState", {})
-        vehicle.front_left_seat_status = SEAT_STATUS.get(
-            seat_state.get("drvSeatHeatState")
-        )
-        vehicle.front_right_seat_status = SEAT_STATUS.get(
-            seat_state.get("astSeatHeatState")
-        )
-        vehicle.rear_left_seat_status = SEAT_STATUS.get(
-            seat_state.get("rlSeatHeatState")
-        )
-        vehicle.rear_right_seat_status = SEAT_STATUS.get(
-            seat_state.get("rrSeatHeatState")
-        )
-
-        # Tire pressure warnings
-        # Note: Brazilian Creta only has "all" indicator, not individual sensors
-        tire_lamp = state.get("tirePressureLamp", {})
-        vehicle.tire_pressure_all_warning_is_on = bool(
-            tire_lamp.get("tirePressureLampAll")
-        )
-
-        # Set individual tire warnings to match "all" if they don't exist
-        # (Some vehicles may have individual sensors)
-        tire_all = bool(tire_lamp.get("tirePressureLampAll"))
-        vehicle.tire_pressure_rear_left_warning_is_on = bool(
-            tire_lamp.get("tirePressureWarningLampRearLeft", tire_all)
-        )
-        vehicle.tire_pressure_front_left_warning_is_on = bool(
-            tire_lamp.get("tirePressureWarningLampFrontLeft", tire_all)
-        )
-        vehicle.tire_pressure_front_right_warning_is_on = bool(
-            tire_lamp.get("tirePressureWarningLampFrontRight", tire_all)
-        )
-        vehicle.tire_pressure_rear_right_warning_is_on = bool(
-            tire_lamp.get("tirePressureWarningLampRearRight", tire_all)
-        )
-
-        # Warnings and alerts
-        vehicle.washer_fluid_warning_is_on = state.get("washerFluidStatus", False)
-        vehicle.brake_fluid_warning_is_on = state.get("breakOilStatus", False)
-        vehicle.smart_key_battery_warning_is_on = state.get(
-            "smartKeyBatteryWarning", False
-        )
-
-        # Store raw data for future use
-        vehicle.data = state
-
-    def _update_vehicle_location(self, vehicle: Vehicle, location_data: dict) -> None:
-        """Update vehicle location from location data."""
-        if not location_data:
-            return
-
-        coord = location_data.get("coord", {})
-        lat = coord.get("lat")
-        lon = coord.get("lng") or coord.get("lon")
-        time_str = location_data.get("time")
-
-        if lat and lon:
-            location_time = (
-                parse_date_br(time_str, self.data_timezone) if time_str else None
-            )
-            vehicle.location = (lat, lon, location_time)
+        return response.json()["resMsg"]["state"]["Vehicle"]
 
     def update_vehicle_with_cached_state(self, token: Token, vehicle: Vehicle) -> None:
-        """Update vehicle with cached state from API."""
-        state = self._get_vehicle_state(token, vehicle, force_refresh=False)
-        location_data = self._get_vehicle_location(token, vehicle)
-
-        self._update_vehicle_properties(vehicle, state)
-        self._update_vehicle_location(vehicle, location_data)
+        """Update with the server-cached CCS2 state (does not wake the car)."""
+        state = self._get_cached_vehicle_state(token, vehicle)
+        self._update_vehicle_properties_ccs2(vehicle, state)
 
     def force_refresh_vehicle_state(self, token: Token, vehicle: Vehicle) -> None:
-        """Force refresh vehicle state (wakes up the vehicle)."""
-        state = self._get_vehicle_state(token, vehicle, force_refresh=True)
-        location_data = self._get_vehicle_location(token, vehicle)
+        """Force a fresh reading from the vehicle (wakes the car).
 
-        self._update_vehicle_properties(vehicle, state)
-        self._update_vehicle_location(vehicle, location_data)
+        The BR CCS2 force is asynchronous: GET /ccs2/carstatus only returns an
+        acknowledgement, then the vehicle pushes a fresh snapshot to
+        /ccs2/carstatus/latest a few seconds later (its lastUpdateTime
+        advances). Trigger the refresh, poll until the timestamp changes, then
+        parse the fresh state; fall back to the last cached snapshot if the
+        vehicle does not report in time.
+        """
+        latest_url = self._build_api_url(
+            f"/spa/vehicles/{vehicle.id}/ccs2/carstatus/latest"
+        )
+        previous = self.session.get(
+            latest_url, headers=self._get_authenticated_headers(token)
+        )
+        previous.raise_for_status()
+        previous_update = previous.json()["resMsg"].get("lastUpdateTime")
+
+        trigger_url = self._build_api_url(f"/spa/vehicles/{vehicle.id}/ccs2/carstatus")
+        _LOGGER.debug(f"{DOMAIN} - Triggering async force refresh")
+        trigger = self.session.get(
+            trigger_url, headers=self._get_authenticated_headers(token)
+        )
+        trigger.raise_for_status()
+
+        state = None
+        for _ in range(self._FORCE_REFRESH_MAX_POLLS):
+            sleep(self._FORCE_REFRESH_POLL_INTERVAL)
+            response = self.session.get(
+                latest_url, headers=self._get_authenticated_headers(token)
+            )
+            response.raise_for_status()
+            resmsg = response.json()["resMsg"]
+            if resmsg.get("lastUpdateTime") != previous_update:
+                state = resmsg["state"]["Vehicle"]
+                break
+
+        if state is None:
+            _LOGGER.warning(
+                f"{DOMAIN} - Force refresh did not report new data in time; "
+                "using the latest cached snapshot"
+            )
+            state = self._get_cached_vehicle_state(token, vehicle)
+
+        self._update_vehicle_properties_ccs2(vehicle, state)
 
     def _ensure_control_token(self, token: Token) -> str:
         """Ensure we have a valid control token for remote commands."""

--- a/tests/fixtures/br_hyundai_creta_2025_ccs2_cached.json
+++ b/tests/fixtures/br_hyundai_creta_2025_ccs2_cached.json
@@ -1,304 +1,304 @@
 {
-  "_fixture_meta": {
-    "description": "BR Hyundai Creta 2025 (ICE, reports ccuCCS2ProtocolSupport=0) cached status from /ccs2/carstatus/latest. Anonymized: GeoCoord replaced with a placeholder, no VIN/tokens.",
-    "expected": {
-      "car_battery_percentage": 59,
-      "engine_is_running": false,
-      "fuel_level": 20,
-      "is_locked": true,
-      "odometer": 6208.1,
-      "odometer_unit": "km",
-      "total_driving_range": 102.0,
-      "total_driving_range_unit": "km"
+    "_fixture_meta": {
+        "description": "BR Hyundai Creta 2025 (ICE, reports ccuCCS2ProtocolSupport=0) cached status from /ccs2/carstatus/latest. Anonymized: GeoCoord replaced with a placeholder, no VIN/tokens.",
+        "expected": {
+            "car_battery_percentage": 59,
+            "engine_is_running": false,
+            "fuel_level": 20,
+            "is_locked": true,
+            "odometer": 6208.1,
+            "odometer_unit": "km",
+            "total_driving_range": 102.0,
+            "total_driving_range_unit": "km"
+        },
+        "source": "GET /api/v1/spa/vehicles/{id}/ccs2/carstatus/latest"
     },
-    "source": "GET /api/v1/spa/vehicles/{id}/ccs2/carstatus/latest"
-  },
-  "resMsg": {
-    "lastUpdateTime": "20260717174232",
-    "state": {
-      "Vehicle": {
-        "Body": {
-          "Hood": {
-            "Open": 0
-          },
-          "Lights": {
-            "DischargeAlert": {
-              "State": 0
-            },
-            "Front": {
-              "HeadLamp": {
-                "SystemWarning": 0
-              },
-              "Left": {
-                "High": {
-                  "Warning": 0
+    "resMsg": {
+        "lastUpdateTime": "20260717174232",
+        "state": {
+            "Vehicle": {
+                "Body": {
+                    "Hood": {
+                        "Open": 0
+                    },
+                    "Lights": {
+                        "DischargeAlert": {
+                            "State": 0
+                        },
+                        "Front": {
+                            "HeadLamp": {
+                                "SystemWarning": 0
+                            },
+                            "Left": {
+                                "High": {
+                                    "Warning": 0
+                                },
+                                "Low": {
+                                    "Warning": 0
+                                },
+                                "TurnSignal": {
+                                    "Warning": 0
+                                }
+                            },
+                            "Right": {
+                                "High": {
+                                    "Warning": 0
+                                },
+                                "Low": {
+                                    "Warning": 0
+                                },
+                                "TurnSignal": {
+                                    "Warning": 0
+                                }
+                            }
+                        },
+                        "Hazard": {
+                            "Alert": 0
+                        },
+                        "Rear": {
+                            "Left": {
+                                "StopLamp": {
+                                    "Warning": 0
+                                },
+                                "TurnSignal": {
+                                    "Warning": 0
+                                }
+                            },
+                            "Right": {
+                                "StopLamp": {
+                                    "Warning": 0
+                                },
+                                "TurnSignal": {
+                                    "Warning": 0
+                                }
+                            }
+                        },
+                        "TailLamp": {
+                            "Alert": 0
+                        }
+                    },
+                    "Trunk": {
+                        "Open": 0
+                    },
+                    "Windshield": {
+                        "Front": {
+                            "Defog": {
+                                "State": 0
+                            },
+                            "WasherFluid": {
+                                "LevelLow": 0
+                            }
+                        },
+                        "Rear": {
+                            "Defog": {
+                                "State": 0
+                            }
+                        }
+                    }
                 },
-                "Low": {
-                  "Warning": 0
+                "Cabin": {
+                    "Door": {
+                        "Row1": {
+                            "Driver": {
+                                "Lock": 0,
+                                "Open": 0
+                            },
+                            "Passenger": {
+                                "Lock": 0,
+                                "Open": 0
+                            }
+                        },
+                        "Row2": {
+                            "Left": {
+                                "Lock": 0,
+                                "Open": 0
+                            },
+                            "Right": {
+                                "Lock": 0,
+                                "Open": 0
+                            }
+                        }
+                    },
+                    "HVAC": {
+                        "Row1": {
+                            "Driver": {
+                                "Blower": {
+                                    "SpeedLevel": 0
+                                },
+                                "Temperature": {
+                                    "Unit": 0,
+                                    "Value": "OFF"
+                                }
+                            }
+                        },
+                        "Temperature": {
+                            "RangeType": 1
+                        }
+                    },
+                    "Seat": {
+                        "Row1": {
+                            "Driver": {
+                                "Climate": {
+                                    "State": 2
+                                }
+                            },
+                            "Passenger": {
+                                "Climate": {
+                                    "State": 2
+                                }
+                            }
+                        },
+                        "Row2": {
+                            "Left": {
+                                "Climate": {
+                                    "State": 2
+                                }
+                            },
+                            "Right": {
+                                "Climate": {
+                                    "State": 2
+                                }
+                            }
+                        }
+                    },
+                    "SteeringWheel": {
+                        "Heat": {
+                            "State": 0
+                        }
+                    },
+                    "Window": {
+                        "Row1": {
+                            "Driver": {
+                                "Open": 0
+                            },
+                            "Passenger": {
+                                "Open": 0
+                            }
+                        },
+                        "Row2": {
+                            "Left": {
+                                "Open": 0
+                            },
+                            "Right": {
+                                "Open": 0
+                            }
+                        }
+                    }
                 },
-                "TurnSignal": {
-                  "Warning": 0
-                }
-              },
-              "Right": {
-                "High": {
-                  "Warning": 0
+                "Chassis": {
+                    "Axle": {
+                        "Tire": {
+                            "PressureLow": 0
+                        }
+                    },
+                    "Brake": {
+                        "Fluid": {
+                            "Warning": 0
+                        }
+                    }
                 },
-                "Low": {
-                  "Warning": 0
+                "Date": "20260717174232.585",
+                "Drivetrain": {
+                    "FuelSystem": {
+                        "DTE": {
+                            "Total": 102,
+                            "Unit": 1
+                        },
+                        "FuelLevel": 20,
+                        "LowFuelWarning": 0
+                    },
+                    "InternalCombustionEngine": {
+                        "OilLevelWarning": 0
+                    },
+                    "Odometer": 6208.1,
+                    "Transmission": {
+                        "ParkingPosition": 1
+                    }
                 },
-                "TurnSignal": {
-                  "Warning": 0
-                }
-              }
-            },
-            "Hazard": {
-              "Alert": 0
-            },
-            "Rear": {
-              "Left": {
-                "StopLamp": {
-                  "Warning": 0
+                "DrivingReady": 0,
+                "Electronics": {
+                    "AutoCut": {
+                        "BatteryPreWarning": 0,
+                        "DeliveryMode": 1,
+                        "PowerMode": 2
+                    },
+                    "Battery": {
+                        "Charging": {
+                            "WarningLevel": 65
+                        },
+                        "Level": 59,
+                        "SensorReliability": 0
+                    },
+                    "FOB": {
+                        "LowBattery": 0
+                    },
+                    "PowerSupply": {
+                        "Accessory": 0
+                    }
                 },
-                "TurnSignal": {
-                  "Warning": 0
-                }
-              },
-              "Right": {
-                "StopLamp": {
-                  "Warning": 0
+                "Green": {
+                    "ChargingInformation": {
+                        "SequenceDetails": 510,
+                        "SequenceSubcode": -1
+                    },
+                    "Reservation": {
+                        "Departure": {
+                            "Schedule1": {
+                                "Fri": 0,
+                                "Mon": 0,
+                                "Sat": 0,
+                                "Sun": 0,
+                                "Thu": 0,
+                                "Tue": 0,
+                                "Wed": 0
+                            },
+                            "Schedule2": {
+                                "Fri": 0,
+                                "Mon": 0,
+                                "Sat": 0,
+                                "Sun": 0,
+                                "Thu": 0,
+                                "Tue": 0,
+                                "Wed": 0
+                            }
+                        },
+                        "OffPeakTime": {
+                            "Mode": 1
+                        }
+                    }
                 },
-                "TurnSignal": {
-                  "Warning": 0
-                }
-              }
-            },
-            "TailLamp": {
-              "Alert": 0
-            }
-          },
-          "Trunk": {
-            "Open": 0
-          },
-          "Windshield": {
-            "Front": {
-              "Defog": {
-                "State": 0
-              },
-              "WasherFluid": {
-                "LevelLow": 0
-              }
-            },
-            "Rear": {
-              "Defog": {
-                "State": 0
-              }
-            }
-          }
-        },
-        "Cabin": {
-          "Door": {
-            "Row1": {
-              "Driver": {
-                "Lock": 0,
-                "Open": 0
-              },
-              "Passenger": {
-                "Lock": 0,
-                "Open": 0
-              }
-            },
-            "Row2": {
-              "Left": {
-                "Lock": 0,
-                "Open": 0
-              },
-              "Right": {
-                "Lock": 0,
-                "Open": 0
-              }
-            }
-          },
-          "HVAC": {
-            "Row1": {
-              "Driver": {
-                "Blower": {
-                  "SpeedLevel": 0
+                "Location": {
+                    "GeoCoord": {
+                        "Altitude": 700,
+                        "Latitude": -23.5,
+                        "Longitude": -46.6,
+                        "Type": 0
+                    },
+                    "Speed": {
+                        "Unit": 0,
+                        "Value": 0
+                    },
+                    "TimeStamp": {
+                        "Day": 17,
+                        "Hour": 17,
+                        "Min": 42,
+                        "Mon": 7,
+                        "Sec": 30,
+                        "Year": 2026
+                    }
                 },
-                "Temperature": {
-                  "Unit": 0,
-                  "Value": "OFF"
+                "RemoteControl": {
+                    "SleepMode": 0
+                },
+                "Service": {
+                    "ConnectedCar": {
+                        "RemoteControl": {
+                            "Available": 1,
+                            "WaitingTime": 168
+                        }
+                    }
                 }
-              }
-            },
-            "Temperature": {
-              "RangeType": 1
             }
-          },
-          "Seat": {
-            "Row1": {
-              "Driver": {
-                "Climate": {
-                  "State": 2
-                }
-              },
-              "Passenger": {
-                "Climate": {
-                  "State": 2
-                }
-              }
-            },
-            "Row2": {
-              "Left": {
-                "Climate": {
-                  "State": 2
-                }
-              },
-              "Right": {
-                "Climate": {
-                  "State": 2
-                }
-              }
-            }
-          },
-          "SteeringWheel": {
-            "Heat": {
-              "State": 0
-            }
-          },
-          "Window": {
-            "Row1": {
-              "Driver": {
-                "Open": 0
-              },
-              "Passenger": {
-                "Open": 0
-              }
-            },
-            "Row2": {
-              "Left": {
-                "Open": 0
-              },
-              "Right": {
-                "Open": 0
-              }
-            }
-          }
-        },
-        "Chassis": {
-          "Axle": {
-            "Tire": {
-              "PressureLow": 0
-            }
-          },
-          "Brake": {
-            "Fluid": {
-              "Warning": 0
-            }
-          }
-        },
-        "Date": "20260717174232.585",
-        "Drivetrain": {
-          "FuelSystem": {
-            "DTE": {
-              "Total": 102,
-              "Unit": 1
-            },
-            "FuelLevel": 20,
-            "LowFuelWarning": 0
-          },
-          "InternalCombustionEngine": {
-            "OilLevelWarning": 0
-          },
-          "Odometer": 6208.1,
-          "Transmission": {
-            "ParkingPosition": 1
-          }
-        },
-        "DrivingReady": 0,
-        "Electronics": {
-          "AutoCut": {
-            "BatteryPreWarning": 0,
-            "DeliveryMode": 1,
-            "PowerMode": 2
-          },
-          "Battery": {
-            "Charging": {
-              "WarningLevel": 65
-            },
-            "Level": 59,
-            "SensorReliability": 0
-          },
-          "FOB": {
-            "LowBattery": 0
-          },
-          "PowerSupply": {
-            "Accessory": 0
-          }
-        },
-        "Green": {
-          "ChargingInformation": {
-            "SequenceDetails": 510,
-            "SequenceSubcode": -1
-          },
-          "Reservation": {
-            "Departure": {
-              "Schedule1": {
-                "Fri": 0,
-                "Mon": 0,
-                "Sat": 0,
-                "Sun": 0,
-                "Thu": 0,
-                "Tue": 0,
-                "Wed": 0
-              },
-              "Schedule2": {
-                "Fri": 0,
-                "Mon": 0,
-                "Sat": 0,
-                "Sun": 0,
-                "Thu": 0,
-                "Tue": 0,
-                "Wed": 0
-              }
-            },
-            "OffPeakTime": {
-              "Mode": 1
-            }
-          }
-        },
-        "Location": {
-          "GeoCoord": {
-            "Altitude": 700,
-            "Latitude": -23.5,
-            "Longitude": -46.6,
-            "Type": 0
-          },
-          "Speed": {
-            "Unit": 0,
-            "Value": 0
-          },
-          "TimeStamp": {
-            "Day": 17,
-            "Hour": 17,
-            "Min": 42,
-            "Mon": 7,
-            "Sec": 30,
-            "Year": 2026
-          }
-        },
-        "RemoteControl": {
-          "SleepMode": 0
-        },
-        "Service": {
-          "ConnectedCar": {
-            "RemoteControl": {
-              "Available": 1,
-              "WaitingTime": 168
-            }
-          }
         }
-      }
     }
-  }
 }

--- a/tests/fixtures/br_hyundai_creta_2025_ccs2_cached.json
+++ b/tests/fixtures/br_hyundai_creta_2025_ccs2_cached.json
@@ -1,0 +1,304 @@
+{
+  "_fixture_meta": {
+    "description": "BR Hyundai Creta 2025 (ICE, reports ccuCCS2ProtocolSupport=0) cached status from /ccs2/carstatus/latest. Anonymized: GeoCoord replaced with a placeholder, no VIN/tokens.",
+    "expected": {
+      "car_battery_percentage": 59,
+      "engine_is_running": false,
+      "fuel_level": 20,
+      "is_locked": true,
+      "odometer": 6208.1,
+      "odometer_unit": "km",
+      "total_driving_range": 102.0,
+      "total_driving_range_unit": "km"
+    },
+    "source": "GET /api/v1/spa/vehicles/{id}/ccs2/carstatus/latest"
+  },
+  "resMsg": {
+    "lastUpdateTime": "20260717174232",
+    "state": {
+      "Vehicle": {
+        "Body": {
+          "Hood": {
+            "Open": 0
+          },
+          "Lights": {
+            "DischargeAlert": {
+              "State": 0
+            },
+            "Front": {
+              "HeadLamp": {
+                "SystemWarning": 0
+              },
+              "Left": {
+                "High": {
+                  "Warning": 0
+                },
+                "Low": {
+                  "Warning": 0
+                },
+                "TurnSignal": {
+                  "Warning": 0
+                }
+              },
+              "Right": {
+                "High": {
+                  "Warning": 0
+                },
+                "Low": {
+                  "Warning": 0
+                },
+                "TurnSignal": {
+                  "Warning": 0
+                }
+              }
+            },
+            "Hazard": {
+              "Alert": 0
+            },
+            "Rear": {
+              "Left": {
+                "StopLamp": {
+                  "Warning": 0
+                },
+                "TurnSignal": {
+                  "Warning": 0
+                }
+              },
+              "Right": {
+                "StopLamp": {
+                  "Warning": 0
+                },
+                "TurnSignal": {
+                  "Warning": 0
+                }
+              }
+            },
+            "TailLamp": {
+              "Alert": 0
+            }
+          },
+          "Trunk": {
+            "Open": 0
+          },
+          "Windshield": {
+            "Front": {
+              "Defog": {
+                "State": 0
+              },
+              "WasherFluid": {
+                "LevelLow": 0
+              }
+            },
+            "Rear": {
+              "Defog": {
+                "State": 0
+              }
+            }
+          }
+        },
+        "Cabin": {
+          "Door": {
+            "Row1": {
+              "Driver": {
+                "Lock": 0,
+                "Open": 0
+              },
+              "Passenger": {
+                "Lock": 0,
+                "Open": 0
+              }
+            },
+            "Row2": {
+              "Left": {
+                "Lock": 0,
+                "Open": 0
+              },
+              "Right": {
+                "Lock": 0,
+                "Open": 0
+              }
+            }
+          },
+          "HVAC": {
+            "Row1": {
+              "Driver": {
+                "Blower": {
+                  "SpeedLevel": 0
+                },
+                "Temperature": {
+                  "Unit": 0,
+                  "Value": "OFF"
+                }
+              }
+            },
+            "Temperature": {
+              "RangeType": 1
+            }
+          },
+          "Seat": {
+            "Row1": {
+              "Driver": {
+                "Climate": {
+                  "State": 2
+                }
+              },
+              "Passenger": {
+                "Climate": {
+                  "State": 2
+                }
+              }
+            },
+            "Row2": {
+              "Left": {
+                "Climate": {
+                  "State": 2
+                }
+              },
+              "Right": {
+                "Climate": {
+                  "State": 2
+                }
+              }
+            }
+          },
+          "SteeringWheel": {
+            "Heat": {
+              "State": 0
+            }
+          },
+          "Window": {
+            "Row1": {
+              "Driver": {
+                "Open": 0
+              },
+              "Passenger": {
+                "Open": 0
+              }
+            },
+            "Row2": {
+              "Left": {
+                "Open": 0
+              },
+              "Right": {
+                "Open": 0
+              }
+            }
+          }
+        },
+        "Chassis": {
+          "Axle": {
+            "Tire": {
+              "PressureLow": 0
+            }
+          },
+          "Brake": {
+            "Fluid": {
+              "Warning": 0
+            }
+          }
+        },
+        "Date": "20260717174232.585",
+        "Drivetrain": {
+          "FuelSystem": {
+            "DTE": {
+              "Total": 102,
+              "Unit": 1
+            },
+            "FuelLevel": 20,
+            "LowFuelWarning": 0
+          },
+          "InternalCombustionEngine": {
+            "OilLevelWarning": 0
+          },
+          "Odometer": 6208.1,
+          "Transmission": {
+            "ParkingPosition": 1
+          }
+        },
+        "DrivingReady": 0,
+        "Electronics": {
+          "AutoCut": {
+            "BatteryPreWarning": 0,
+            "DeliveryMode": 1,
+            "PowerMode": 2
+          },
+          "Battery": {
+            "Charging": {
+              "WarningLevel": 65
+            },
+            "Level": 59,
+            "SensorReliability": 0
+          },
+          "FOB": {
+            "LowBattery": 0
+          },
+          "PowerSupply": {
+            "Accessory": 0
+          }
+        },
+        "Green": {
+          "ChargingInformation": {
+            "SequenceDetails": 510,
+            "SequenceSubcode": -1
+          },
+          "Reservation": {
+            "Departure": {
+              "Schedule1": {
+                "Fri": 0,
+                "Mon": 0,
+                "Sat": 0,
+                "Sun": 0,
+                "Thu": 0,
+                "Tue": 0,
+                "Wed": 0
+              },
+              "Schedule2": {
+                "Fri": 0,
+                "Mon": 0,
+                "Sat": 0,
+                "Sun": 0,
+                "Thu": 0,
+                "Tue": 0,
+                "Wed": 0
+              }
+            },
+            "OffPeakTime": {
+              "Mode": 1
+            }
+          }
+        },
+        "Location": {
+          "GeoCoord": {
+            "Altitude": 700,
+            "Latitude": -23.5,
+            "Longitude": -46.6,
+            "Type": 0
+          },
+          "Speed": {
+            "Unit": 0,
+            "Value": 0
+          },
+          "TimeStamp": {
+            "Day": 17,
+            "Hour": 17,
+            "Min": 42,
+            "Mon": 7,
+            "Sec": 30,
+            "Year": 2026
+          }
+        },
+        "RemoteControl": {
+          "SleepMode": 0
+        },
+        "Service": {
+          "ConnectedCar": {
+            "RemoteControl": {
+              "Available": 1,
+              "WaitingTime": 168
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/test_br_vehicle_properties.py
+++ b/tests/test_br_vehicle_properties.py
@@ -1,0 +1,187 @@
+"""Tests for the Brazilian Hyundai BlueLink API.
+
+Covers:
+  * the cached-status endpoint (regression for the /status/latest 503 bug),
+  * the asynchronous force-refresh flow, and
+  * CCS2 status parsing driven by a JSON fixture.
+
+BR reports ``ccuCCS2ProtocolSupport: 0`` but serves status in CCS2 format at
+``/ccs2/carstatus/latest``, so BR extends ``ApiImplType1`` and reuses its
+``_update_vehicle_properties_ccs2`` parser.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from hyundai_kia_connect_api.const import BRAND_HYUNDAI, BRANDS, REGION_BRAZIL, REGIONS
+from hyundai_kia_connect_api.HyundaiBlueLinkApiBR import HyundaiBlueLinkApiBR
+from hyundai_kia_connect_api.Vehicle import Vehicle
+
+from tests.fixture_helpers import discover_fixtures, get_fixture_expected, load_fixture
+
+BR_FIXTURE_FILES = discover_fixtures("br_")
+
+_BR_REGION = [k for k, v in REGIONS.items() if v == REGION_BRAZIL][0]
+_HYUNDAI_BRAND = [k for k, v in BRANDS.items() if v == BRAND_HYUNDAI][0]
+
+
+def _response(json_data):
+    resp = MagicMock()
+    resp.json.return_value = json_data
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def _fixture_state():
+    """Return the CCS2 state.Vehicle dict from the first BR fixture."""
+    data = load_fixture(BR_FIXTURE_FILES[0])
+    return data["resMsg"]["state"]["Vehicle"]
+
+
+@pytest.fixture
+def br_api() -> HyundaiBlueLinkApiBR:
+    return HyundaiBlueLinkApiBR(region=_BR_REGION, brand=_HYUNDAI_BRAND)
+
+
+@pytest.fixture
+def token() -> MagicMock:
+    tok = MagicMock()
+    tok.access_token = "test-access-token"
+    tok.device_id = "test-device-id"
+    return tok
+
+
+def _called_urls(session_get):
+    urls = []
+    for call in session_get.call_args_list:
+        urls.append(call.args[0] if call.args else call.kwargs["url"])
+    return urls
+
+
+class TestBRInheritance:
+    def test_extends_apiimpltype1_and_reuses_ccs2_parser(self, br_api):
+        # BR must inherit the CCS2 parser rather than duplicate it.
+        assert hasattr(br_api, "_update_vehicle_properties_ccs2")
+        assert type(br_api).__mro__[1].__name__ == "ApiImplType1"
+
+    def test_valet_mode_disabled(self, br_api):
+        # ApiImplType1 defaults valet mode on; BR must keep it off.
+        assert br_api.supports_valet_mode is False
+
+
+class TestBRCachedEndpoint:
+    """The cached read must use /ccs2/carstatus/latest (never /status*)."""
+
+    def test_cached_state_uses_ccs2_latest(self, br_api, token):
+        state = _fixture_state()
+        br_api.session = MagicMock()
+        br_api.session.get.return_value = _response(
+            {"resMsg": {"state": {"Vehicle": state}}}
+        )
+        vehicle = Vehicle(id="VID", ccu_ccs2_protocol_support=0)
+
+        br_api.update_vehicle_with_cached_state(token, vehicle)
+
+        urls = _called_urls(br_api.session.get)
+        assert any(u.endswith("/spa/vehicles/VID/ccs2/carstatus/latest") for u in urls)
+        assert not any("/status/latest" in u for u in urls)
+        assert not any(u.endswith("/status") for u in urls)
+        # Parsed via the inherited CCS2 parser.
+        assert vehicle.car_battery_percentage == 59
+
+
+class TestBRForceRefresh:
+    """Force refresh triggers /ccs2/carstatus then polls /ccs2/carstatus/latest."""
+
+    def test_force_triggers_and_polls_until_fresh(self, br_api, token):
+        state = _fixture_state()
+        old = {"resMsg": {"lastUpdateTime": "T1", "state": {"Vehicle": state}}}
+        new = {"resMsg": {"lastUpdateTime": "T2", "state": {"Vehicle": state}}}
+        ack = {"retCode": "S", "resCode": "0000"}
+        br_api._FORCE_REFRESH_POLL_INTERVAL = 0
+
+        latest_hits = {"n": 0}
+
+        def side_effect(url, **kwargs):
+            if url.endswith("/ccs2/carstatus"):  # async trigger
+                return _response(ack)
+            latest_hits["n"] += 1
+            return _response(old if latest_hits["n"] == 1 else new)
+
+        br_api.session = MagicMock()
+        br_api.session.get.side_effect = side_effect
+        vehicle = Vehicle(id="VID", ccu_ccs2_protocol_support=0)
+
+        br_api.force_refresh_vehicle_state(token, vehicle)
+
+        urls = _called_urls(br_api.session.get)
+        assert any(u.endswith("/spa/vehicles/VID/ccs2/carstatus") for u in urls)
+        assert vehicle.car_battery_percentage == 59
+
+    def test_force_falls_back_to_cache_when_no_new_data(self, br_api, token):
+        state = _fixture_state()
+        same = {"resMsg": {"lastUpdateTime": "T1", "state": {"Vehicle": state}}}
+        ack = {"retCode": "S", "resCode": "0000"}
+        br_api._FORCE_REFRESH_POLL_INTERVAL = 0
+        br_api._FORCE_REFRESH_MAX_POLLS = 2
+
+        def side_effect(url, **kwargs):
+            return (
+                _response(ack) if url.endswith("/ccs2/carstatus") else _response(same)
+            )
+
+        br_api.session = MagicMock()
+        br_api.session.get.side_effect = side_effect
+        vehicle = Vehicle(id="VID", ccu_ccs2_protocol_support=0)
+
+        # Should not raise, and still parse the (unchanged) cached snapshot.
+        br_api.force_refresh_vehicle_state(token, vehicle)
+        assert vehicle.car_battery_percentage == 59
+
+
+@pytest.fixture
+def properties_api() -> HyundaiBlueLinkApiBR:
+    api = HyundaiBlueLinkApiBR.__new__(HyundaiBlueLinkApiBR)
+    api.data_timezone = HyundaiBlueLinkApiBR.data_timezone
+    return api
+
+
+@pytest.fixture
+def vehicle() -> Vehicle:
+    return Vehicle()
+
+
+@pytest.mark.parametrize("fixture_file", BR_FIXTURE_FILES, ids=BR_FIXTURE_FILES)
+class TestBRUpdateVehicleProperties:
+    def _parse(self, properties_api, vehicle, fixture_file):
+        data = load_fixture(fixture_file)
+        state = data["resMsg"]["state"]["Vehicle"]
+        properties_api._update_vehicle_properties_ccs2(vehicle, state)
+        return get_fixture_expected(data)
+
+    def test_battery_and_engine(self, properties_api, vehicle, fixture_file):
+        expected = self._parse(properties_api, vehicle, fixture_file)
+        assert vehicle.car_battery_percentage == expected["car_battery_percentage"]
+        assert bool(vehicle.engine_is_running) == expected["engine_is_running"]
+
+    def test_is_locked(self, properties_api, vehicle, fixture_file):
+        expected = self._parse(properties_api, vehicle, fixture_file)
+        assert vehicle.is_locked == expected["is_locked"]
+
+    def test_fuel_and_range(self, properties_api, vehicle, fixture_file):
+        expected = self._parse(properties_api, vehicle, fixture_file)
+        assert vehicle.fuel_level == expected["fuel_level"]
+        assert vehicle.total_driving_range == expected["total_driving_range"]
+        assert vehicle._total_driving_range_unit == expected["total_driving_range_unit"]
+
+    def test_odometer(self, properties_api, vehicle, fixture_file):
+        expected = self._parse(properties_api, vehicle, fixture_file)
+        assert vehicle.odometer == expected["odometer"]
+        assert vehicle._odometer_unit == expected["odometer_unit"]
+
+    def test_last_updated_and_location_set(self, properties_api, vehicle, fixture_file):
+        self._parse(properties_api, vehicle, fixture_file)
+        # CCS2 'Date' populates last_updated_at (not now()), and location is parsed.
+        assert vehicle.last_updated_at is not None
+        assert vehicle.location is not None


### PR DESCRIPTION
## Problem

Status polling for Brazilian (BR) vehicles fails with a **503** on every update, seen in Home Assistant (kia_uvo) as repeated `Force update failed` / `Cached update failed` errors while the official Bluelink app keeps working:

```
GET /api/v1/spa/vehicles/{id}/status/latest
-> 503 {"retCode":"F","resCode":"5031","resMsg":"Unavailable remote control - Service Temporary Unavailable"}
```

BR vehicles report `ccuCCS2ProtocolSupport: 0`, so `_get_vehicle_state` used the legacy `/status/latest` endpoint. On the BR backend that endpoint is the **remote-control command result**, not a status read — it returns 503 / resCode `5031` until a remote command has been issued.

## What actually works on BR

Tested live against a non-CCS2 Creta 2025 (`type: GN`, `ccuCCS2ProtocolSupport: 0`):

| Endpoint | Result |
|---|---|
| `GET /status/latest` | **503** resCode 5031, always |
| `GET /status` | 200, but **wakes the car** (~20s), legacy flat payload |
| `GET /ccs2/carstatus/latest` | **200, instant, no wake** — CCS2 `state.Vehicle`, with a `lastUpdateTime` |
| `GET /ccs2/carstatus` | ack only; ~10s later the car reports and `/ccs2/carstatus/latest` advances (async force) |

So even though the flag is `0`, BR serves the status in **CCS2** format. That's what the app reads for the passive view without waking the car, and it even includes data the flat `/status` payload lacks (e.g. odometer).

## Fix

- cached read (no wake) → `GET /ccs2/carstatus/latest`
- force refresh (wakes the car, async) → trigger `GET /ccs2/carstatus`, then poll `/ccs2/carstatus/latest` until `lastUpdateTime` advances (with a fallback to the last cached snapshot)

To parse the CCS2 payload without duplicating ~500 lines, `HyundaiBlueLinkApiBR` now extends `ApiImplType1` and reuses its `_update_vehicle_properties_ccs2`. BR keeps overriding its own auth, headers, `get_vehicles`, endpoint selection and the async force-refresh flow; `ApiImplType1` is untouched. Valet mode is explicitly disabled for BR.

## Tests

`tests/test_br_vehicle_properties.py`:
- cached read uses `/ccs2/carstatus/latest` (never `/status*`)
- async force refresh: trigger + poll until fresh, and the fallback when the car doesn't report in time
- CCS2 property parsing (battery, engine, locks, fuel, range, odometer, location, last_updated_at)

Backed by an anonymized `br_hyundai_creta_2025_ccs2_cached.json` fixture (status data only — no VIN/location/tokens). All new tests pass; `flake8`/`black` clean. Verified end-to-end against the live API: cached read populates without waking the car, and force refresh returns fresh data in ~26s.