### PR TITLE
fix(AU/NZ): send Stamp on refresh + derive login valid_until from expires_in (#1778)

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -1321,6 +1321,14 @@ class ApiImplType1(ApiImpl):
         _check_response_for_errors(response)
         return response["msgId"]
 
+    def _refresh_access_token_headers(self) -> dict[str, str]:
+        """Extra headers for the refresh_token grant. Default: none.
+
+        AU overrides to add the Stamp header its server requires;
+        IN/CN inherit the empty default (no behavior change).
+        """
+        return {}
+
     def refresh_access_token(self, token: Token) -> Token:
         """Refresh access token using the stored refresh token.
 
@@ -1355,6 +1363,7 @@ class ApiImplType1(ApiImpl):
                     "Accept-Encoding": "gzip, deflate",
                     "User-Agent": USER_AGENT_OK_HTTP,
                 }
+                headers.update(self._refresh_access_token_headers())
                 data = "grant_type=refresh_token&refresh_token=" + token.refresh_token
                 response = self.session.post(url, data=data, headers=headers)
                 response_json = response.json()

--- a/hyundai_kia_connect_api/KiaUvoApiAU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiAU.py
@@ -955,3 +955,7 @@ class KiaUvoApiAU(ApiImplType1):
         token_type = response["token_type"]
         refresh_token = token_type + " " + response["access_token"]
         return token_type, refresh_token
+
+    def _refresh_access_token_headers(self) -> dict[str, str]:
+        """AU requires the Stamp header on the refresh_token grant."""
+        return {"Stamp": self._get_stamp()}

--- a/hyundai_kia_connect_api/KiaUvoApiAU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiAU.py
@@ -21,6 +21,7 @@ from .const import (
     DISTANCE_UNITS,
     DOMAIN,
     ENGINE_TYPES,
+    LOGIN_TOKEN_LIFETIME,
     REGION_AUSTRALIA,
     REGION_NZ,
     REGIONS,
@@ -109,11 +110,16 @@ class KiaUvoApiAU(ApiImplType1):
         if authorization_code is None:
             raise AuthenticationError("Login Failed")
 
-        _, access_token, authorization_code = self._get_access_token(
+        _, access_token, authorization_code, expires_in = self._get_access_token(
             authorization_code, stamp
         )
         _, refresh_token = self._get_refresh_token(authorization_code, stamp)
-        valid_until = dt.datetime.now(dt.timezone.utc) + dt.timedelta(hours=23)
+        if expires_in is not None:
+            valid_until = dt.datetime.now(dt.timezone.utc) + dt.timedelta(
+                seconds=int(expires_in)
+            )
+        else:
+            valid_until = dt.datetime.now(dt.timezone.utc) + LOGIN_TOKEN_LIFETIME
 
         return Token(
             username=username,
@@ -934,7 +940,8 @@ class KiaUvoApiAU(ApiImplType1):
         token_type = response["token_type"]
         access_token = token_type + " " + response["access_token"]
         authorization_code = response["refresh_token"]
-        return token_type, access_token, authorization_code
+        expires_in = response.get("expires_in")
+        return token_type, access_token, authorization_code, expires_in
 
     def _get_refresh_token(self, authorization_code, stamp):
         # Get Refresh Token #

--- a/tests/test_au_login_token_lifetime.py
+++ b/tests/test_au_login_token_lifetime.py
@@ -1,0 +1,68 @@
+"""Tests for KiaUvoApiAU.login() token lifetime (kia_uvo #1778, NZ finding).
+
+The AU/NZ gateway returns tokens with expires_in (e.g. 21600s = 6h), but
+KiaUvoApiAU.login() hardcoded valid_until = now + 23h, so the library kept
+using a dead token for ~17h and HA reauthed ~twice a day. login() must now
+derive valid_until from the access_token response's expires_in, falling back
+to LOGIN_TOKEN_LIFETIME (23h) only when the server omits it.
+"""
+
+import datetime as dt
+from unittest.mock import MagicMock
+
+from hyundai_kia_connect_api.KiaUvoApiAU import KiaUvoApiAU
+from hyundai_kia_connect_api.const import LOGIN_TOKEN_LIFETIME
+
+
+def _au_api_with_login_chain(expires_in: int | None) -> KiaUvoApiAU:
+    """AU api with the full login chain stubbed; _get_access_token returns
+    the given expires_in as the 4th element."""
+    api = KiaUvoApiAU(region=5, brand=2, language="en")
+    api._get_stamp = lambda: "S"  # type: ignore[assignment]
+    api._get_device_id = lambda stamp: "dev"  # type: ignore[assignment]
+    api._get_cookies = lambda: {}  # type: ignore[assignment]
+    api._get_authorization_code_with_redirect_url = (  # type: ignore[assignment]
+        lambda username, password, cookies: "authcode"
+    )
+    api._get_access_token = (  # type: ignore[assignment]
+        lambda authorization_code, stamp: ("Bearer", "Bearer atk", "rtk", expires_in)
+    )
+    api._get_refresh_token = (  # type: ignore[assignment]
+        lambda authorization_code, stamp: ("Bearer", "Bearer rtk")
+    )
+    return api
+
+
+def test_au_get_access_token_returns_expires_in() -> None:
+    """_get_access_token must surface the response expires_in (4th element)."""
+    api = KiaUvoApiAU(region=5, brand=2, language="en")
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {
+        "token_type": "Bearer",
+        "access_token": "atk",
+        "refresh_token": "rtk",
+        "expires_in": 21600,
+    }
+    api.session.post = MagicMock(return_value=mock_resp)  # type: ignore[assignment]
+    result = api._get_access_token("authcode", "S")
+    assert result[3] == 21600
+
+
+def test_au_login_valid_until_from_expires_in() -> None:
+    """login() must set valid_until from expires_in (6h), not the 23h hardcode."""
+    api = _au_api_with_login_chain(expires_in=21600)
+    token = api.login("u", "p", pin="0000")
+    delta = token.valid_until - dt.datetime.now(dt.timezone.utc)
+    assert dt.timedelta(hours=5, minutes=55) < delta < dt.timedelta(hours=6, minutes=5)
+
+
+def test_au_login_valid_until_fallback_when_no_expires_in() -> None:
+    """When the server omits expires_in, fall back to LOGIN_TOKEN_LIFETIME (23h)."""
+    api = _au_api_with_login_chain(expires_in=None)
+    token = api.login("u", "p", pin="0000")
+    delta = token.valid_until - dt.datetime.now(dt.timezone.utc)
+    assert (
+        dt.timedelta(hours=22, minutes=55) < delta < dt.timedelta(hours=23, minutes=5)
+    )
+    # sanity: the fallback is the existing constant, not some other value
+    assert LOGIN_TOKEN_LIFETIME == dt.timedelta(hours=23)

--- a/tests/test_au_refresh_access_token.py
+++ b/tests/test_au_refresh_access_token.py
@@ -6,6 +6,7 @@ from hyundai_kia_connect_api.KiaUvoApiAU import KiaUvoApiAU
 from hyundai_kia_connect_api.KiaUvoApiCN import KiaUvoApiCN
 from hyundai_kia_connect_api.KiaUvoApiIN import KiaUvoApiIN
 from hyundai_kia_connect_api.Token import Token
+from hyundai_kia_connect_api.exceptions import DeviceIDError
 
 _TOKEN_RESPONSE = {
     "token_type": "Bearer",
@@ -52,3 +53,16 @@ def test_au_refresh_grant_type_and_url() -> None:
     assert call.args[0] == api.USER_API_URL + "oauth2/token"
     assert "grant_type=refresh_token" in call.kwargs["data"]
     assert "refresh_token=old-rtk" in call.kwargs["data"]
+
+
+def test_au_refresh_falls_back_to_login_on_error() -> None:
+    """If the refresh request raises, the base must fall back to self.login()."""
+    api = KiaUvoApiAU(region=5, brand=2, language="en")
+    api._get_stamp = lambda: "STAMP-FAKE"  # type: ignore[assignment]
+    api.session.post = MagicMock(  # type: ignore[assignment]
+        side_effect=DeviceIDError("4002 Invalid parameters")
+    )
+    api.login = MagicMock(return_value="FELLBACK")  # type: ignore[assignment]
+    result = api.refresh_access_token(Token(refresh_token="old-rtk"))
+    assert result == "FELLBACK"
+    api.login.assert_called_once()

--- a/tests/test_au_refresh_access_token.py
+++ b/tests/test_au_refresh_access_token.py
@@ -1,0 +1,16 @@
+"""Tests for the refresh_access_token Stamp hook (kia_uvo #1778, AU)."""
+
+from hyundai_kia_connect_api.KiaUvoApiCN import KiaUvoApiCN
+from hyundai_kia_connect_api.KiaUvoApiIN import KiaUvoApiIN
+
+
+def test_cn_refresh_hook_default_empty() -> None:
+    """CN inherits the base hook and must not send Stamp on refresh."""
+    api = KiaUvoApiCN(region=4, brand=1, language="en")
+    assert api._refresh_access_token_headers() == {}
+
+
+def test_in_refresh_hook_default_empty() -> None:
+    """IN inherits the base hook and must not send Stamp on refresh."""
+    api = KiaUvoApiIN(brand=2)
+    assert api._refresh_access_token_headers() == {}

--- a/tests/test_au_refresh_access_token.py
+++ b/tests/test_au_refresh_access_token.py
@@ -1,7 +1,18 @@
 """Tests for the refresh_access_token Stamp hook (kia_uvo #1778, AU)."""
 
+from unittest.mock import MagicMock
+
+from hyundai_kia_connect_api.KiaUvoApiAU import KiaUvoApiAU
 from hyundai_kia_connect_api.KiaUvoApiCN import KiaUvoApiCN
 from hyundai_kia_connect_api.KiaUvoApiIN import KiaUvoApiIN
+from hyundai_kia_connect_api.Token import Token
+
+_TOKEN_RESPONSE = {
+    "token_type": "Bearer",
+    "access_token": "atk",
+    "refresh_token": "rtk",
+    "expires_in": 86400,
+}
 
 
 def test_cn_refresh_hook_default_empty() -> None:
@@ -14,3 +25,30 @@ def test_in_refresh_hook_default_empty() -> None:
     """IN inherits the base hook and must not send Stamp on refresh."""
     api = KiaUvoApiIN(brand=2)
     assert api._refresh_access_token_headers() == {}
+
+
+def _au_api_with_mock_session() -> KiaUvoApiAU:
+    api = KiaUvoApiAU(region=5, brand=2, language="en")
+    api._get_stamp = lambda: "STAMP-FAKE"  # type: ignore[assignment]
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = _TOKEN_RESPONSE
+    api.session.post = MagicMock(return_value=mock_resp)  # type: ignore[assignment]
+    return api
+
+
+def test_au_refresh_sends_stamp() -> None:
+    """AU refresh_token grant must include the Stamp header."""
+    api = _au_api_with_mock_session()
+    api.refresh_access_token(Token(refresh_token="old-rtk"))
+    sent_headers = api.session.post.call_args.kwargs["headers"]
+    assert sent_headers.get("Stamp") == "STAMP-FAKE"
+
+
+def test_au_refresh_grant_type_and_url() -> None:
+    """AU refresh uses grant_type=refresh_token to the oauth2/token endpoint."""
+    api = _au_api_with_mock_session()
+    api.refresh_access_token(Token(refresh_token="old-rtk"))
+    call = api.session.post.call_args
+    assert call.args[0] == api.USER_API_URL + "oauth2/token"
+    assert "grant_type=refresh_token" in call.kwargs["data"]
+    assert "refresh_token=old-rtk" in call.kwargs["data"]

--- a/tests/test_type1_refresh_access_token.py
+++ b/tests/test_type1_refresh_access_token.py
@@ -1,12 +1,13 @@
 """Tests for ApiImplType1.refresh_access_token (shared by AU, IN, CN).
 
-Locks in the unified base behaviour: the refresh_token grant is sent to
-``oauth2/token`` without a Stamp header. CN's existing ``_get_refresh_token``
-already omits Stamp and works, which shows the endpoint family does not
-require it. AU and IN previously sent Stamp, but that was carried over from
-``_get_access_token`` (authorization_code grant) and is not required for the
-refresh_token grant. If a region's server turns out to require Stamp, the
-call fails and falls back to ``self.login()`` — no regression vs. pre-PR.
+The base implementation sends the refresh_token grant to ``oauth2/token``
+without a Stamp header. CN's existing ``_get_refresh_token`` already omits
+Stamp and works, so CN and IN inherit the base (no Stamp). AU, however,
+requires Stamp on the refresh_token grant — confirmed live in kia_uvo #1778
+(errCode 4002 "Invalid parameters" without it) — so AU overrides the
+``_refresh_access_token_headers`` hook to add ``Stamp`` while still inheriting
+the base method. If a region's refresh fails, the base falls back to
+``self.login()`` — no regression vs. pre-PR.
 """
 
 from unittest.mock import patch
@@ -166,7 +167,10 @@ class TestRegionsUseBaseRefreshAccessToken:
     def test_cn_does_not_override_refresh_access_token(self):
         assert KiaUvoApiCN.refresh_access_token is ApiImplType1.refresh_access_token
 
-    def test_au_refresh_does_not_send_stamp(self):
+    def test_au_refresh_sends_stamp(self):
+        # AU requires the Stamp header on the refresh_token grant — confirmed
+        # live in kia_uvo #1778 (errCode 4002 "Invalid parameters" without it).
+        # AU overrides the _refresh_access_token_headers hook, not the method.
         api = KiaUvoApiAU(region=5, brand=2, language="en")
         captured = {}
 
@@ -179,4 +183,5 @@ class TestRegionsUseBaseRefreshAccessToken:
         ):
             api.refresh_access_token(_make_token())
 
-        assert "Stamp" not in captured["headers"]
+        assert "Stamp" in captured["headers"]
+        assert captured["headers"]["Stamp"]


### PR DESCRIPTION
Fixes the two AU/NZ `KiaUvoApiAU` authentication issues confirmed live in kia_uvo #1778 (https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1778), specifically the diagnostic transcript from @stuartdenne (Kia NZ, region 7, same `KiaUvoApiAU` / `au-apigw.ccs.kia.com.au:8082` gateway).

## 1. `refresh_access_token` must send the `Stamp` header (the `4002`)

The base `ApiImplType1.refresh_access_token` (shared by AU, IN, CN) sends the `oauth2/token` refresh_token grant **without** `Stamp`, on the assumption that the endpoint family does not require it (PR #1188, based on CN's behaviour). Live evidence in #1778 disproves this for AU/NZ:

- Without `Stamp` → `400 errCode 4002 "Invalid parameters"`.
- The byte-identical grant **with** `Stamp` (inside the login flow) → `200` + `access_token`.

The fallback `try/except → self.login()` masked this, so it was benign in isolation but meant AU/NZ did a full re-login on every token expiry.

**Fix:** add a small hook on `ApiImplType1`:

```python
def _refresh_access_token_headers(self) -> dict[str, str]:
    return {}
```

The base merges it into the refresh request headers (`headers.update(self._refresh_access_token_headers())`). `KiaUvoApiAU` overrides only the hook:

```python
def _refresh_access_token_headers(self) -> dict[str, str]:
    return {"Stamp": self._get_stamp()}
```

IN and CN inherit the empty default — no behaviour change. AU still inherits the base `refresh_access_token` method (it overrides the hook, not the method), so the existing `test_au_does_not_override_refresh_access_token` still holds. The #1188 test that locked in the old no-Stamp assumption for AU (`test_au_refresh_does_not_send_stamp`) is flipped to `test_au_refresh_sends_stamp` and the module docstring corrected.

This mirrors the existing `KiaUvoApiEU._get_access_token` pattern of surfacing headers/expires_in through small per-region overrides rather than duplicating the whole method.

## 2. `login()` must derive `valid_until` from `expires_in`, not the 23h hardcode

`KiaUvoApiAU.login()` set `valid_until = now + LOGIN_TOKEN_LIFETIME` (23h), but the AU/NZ gateway returns tokens with `expires_in: 21600` (6h) and the JWT `exp` agrees. From hour 6 to 23 the library believed a dead token was alive: `check_and_refresh_token()` did not fire (valid_until in the future) and `test_token()` (base `return True`) never invalidated, so every API call 401'd until HA reauthed ~twice a day. Live-confirmed on Kia NZ by @stuartdenne.

The base `refresh_access_token` already used `expires_in` correctly; only the initial `login()` path hardcoded it.

**Fix:** `_get_access_token` now surfaces `expires_in` as a 4th return value (mirroring `KiaUvoApiEU._get_access_token`). `login()` uses it when present, falling back to `LOGIN_TOKEN_LIFETIME` (23h) when the server omits it — preserving the old behaviour for any endpoint that does not return `expires_in`.

## Out of scope

- The AU **Hyundai** `/signin` failure (`errCode 4003 "Invalid values"`, gateway returns the new Vite SPA login page) reported by the original AU Hyundai reporter is a separate, Hyundai-gateway-specific server-side change and is **not** addressed here. kia_uvo #1778 tracks it. The Kia NZ/AU gateway `/signin` works fine.
- IN / CN are unchanged (no live evidence they need Stamp on refresh).

## Tests

- `tests/test_au_refresh_access_token.py` (new): AU sends Stamp, IN/CN do not, correct grant/URL, fallback to login still works.
- `tests/test_au_login_token_lifetime.py` (new): `_get_access_token` surfaces `expires_in`; `login()` derives `valid_until` from it; falls back to `LOGIN_TOKEN_LIFETIME` when absent.
- `tests/test_type1_refresh_access_token.py`: the #1188 AU no-Stamp test flipped to assert Stamp is sent; docstring corrected.

`ruff` clean; the new tests pass; no new failures in the committed suite (the 10 `test_vehicle_snapshots` failures are pre-existing on `master`, unrelated `.ambr` staleness).

---

Live-confirmed on the Kia NZ/AU gateway by @stuartdenne (https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1778). I do not have AU/NZ credentials to test end-to-end myself; review/live-test welcome — particularly a Kia AU reporter, and a Hyundai AU reporter for the separate `/signin` issue above.
