### PR TITLE
fix(AU/NZ): store the real refresh token instead of a second access token (#1778)

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiAU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiAU.py
@@ -110,10 +110,9 @@ class KiaUvoApiAU(ApiImplType1):
         if authorization_code is None:
             raise AuthenticationError("Login Failed")
 
-        _, access_token, authorization_code, expires_in = self._get_access_token(
+        _, access_token, refresh_token, expires_in = self._get_access_token(
             authorization_code, stamp
         )
-        _, refresh_token = self._get_refresh_token(authorization_code, stamp)
         if expires_in is not None:
             valid_until = dt.datetime.now(dt.timezone.utc) + dt.timedelta(
                 seconds=int(expires_in)
@@ -939,29 +938,12 @@ class KiaUvoApiAU(ApiImplType1):
 
         token_type = response["token_type"]
         access_token = token_type + " " + response["access_token"]
-        authorization_code = response["refresh_token"]
+        # Keep the refresh token verbatim: the oauth2/token refresh_token grant
+        # rejects "Bearer "-prefixed values and access tokens in the
+        # refresh_token slot with 4002 (kia_uvo #1778).
+        refresh_token = response["refresh_token"]
         expires_in = response.get("expires_in")
-        return token_type, access_token, authorization_code, expires_in
-
-    def _get_refresh_token(self, authorization_code, stamp):
-        # Get Refresh Token #
-        url = self.USER_API_URL + "oauth2/token"
-        headers = {
-            "Authorization": self.BASIC_AUTHORIZATION,
-            "Stamp": stamp,
-            "Content-type": "application/x-www-form-urlencoded",
-            "Host": self.BASE_URL,
-            "Connection": "close",
-            "Accept-Encoding": "gzip, deflate",
-            "User-Agent": USER_AGENT_OK_HTTP,
-        }
-
-        data = "grant_type=refresh_token&refresh_token=" + authorization_code
-        response = self.session.post(url, data=data, headers=headers)
-        response = response.json()
-        token_type = response["token_type"]
-        refresh_token = token_type + " " + response["access_token"]
-        return token_type, refresh_token
+        return token_type, access_token, refresh_token, expires_in
 
     def _refresh_access_token_headers(self) -> dict[str, str]:
         """AU requires the Stamp header on the refresh_token grant."""

--- a/tests/test_au_login_refresh_token.py
+++ b/tests/test_au_login_refresh_token.py
@@ -1,0 +1,64 @@
+"""Tests for KiaUvoApiAU.login() refresh-token storage (kia_uvo #1778, NZ finding).
+
+login() previously minted a second access token via a refresh_token grant and
+stored THAT, "Bearer "-prefixed, as Token.refresh_token — discarding the real
+refresh token returned by the authorization_code grant. The AU/NZ gateway
+rejects both deviations independently with 4002 "Invalid parameters"
+("Bearer "-prefixed values, and access tokens in the refresh_token slot), so
+refresh_access_token could never succeed and always fell back to a full login.
+login() must store the authorization_code grant's refresh_token verbatim.
+"""
+
+from unittest.mock import MagicMock
+
+from hyundai_kia_connect_api.KiaUvoApiAU import KiaUvoApiAU
+
+
+def _au_api_with_login_chain() -> KiaUvoApiAU:
+    """AU api with the full login chain stubbed at the helper level."""
+    api = KiaUvoApiAU(region=5, brand=2, language="en")
+    api._get_stamp = lambda: "S"  # type: ignore[assignment]
+    api._get_device_id = lambda stamp: "dev"  # type: ignore[assignment]
+    api._get_cookies = lambda: {}  # type: ignore[assignment]
+    api._get_authorization_code_with_redirect_url = (  # type: ignore[assignment]
+        lambda username, password, cookies: "authcode"
+    )
+    api._get_access_token = (  # type: ignore[assignment]
+        lambda authorization_code, stamp: ("Bearer", "Bearer atk", "raw-rtk", 21600)
+    )
+    return api
+
+
+def test_au_get_access_token_returns_raw_refresh_token() -> None:
+    """_get_access_token must surface the response refresh_token verbatim
+    (3rd element) — no "Bearer " prefix, not a second access token."""
+    api = KiaUvoApiAU(region=5, brand=2, language="en")
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {
+        "token_type": "Bearer",
+        "access_token": "atk",
+        "refresh_token": "rtk",
+        "expires_in": 21600,
+    }
+    api.session.post = MagicMock(return_value=mock_resp)  # type: ignore[assignment]
+    result = api._get_access_token("authcode", "S")
+    assert result[2] == "rtk"
+
+
+def test_au_login_stores_real_refresh_token_verbatim() -> None:
+    """login() must store the auth-code grant's refresh_token, unmodified."""
+    api = _au_api_with_login_chain()
+    token = api.login("u", "p", pin="0000")
+    assert token.refresh_token == "raw-rtk"
+
+
+def test_au_login_makes_no_second_token_request() -> None:
+    """login() must not mint a second access token to use as refresh token.
+
+    With every login helper stubbed, no request should reach the session at
+    all — the old _get_refresh_token grant was the only remaining one.
+    """
+    api = _au_api_with_login_chain()
+    api.session.post = MagicMock()  # type: ignore[assignment]
+    api.login("u", "p", pin="0000")
+    api.session.post.assert_not_called()

--- a/tests/test_au_login_token_lifetime.py
+++ b/tests/test_au_login_token_lifetime.py
@@ -27,9 +27,6 @@ def _au_api_with_login_chain(expires_in: int | None) -> KiaUvoApiAU:
     api._get_access_token = (  # type: ignore[assignment]
         lambda authorization_code, stamp: ("Bearer", "Bearer atk", "rtk", expires_in)
     )
-    api._get_refresh_token = (  # type: ignore[assignment]
-        lambda authorization_code, stamp: ("Bearer", "Bearer rtk")
-    )
     return api
 
 


### PR DESCRIPTION
Follow-up to #1241 / kia_uvo #1778.  On v4.25.2 the AU/NZ refresh grant still gets the `4002` and falls back to a full login every cycle (live-confirmed on Kia NZ in [this comment](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/pull/1241#issuecomment-5012595311)).  The Stamp was necessary but not sufficient - the *token* the library presents is wrong.

## Cause

`KiaUvoApiAU.login()` minted a second access token via `_get_refresh_token()` and stored it, `"Bearer "`-prefixed, as `Token.refresh_token` - discarding the genuine refresh token returned by the authorization_code grant (it was consumed once as the `authorization_code` arg and dropped).

Probed the `oauth2/token` refresh_token grant on live Kia NZ (all variants with Stamp + Basic auth):

| refresh_token param | result |
|---|---|
| real refresh token, verbatim | **200** |
| `"Bearer "` + real refresh token | 400 `4002 Invalid parameters` |
| raw access token (seconds old) | 400 `4002 Invalid parameters` |
| real refresh token, reused | **200** |

So both deviations in the stored value are *independently* fatal: the `"Bearer "` prefix, and access-tokens-in-the-refresh-slot (regardless of liveness - this corrects my earlier #1241 comment, which attributed it to token type alone).  Also of note: the real refresh token is opaque (not a JWT) and survives reuse - no rotation.

## Fix

- `_get_access_token()` returns the response's `refresh_token` verbatim (the misleading `authorization_code` variable name is gone).
- `login()` stores it directly and no longer calls `_get_refresh_token()`; the method is removed (its only effect was minting the bogus stored value - login now makes one `oauth2/token` call instead of two).

CN/IN/EU have the same `_get_refresh_token` pattern but are untouched - no live evidence from those regions, and EU overrides the refresh flow anyway.

(Noticed in passing, untouched here: the base fallback `self.login(token.username, token.password, token.pin)` in `ApiImplType1.refresh_access_token` passes `pin` into the `otp_handler` positional, so the fallback-minted Token has `pin=None` - worth a separate look.)

**Migration:** existing stored tokens still hold the old `"Bearer <access token>"` value; the first refresh attempt fails as it does today and the existing fallback does a full login, after which the real refresh token is stored.  Self-healing, no action needed.

## Tests

- `tests/test_au_login_refresh_token.py` (new): `_get_access_token` surfaces the refresh token verbatim; `login()` stores it unmodified; `login()` makes no second token request.
- `tests/test_au_login_token_lifetime.py`: login-chain stub updated (no `_get_refresh_token` any more).
- Full suite: 389 passed; the 10 `test_vehicle_snapshots` failures are pre-existing on clean `master` (re-verified today).  `ruff check` + `format` clean.

## Live end-to-end on Kia NZ (this branch)

```
login:                        signin -> 200, oauth2/token -> 200   (refresh_token: raw opaque, 48 chars; valid_until +6.0h)
refresh_access_token:         oauth2/token -> 200, NO /signin      (same refresh_token retained)
check_and_refresh_token
  (valid_until forced past):  oauth2/token -> 200, NO /signin
```

First time the AU/NZ refresh path actually refreshes.  One caveat I could not test quickly: whether the refresh token stays valid well past the 6h access-token lifetime - it is opaque, so no `exp` to read.  My HA install runs this branch's behaviour from tonight (backported into the custom component), so I'll have multi-cycle soak data within a day or two if you want it before merging.

Disclosure, same as my #1778 comment: diagnosis, patch and tests are largely Claude (AI) work - reviewed, run and live-tested against Kia NZ by me.
