### PR TITLE
fix: Stop forcing urllib3 to AF_INET

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -6,14 +6,12 @@ import datetime as dt
 import json
 import logging
 import platform
-import socket
 import time
 from zoneinfo import ZoneInfo
 import uuid
 import base64
 
 import requests
-import requests.packages.urllib3.util.connection as urllib3_cn
 
 # Try to fix hyundai/cloudflare
 
@@ -43,13 +41,6 @@ from .utils import (
     parse_datetime,
 )
 from .Vehicle import DailyDrivingStats, Vehicle
-
-
-def allowed_gai_family():
-    return socket.AF_INET
-
-
-urllib3_cn.allowed_gai_family = allowed_gai_family
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/scripts/ca_api_diagnostic.py
+++ b/scripts/ca_api_diagnostic.py
@@ -24,20 +24,10 @@ Safe: This script only reads data. It does not send commands to your vehicle.
 import argparse
 import base64
 import platform
-import socket
 import time
 import uuid
 
 import requests
-import requests.packages.urllib3.util.connection as urllib3_cn
-
-
-# Force IPv4 — CA API has known IPv6 issues
-def allowed_gai_family():
-    return socket.AF_INET
-
-
-urllib3_cn.allowed_gai_family = allowed_gai_family
 
 # ── Brand config ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
This setting is application-wide, so forces all outbound connections made by python to use/prefer an AF_INET socket. This seems to be causing all connections in my Home Assistant to prefer IPv4 despite almost everything having AAAA records.

It appears to be left over from debugging and not removed when merging 7f59ae73fa15c694c0273d82c1d6a37d46e7429b.