### PR TITLE
fix(USA): raise typed exceptions in auth chain (login / verify OTP)

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiUSA.py
@@ -229,15 +229,16 @@ class KiaUvoApiUSA(ApiImpl):
         response = self.session.post(url, json=data, headers=headers)
         _LOGGER.debug(f"{DOMAIN} - Verify OTP Response {response.text}")
         response_json = response.json()
-        if response_json["status"]["statusCode"] != 0:
-            raise Exception(
-                f"{DOMAIN} - OTP verification failed: {response_json['status']['errorMessage']}"
+        status = response_json.get("status") or {}
+        if status.get("statusCode") != 0:
+            raise AuthenticationError(
+                f"OTP verification failed: {status.get('errorMessage', '')}"
             )
         sid = response.headers.get("sid")
         rmtoken = response.headers.get("rmtoken")
         if not sid or not rmtoken:
-            raise Exception(
-                f"{DOMAIN} - No sid or rmtoken in OTP verification response. Headers: {response.headers}"
+            raise APIError(
+                f"No sid or rmtoken in OTP verification response. Headers: {response.headers}"
             )
         return sid, rmtoken
 

--- a/hyundai_kia_connect_api/KiaUvoApiUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiUSA.py
@@ -365,9 +365,12 @@ class KiaUvoApiUSA(ApiImpl):
                 has_email=bool(payload.get("hasEmail")),
                 has_sms=bool(payload.get("hasPhone")),
             )
-        raise Exception(
-            f"{DOMAIN} - No session id returned in login. Response: {response.text} headers {response.headers} cookies {response.cookies}"
-        )
+        status = response_json.get("status") or {}
+        if status.get("errorCode") == 1001:
+            raise AuthenticationError(
+                f"Invalid Email or Password: {status.get('errorMessage', '')}"
+            )
+        raise APIError(f"No session id returned in login. Response: {response.text}")
 
     def refresh_access_token(self, token: Token) -> Token | OTPRequest:
         """Refresh the token using the refresh token"""

--- a/hyundai_kia_connect_api/KiaUvoApiUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiUSA.py
@@ -259,9 +259,7 @@ class KiaUvoApiUSA(ApiImpl):
         _LOGGER.debug(f"{DOMAIN} - Complete Login Response {response.text}")
         final_sid = response.headers.get("sid")
         if not final_sid:
-            raise Exception(
-                f"{DOMAIN} - No final sid returned. Response: {response.text}"
-            )
+            raise APIError(f"No final sid returned. Response: {response.text}")
         return final_sid
 
     def send_otp(self, otp_request: OTPRequest, notify_type: OTP_NOTIFY_TYPE) -> dict:

--- a/hyundai_kia_connect_api/KiaUvoApiUSA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiUSA.py
@@ -230,7 +230,7 @@ class KiaUvoApiUSA(ApiImpl):
         _LOGGER.debug(f"{DOMAIN} - Verify OTP Response {response.text}")
         response_json = response.json()
         status = response_json.get("status") or {}
-        if status.get("statusCode") != 0:
+        if status.get("statusCode"):
             raise AuthenticationError(
                 f"OTP verification failed: {status.get('errorMessage', '')}"
             )

--- a/tests/test_usa_login_errors.py
+++ b/tests/test_usa_login_errors.py
@@ -200,3 +200,17 @@ def test_verify_otp_success_returns_sid_rmtoken(usa_api):
 
     assert sid == "sid-val"
     assert rmtoken == "rm-val"
+
+
+def test_verify_otp_no_status_block_raises_apierror(usa_api):
+    """A malformed verifyOTP response with no status block must not be misclassified as wrong-OTP (AuthenticationError)."""
+    usa_api.session = MagicMock()
+    resp = MagicMock()
+    resp.json.return_value = {}  # no "status" key at all
+    resp.text = "{}"
+    resp.headers = {}
+    usa_api.session.post.return_value = resp
+
+    with pytest.raises(APIError) as exc_info:
+        usa_api._verify_otp("otpkey", "1234", "xid")
+    assert not isinstance(exc_info.value, AuthenticationError)

--- a/tests/test_usa_login_errors.py
+++ b/tests/test_usa_login_errors.py
@@ -62,7 +62,7 @@ def _otp_verify_response(
 ) -> MagicMock:
     """Build a mocked /cmm/verifyOTP response."""
     resp = MagicMock()
-    body = {
+    body: dict = {
         "status": {
             "statusCode": status_code,
             "errorType": 0,
@@ -85,7 +85,7 @@ def _complete_login_response(sid: str | None = None) -> MagicMock:
     """Build a mocked final /prof/authUser (complete-login) response."""
     resp = MagicMock()
     resp.json.return_value = {"status": {"statusCode": 0, "errorMessage": ""}}
-    resp.text = "{}"
+    resp.text = json.dumps({"status": {"statusCode": 0, "errorMessage": ""}})
     resp.headers = {"sid": sid} if sid is not None else {}
     return resp
 
@@ -103,9 +103,6 @@ def test_login_wrong_credentials_raises_authentication_error(usa_api):
     with pytest.raises(AuthenticationError) as exc_info:
         usa_api.login("u", "bad", token)
     assert "Invalid Email or Password" in str(exc_info.value)
-    assert not isinstance(exc_info.value, APIError) or isinstance(
-        exc_info.value, AuthenticationError
-    )
 
 
 def test_login_invalid_request_raises_apierror_not_auth(usa_api):

--- a/tests/test_usa_login_errors.py
+++ b/tests/test_usa_login_errors.py
@@ -9,7 +9,10 @@ import json
 import pytest
 from unittest.mock import MagicMock
 
+from hyundai_kia_connect_api.ApiImpl import OTPRequest
 from hyundai_kia_connect_api.KiaUvoApiUSA import KiaUvoApiUSA
+from hyundai_kia_connect_api.Token import Token
+from hyundai_kia_connect_api.exceptions import APIError, AuthenticationError
 
 
 @pytest.fixture
@@ -85,3 +88,83 @@ def _complete_login_response(sid: str | None = None) -> MagicMock:
     resp.text = "{}"
     resp.headers = {"sid": sid} if sid is not None else {}
     return resp
+
+
+def test_login_wrong_credentials_raises_authentication_error(usa_api):
+    token = Token(username="u", password="bad", access_token="x", refresh_token="r")
+    usa_api.session = MagicMock()
+    usa_api.session.post.return_value = _login_response(
+        status_code=1,
+        error_type=1,
+        error_code=1001,
+        error_message="Invalid Email or Password",
+    )
+
+    with pytest.raises(AuthenticationError) as exc_info:
+        usa_api.login("u", "bad", token)
+    assert "Invalid Email or Password" in str(exc_info.value)
+    assert not isinstance(exc_info.value, APIError) or isinstance(
+        exc_info.value, AuthenticationError
+    )
+
+
+def test_login_invalid_request_raises_apierror_not_auth(usa_api):
+    """9789 'Invalid Request' is a protocol issue, not bad creds — must NOT be AuthenticationError."""
+    token = Token(username="u", password="p", access_token="x", refresh_token="r")
+    usa_api.session = MagicMock()
+    usa_api.session.post.return_value = _login_response(
+        status_code=1,
+        error_type=3,
+        error_code=9789,
+        error_message="Invalid Request",
+    )
+
+    with pytest.raises(APIError) as exc_info:
+        usa_api.login("u", "p", token)
+    assert not isinstance(exc_info.value, AuthenticationError)
+
+
+def test_login_status_zero_no_sid_raises_apierror(usa_api):
+    token = Token(username="u", password="p", access_token="x", refresh_token="r")
+    usa_api.session = MagicMock()
+    usa_api.session.post.return_value = _login_response(
+        status_code=0, error_message="Success with response body"
+    )
+
+    with pytest.raises(APIError) as exc_info:
+        usa_api.login("u", "p", token)
+    assert not isinstance(exc_info.value, AuthenticationError)
+
+
+def test_login_success_returns_token(usa_api):
+    """Regression: sid present -> Token (unchanged path)."""
+    usa_api.session = MagicMock()
+    usa_api.session.post.return_value = _login_response(
+        status_code=0, sid="session-id", error_message="Success"
+    )
+
+    result = usa_api.login("u", "p")
+
+    assert isinstance(result, Token)
+    assert result.access_token == "session-id"
+
+
+def test_login_otp_required_returns_otprequest(usa_api):
+    """Regression: otpKey in payload -> OTPRequest (unchanged path)."""
+    usa_api.session = MagicMock()
+    usa_api.session.post.return_value = _login_response(
+        status_code=0,
+        payload={
+            "otpKey": "k",
+            "email": "e",
+            "phone": "s",
+            "hasEmail": True,
+            "hasPhone": True,
+        },
+        error_message="Success",
+    )
+
+    result = usa_api.login("u", "p")
+
+    assert isinstance(result, OTPRequest)
+    assert result.otp_key == "k"

--- a/tests/test_usa_login_errors.py
+++ b/tests/test_usa_login_errors.py
@@ -168,3 +168,35 @@ def test_login_otp_required_returns_otprequest(usa_api):
 
     assert isinstance(result, OTPRequest)
     assert result.otp_key == "k"
+
+
+def test_verify_otp_wrong_code_raises_authentication_error(usa_api):
+    usa_api.session = MagicMock()
+    usa_api.session.post.return_value = _otp_verify_response(
+        status_code=1, error_message="Invalid OTP"
+    )
+
+    with pytest.raises(AuthenticationError) as exc_info:
+        usa_api._verify_otp("otpkey", "0000", "xid")
+    assert "OTP verification failed" in str(exc_info.value)
+
+
+def test_verify_otp_missing_sid_rmtoken_raises_apierror(usa_api):
+    usa_api.session = MagicMock()
+    usa_api.session.post.return_value = _otp_verify_response(status_code=0)
+
+    with pytest.raises(APIError) as exc_info:
+        usa_api._verify_otp("otpkey", "1234", "xid")
+    assert not isinstance(exc_info.value, AuthenticationError)
+
+
+def test_verify_otp_success_returns_sid_rmtoken(usa_api):
+    usa_api.session = MagicMock()
+    usa_api.session.post.return_value = _otp_verify_response(
+        status_code=0, sid="sid-val", rmtoken="rm-val"
+    )
+
+    sid, rmtoken = usa_api._verify_otp("otpkey", "1234", "xid")
+
+    assert sid == "sid-val"
+    assert rmtoken == "rm-val"

--- a/tests/test_usa_login_errors.py
+++ b/tests/test_usa_login_errors.py
@@ -214,3 +214,22 @@ def test_verify_otp_no_status_block_raises_apierror(usa_api):
     with pytest.raises(APIError) as exc_info:
         usa_api._verify_otp("otpkey", "1234", "xid")
     assert not isinstance(exc_info.value, AuthenticationError)
+
+
+def test_complete_login_with_otp_missing_sid_raises_apierror(usa_api):
+    usa_api.session = MagicMock()
+    usa_api.session.post.return_value = _complete_login_response(sid=None)
+
+    with pytest.raises(APIError) as exc_info:
+        usa_api._complete_login_with_otp("u", "p", "sid", "rmtoken")
+    assert "No final sid returned" in str(exc_info.value)
+    assert not isinstance(exc_info.value, AuthenticationError)
+
+
+def test_complete_login_with_otp_success_returns_sid(usa_api):
+    usa_api.session = MagicMock()
+    usa_api.session.post.return_value = _complete_login_response(sid="final-sid")
+
+    result = usa_api._complete_login_with_otp("u", "p", "sid", "rmtoken")
+
+    assert result == "final-sid"

--- a/tests/test_usa_login_errors.py
+++ b/tests/test_usa_login_errors.py
@@ -1,0 +1,87 @@
+"""Tests for USA auth-chain error mapping in login / _verify_otp / _complete_login_with_otp.
+
+KiaUvoApiUSA must raise typed exceptions (AuthenticationError / APIError) instead of
+bare Exception, so Home Assistant can surface wrong-credentials / wrong-OTP via re-auth.
+"""
+
+import json
+
+import pytest
+from unittest.mock import MagicMock
+
+from hyundai_kia_connect_api.KiaUvoApiUSA import KiaUvoApiUSA
+
+
+@pytest.fixture
+def usa_api() -> KiaUvoApiUSA:
+    api = KiaUvoApiUSA.__new__(KiaUvoApiUSA)
+    api.API_URL = "https://example.com/"
+    api._otp_handler = None
+    api.api_headers = lambda: {}
+    api.device_id = "device-key"
+    return api
+
+
+def _login_response(
+    status_code: int,
+    error_type: int = 0,
+    error_code: int = 0,
+    error_message: str = "",
+    sid: str | None = None,
+    payload: dict | None = None,
+) -> MagicMock:
+    """Build a mocked /prof/authUser response."""
+    resp = MagicMock()
+    body: dict = {
+        "status": {
+            "statusCode": status_code,
+            "errorType": error_type,
+            "errorCode": error_code,
+            "errorMessage": error_message,
+        }
+    }
+    if payload is not None:
+        body["payload"] = payload
+    resp.json.return_value = body
+    resp.text = json.dumps(body)
+    headers: dict = {}
+    if sid is not None:
+        headers["sid"] = sid
+    resp.headers = headers
+    return resp
+
+
+def _otp_verify_response(
+    status_code: int,
+    error_message: str = "",
+    sid: str | None = None,
+    rmtoken: str | None = None,
+) -> MagicMock:
+    """Build a mocked /cmm/verifyOTP response."""
+    resp = MagicMock()
+    body = {
+        "status": {
+            "statusCode": status_code,
+            "errorType": 0,
+            "errorCode": 0,
+            "errorMessage": error_message,
+        }
+    }
+    resp.json.return_value = body
+    resp.text = json.dumps(body)
+    headers: dict = {}
+    if sid is not None:
+        headers["sid"] = sid
+    if rmtoken is not None:
+        headers["rmtoken"] = rmtoken
+    resp.headers = headers
+    return resp
+
+
+def _complete_login_response(sid: str | None = None) -> MagicMock:
+    """Build a mocked final /prof/authUser (complete-login) response."""
+    resp = MagicMock()
+    resp.json.return_value = {"status": {"statusCode": 0, "errorMessage": ""}}
+    resp.text = "{}"
+    resp.headers = {"sid": sid} if sid is not None else {}
+    return resp


### PR DESCRIPTION
Fixes #1247

## Summary

`KiaUvoApiUSA` auth chain raised bare `Exception` on every non-success path, so Home Assistant could not surface wrong credentials / wrong OTP via re-auth flows:

- `kia_uvo` config flow catches `AuthenticationError` → `invalid_auth` (setup / re-auth) and `invalid_otp` (OTP step); bare `Exception` fell through to `errors["base"] = "unknown"`.
- `kia_uvo` coordinator catches `AuthenticationError` → `ConfigEntryAuthFailed` (re-auth); any other `Exception` → `UpdateFailed(retry_after=60)` (retry loop, never re-auth).

So wrong credentials (password changed server-side / typo at setup) looped `UpdateFailed` / "Unknown error" and the only recovery was deleting & re-adding the account. Wrong OTP code showed "Unknown error occurred" (the config_flow OTP step didn't catch bare `Exception`).

This maps the 4 bare-`Exception` sites to typed exceptions:

| Method | Condition | → Exception |
|---|---|---|
| `login()` | `errorCode == 1001` ("Invalid Email or Password") | `AuthenticationError` |
| `login()` | other non-zero status (incl 9789) / `statusCode==0` no sid+otpKey | `APIError` |
| `_verify_otp()` | `statusCode != 0` (wrong OTP code) | `AuthenticationError` |
| `_verify_otp()` | missing sid/rmtoken (malformed) | `APIError` |
| `_complete_login_with_otp()` | missing final sid (malformed) | `APIError` |

Token (sid) and OTPRequest (otpKey) success paths are unchanged. `refresh_access_token()` inherits the fix (calls `login()`).

## Why 9789 is NOT `AuthenticationError`

`errorCode 9789` "Invalid Request" is a protocol/lib-version issue, not bad credentials. Reporters (#747, #982 + others) can log in via the official app with the same credentials; #747 resolved by updating the lib. Raising `AuthenticationError` there would tell users to fix a correct password. So 9789 and other non-1001 non-zero codes map to `APIError`. Root-causing 9789 (why `/prof/authUser` rejects the lib's request) is a separate follow-up — this PR only classifies it correctly.

## Evidence

- `errorCode 1001` captured: #601
- `errorCode 9789` captured (not creds): #747, #982
- Wrong-OTP "Unknown error" (current bare-Exception UX this fixes): kia_uvo #1673

## Approach

Inline status-check in each method (no helper, no mapping dict) — matches USA's own `request_with_logging` (inline `statusCode`/`errorType`/`errorCode` check) and `get_vehicles`/`refresh_vehicles`. CA's `error_code_mapping` dict is CA-specific; one confirmed auth code (1001) does not justify a dict. Defensive parsing: `response_json.get("status") or {}` + `status.get(...)`; missing `status` key → graceful `APIError` (not a crash). `_verify_otp` uses a truthy `statusCode` check so a malformed no-status response falls through to the `APIError` path instead of being misclassified as wrong-OTP.

## Backward compatibility

`AuthenticationError` and `APIError` are siblings under `HyundaiKiaException` (subclass of `Exception`). Code catching `Exception` still catches them — zero regression. Code catching `AuthenticationError` (kia_uvo) now receives the proper signal — that is the desired behavior change. Verified: no kia_uvo code string-matches the old exception messages; the `login()` APIError message keeps the `"No session id returned in login. Response: ..."` prefix.

## Test plan

- [x] `login()` 1001 → `AuthenticationError` (message "Invalid Email or Password")
- [x] `login()` 9789 → `APIError` and NOT `AuthenticationError` (regression guard against broad mapping)
- [x] `login()` status 0 no sid → `APIError`
- [x] `login()` success → `Token` (regression)
- [x] `login()` otpKey → `OTPRequest` (regression)
- [x] `_verify_otp()` wrong code → `AuthenticationError`
- [x] `_verify_otp()` missing sid/rmtoken → `APIError`
- [x] `_verify_otp()` no-status block (malformed) → `APIError` (not misclassified as auth)
- [x] `_verify_otp()` success → `(sid, rmtoken)` (regression)
- [x] `_complete_login_with_otp()` missing sid → `APIError`
- [x] `_complete_login_with_otp()` success → final sid (regression)
- [x] `pytest tests/test_usa_login_errors.py` → 11/11 passing
- [x] `pytest tests/test_usa_session_expiry.py` → 12/12 passing (PR #1193 regression guard)
- [x] `grep "raise Exception" hyundai_kia_connect_api/KiaUvoApiUSA.py` → 0 matches (all 4 auth-chain sites typed)
- [x] `pre-commit run --all-files` green; ruff clean

## Scope

Only `KiaUvoApiUSA` auth chain. CA already maps auth codes; EU/AU/IN/CN untouched. No `VehicleManager` change (no try/except around auth calls — exceptions propagate identically). No `manifest.json` bump (release pipeline handles it).

## Pre-merge checks

- HA plumbing verified end-to-end: `config_flow` (`AuthenticationError` → `invalid_auth` / `invalid_otp`) and `coordinator` (`AuthenticationError` → `ConfigEntryAuthFailed`, other → `UpdateFailed`) already structured for typed exceptions — this PR activates the existing intended path.
- No consumer (kia_uvo or lib) string-matches the old bare-`Exception` messages; the `login()` APIError message preserves the `"No session id returned in login. Response:"` prefix.
- The `_retry_on_auth_error` decorator (PR #1193) re-wraps any re-login failure as `AuthenticationError("Re-login failed: ...")` — behavior unchanged by this PR (it already converted bare `Exception` to `AuthenticationError`; now it converts typed exceptions the same way, still `AuthenticationError` to HA). No infinite loop (`login` is not decorated; single retry).
- No kia_uvo `except` catches a narrower type that would newly intercept these (no `except APIError` / `except HyundaiKiaException` in kia_uvo).

## Out of scope (follow-ups)

1. 9789 root cause — why `/prof/authUser` rejects the lib's request (stale deviceid / headers / protocol drift). Separate issue/PR.
2. Pre-existing 9789 mislabeling in the `_retry_on_auth_error` wrapper (converts `APIError` re-login failure to `AuthenticationError("Re-login failed")`). Pre-existing, not introduced here; a follow-up could refine the wrapper to re-raise `APIError` separately.
3. Other regions' auth chains — whether EU/AU/IN/CN have the same bare-`Exception` gap. Separate investigation.