### PR TITLE
fix(EU): simpler wake+sleep+read CCS2 force refresh (alternative to #1184)

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -8,6 +8,7 @@ import datetime as dt
 import logging
 import uuid
 import re
+from time import sleep
 from urllib.parse import parse_qs, urlparse
 
 from Crypto.PublicKey import RSA
@@ -445,13 +446,22 @@ class KiaUvoApiEU(ApiImplType1):
                 self._update_vehicle_drive_info(vehicle, state)
 
     def _force_refresh_vehicle_state_ccs2(self, token: Token, vehicle: Vehicle) -> None:
-        url = self.SPA_API_URL + "vehicles/" + vehicle.id + "/ccs2/carstatus"
-        response = self.session.get(
-            url,
-            headers=self._get_authenticated_headers(
-                token, vehicle.ccu_ccs2_protocol_support
-            ),
-        ).json()
+        """Force-refresh CCS2 state: wake the vehicle, wait, read the cached snapshot.
+
+        GET /ccs2/carstatus (no /latest) wakes the vehicle but returns an async
+        command envelope ({retCode, resCode, msgId}), not state — reading
+        resMsg.state.Vehicle from it raised KeyError: 'resMsg' (kia_uvo #1786,
+        #1806). Instead: wake, sleep for the car to report (~20s live-measured on
+        a reachable EU CCS2 car), then read the now-fresh cached /latest snapshot.
+        """
+        headers = self._get_authenticated_headers(
+            token, vehicle.ccu_ccs2_protocol_support
+        )
+        trigger_url = self.SPA_API_URL + "vehicles/" + vehicle.id + "/ccs2/carstatus"
+        self.session.get(trigger_url, headers=headers).json()
+        sleep(25)
+        latest_url = trigger_url + "/latest"
+        response = self.session.get(latest_url, headers=headers).json()
         _LOGGER.debug(
             f"{DOMAIN} - Force refresh CCS2 vehicle status response: {response}"
         )

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -453,6 +453,9 @@ class KiaUvoApiEU(ApiImplType1):
         resMsg.state.Vehicle from it raised KeyError: 'resMsg' (kia_uvo #1786,
         #1806). Instead: wake, sleep for the car to report (~20s live-measured on
         a reachable EU CCS2 car), then read the now-fresh cached /latest snapshot.
+
+        The wake GET must return valid JSON; its body is discarded but errors
+        propagate, so a failed wake does not fall through to a stale /latest apply.
         """
         headers = self._get_authenticated_headers(
             token, vehicle.ccu_ccs2_protocol_support

--- a/tests/test_eu_ccs2_force_refresh_sleep.py
+++ b/tests/test_eu_ccs2_force_refresh_sleep.py
@@ -101,3 +101,35 @@ def test_force_refresh_does_not_read_resMsg_from_wake_endpoint(eu_api, ccs2_vehi
         eu_api._force_refresh_vehicle_state_ccs2(token, ccs2_vehicle)
 
     eu_api._update_vehicle_properties_ccs2.assert_called_once()
+
+
+def test_force_refresh_wake_failure_propagates_no_stale_apply(eu_api, ccs2_vehicle):
+    """A failed wake GET (non-JSON / network error) must propagate and NOT
+    fall through to a stale /latest apply. Locks in the safer error behavior
+    so a future try/except wrapper cannot reintroduce stale-apply-on-wake-failure.
+    """
+    from unittest.mock import patch
+
+    token = SimpleNamespace(access_token="t", device_id="d")
+
+    def mock_get(url, headers=None):
+        resp = MagicMock()
+        if url.endswith("/ccs2/carstatus") and not url.endswith("/latest"):
+            resp.json.side_effect = ValueError("not JSON")  # wake fails
+        else:
+            resp.json.return_value = {
+                "retCode": "S",
+                "resMsg": {"state": {"Vehicle": {"Date": "20260724120000.000"}}},
+            }
+        return resp
+
+    with (
+        patch.object(eu_api.session, "get", side_effect=mock_get),
+        patch("hyundai_kia_connect_api.KiaUvoApiEU.sleep"),
+    ):
+        with pytest.raises(ValueError):
+            eu_api._force_refresh_vehicle_state_ccs2(token, ccs2_vehicle)
+
+    # wake failed -> no sleep-then-/latest apply happened
+    eu_api._update_vehicle_properties_ccs2.assert_not_called()
+    eu_api._set_cached_location_park.assert_not_called()

--- a/tests/test_eu_ccs2_force_refresh_sleep.py
+++ b/tests/test_eu_ccs2_force_refresh_sleep.py
@@ -1,0 +1,103 @@
+"""Unit test for the simpler wake+sleep+read CCS2 force-refresh (counter-PR to #1184)."""
+
+import pytest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from hyundai_kia_connect_api.KiaUvoApiEU import KiaUvoApiEU
+from hyundai_kia_connect_api.Vehicle import Vehicle
+
+
+@pytest.fixture
+def eu_api() -> KiaUvoApiEU:
+    api = KiaUvoApiEU.__new__(KiaUvoApiEU)
+    api.SPA_API_URL = "https://test.invalid/api/v1/spa/"
+    api.session = MagicMock()
+    api._get_authenticated_headers = MagicMock(
+        return_value={"Authorization": "Bearer x"}
+    )
+    api._update_vehicle_properties_ccs2 = MagicMock()
+    api._set_cached_location_park = MagicMock()
+    return api
+
+
+@pytest.fixture
+def ccs2_vehicle() -> Vehicle:
+    v = Vehicle()
+    v.id = "vid-123"
+    v.ccu_ccs2_protocol_support = 1
+    return v
+
+
+def test_force_refresh_wakes_sleeps_reads_latest_and_applies(eu_api, ccs2_vehicle):
+    """wake /ccs2/carstatus (ack) -> sleep(25) -> read /latest -> apply + location."""
+    token = SimpleNamespace(access_token="t", device_id="d")
+    get_urls = []
+
+    def mock_get(url, headers=None):
+        get_urls.append(url)
+        resp = MagicMock()
+        if url.endswith("/ccs2/carstatus") and not url.endswith("/latest"):
+            # wake endpoint: async ack envelope, NO resMsg
+            resp.json.return_value = {"retCode": "S", "resCode": "0000", "msgId": "m1"}
+        else:
+            # /latest: cached snapshot with state.Vehicle
+            resp.json.return_value = {
+                "retCode": "S",
+                "resCode": "0000",
+                "resMsg": {"state": {"Vehicle": {"Date": "20260724120000.000"}}},
+            }
+        return resp
+
+    sleep_calls = []
+
+    with (
+        patch.object(eu_api.session, "get", side_effect=mock_get),
+        patch(
+            "hyundai_kia_connect_api.KiaUvoApiEU.sleep",
+            side_effect=lambda s: sleep_calls.append(s),
+        ),
+    ):
+        eu_api._force_refresh_vehicle_state_ccs2(token, ccs2_vehicle)
+
+    # wake + /latest read (2 GETs, distinct URLs)
+    assert len(get_urls) == 2
+    assert get_urls[0].endswith("/ccs2/carstatus")
+    assert get_urls[1].endswith("/ccs2/carstatus/latest")
+    # slept once, 25s
+    assert sleep_calls == [25]
+    # applied the /latest state + refreshed location
+    eu_api._update_vehicle_properties_ccs2.assert_called_once()
+    applied_state = eu_api._update_vehicle_properties_ccs2.call_args[0][1]
+    assert applied_state == {"Date": "20260724120000.000"}
+    eu_api._set_cached_location_park.assert_called_once_with(token, ccs2_vehicle)
+
+
+def test_force_refresh_does_not_read_resMsg_from_wake_endpoint(eu_api, ccs2_vehicle):
+    """The bug (KeyError: 'resMsg') must not recur: wake response has no resMsg,
+    the method must read state from /latest, not from the wake response."""
+    token = SimpleNamespace(access_token="t", device_id="d")
+
+    def mock_get(url, headers=None):
+        resp = MagicMock()
+        if url.endswith("/ccs2/carstatus") and not url.endswith("/latest"):
+            resp.json.return_value = {
+                "retCode": "S",
+                "resCode": "0000",
+                "msgId": "m1",
+            }  # no resMsg
+        else:
+            resp.json.return_value = {
+                "retCode": "S",
+                "resMsg": {"state": {"Vehicle": {"Date": "20260724120000.000"}}},
+            }
+        return resp
+
+    with (
+        patch.object(eu_api.session, "get", side_effect=mock_get),
+        patch("hyundai_kia_connect_api.KiaUvoApiEU.sleep"),
+    ):
+        # must not raise KeyError: 'resMsg'
+        eu_api._force_refresh_vehicle_state_ccs2(token, ccs2_vehicle)
+
+    eu_api._update_vehicle_properties_ccs2.assert_called_once()


### PR DESCRIPTION
## Problem

`_force_refresh_vehicle_state_ccs2()` (EU) calls `GET /ccs2/carstatus` — the wake endpoint (no `/latest`) — and reads `response["resMsg"]["state"]["Vehicle"]` synchronously. That endpoint returns an async command envelope `{retCode, resCode, msgId}`, not state, so it raises `KeyError: 'resMsg'` every force-refresh (kia_uvo #1786, #1806 on the current 4.25.2 release).

## Solution (simpler alternative to #1184)

This is a **much simpler** alternative to #1184, in response to @cdnninja's review there ("Would that solve the same issue but much simpler? I worry about how many internal methods and complexity is continued to be added from a maintenance standpoint"). **Both PRs are open; your call which to merge.**

Replace `_force_refresh_vehicle_state_ccs2` with:

1. **Wake** — `GET /ccs2/carstatus` (no `/latest`) wakes the vehicle (same request as today; its ack envelope `{retCode,resCode,msgId}` is discarded — the body is not parsed, which is what caused the `KeyError`).
2. **Wait** — `sleep(25)` for the car to wake and report.
3. **Read** — `GET /ccs2/carstatus/latest` (the cached snapshot, now fresh) → apply via the existing `_update_vehicle_properties_ccs2` + `_set_cached_location_park`.

No poll loop, no freshness check, no hooks, no new internal methods — reuses the existing parser + location helper. ~8 lines.

The wake-trigger + wait + cached-read sequence and the ~25s wait mirror what the official app already does (wake the vehicle, then receive the status; the lib reads `/latest` as the cached equivalent). The 25s wait is sized to the live-measured ~20s wake on a reachable EU CCS2 car.

## Request budget vs current code (acceptability)

Current code (master / 4.25.2): **1 GET** `/ccs2/carstatus` → `KeyError` (no fresh data returned).

This PR: 1 wake GET (same as today) + 1 `/latest` GET = **2 GETs total, always**. No polling, so the count is fixed (not "up to N"). vs #1184's 3 typical / 15 max.

Why acceptable: 2 GETs is the minimum to wake + read; today the 1 GET crashes and returns nothing. The wake GET must return valid JSON (errors propagate — a failed wake does **not** fall through to a stale `/latest` apply; covered by a test). On a slow/deep-sleep car that doesn't wake within 25s, `/latest` returns the last cached snapshot — applied as-is, and `last_updated_at` (from the car's `Date`) honestly shows it's stale rather than masking it.

## Tradeoff vs #1184 (honest)

| | this PR (sleep+read) | #1184 (poll-until-fresh) |
|---|---|---|
| Typical reachable (~20s wake) | fresh, last_updated_at advances | fresh, early-exit ~20s (2 polls) |
| Slow / deep-sleep (25-140s wake) | applies cached (stale, visible via last_updated_at) | polls to 140s, catches fresh if car wakes; keep-previous on timeout |
| Entity state on slow | applies stale (last_updated_at reveals it) | keeps previous |
| Fast car (10s wake) | waits full 25s | early-exit ~10s |
| Requests / force-refresh | 2 (fixed) | 3 typical / 15 max |
| Complexity | ~8 lines, no new methods | base + 3 hooks + poll loop |
| Regions | EU only | EU/AU/IN/CN |

`last_updated_at` is honest in both — staleness is visible, not masked by the timestamp. This PR is the "good enough + simple" option for the typical reachable case at minimal complexity; #1184 is more robust for slow/deep-sleep. EU only here — AU/IN/CN are covered by #1184.

## Files

- `hyundai_kia_connect_api/KiaUvoApiEU.py` — `_force_refresh_vehicle_state_ccs2` replaced (wake + sleep 25 + read /latest + apply); `from time import sleep` added.
- `tests/test_eu_ccs2_force_refresh_sleep.py` (new) — 3 tests: wake→sleep(25)→/latest→apply (URL sequence + sleep + state-from-/latest), no-KeyError-regression, wake-failure-propagates-no-stale-apply.

## Testing

- 3 new unit tests pass; 47 EU/CCS2 parser tests pass (no regression); `ruff check` + `ruff format` clean; pre-commit hooks clean (ruff/codespell/pyupgrade/prettier).
- Live-measured (EU Santa Fe CCS2, car reachable): wake-to-fresh ~20.7s → sleep 25s is sufficient for the typical reachable case.

Fixes kia_uvo #1786 and kia_uvo #1806 (same `KeyError: 'resMsg'` at `KiaUvoApiEU.py:459`, IONIQ 5 CCS2, on the current 4.25.2 release). Simpler alternative to #1184 — both open.