### PR TITLE
chore: adopt ruff 0.16 default rules (selective ignore + mechanical fixes)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # hyundai_kia_connect_api documentation build configuration file, created by
 # sphinx-quickstart on Fri Jun  9 13:47:02 2017.

--- a/hyundai_kia_connect_api/ApiImpl.py
+++ b/hyundai_kia_connect_api/ApiImpl.py
@@ -236,7 +236,7 @@ class ApiImpl:
         vehicle: Vehicle,
         use_email: bool,
         provider: int = 1,
-        API_KEY: str = None,
+        API_KEY: str | None = None,
     ) -> None:
         if vehicle.location_latitude and vehicle.location_longitude:
             if (

--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -173,23 +173,22 @@ class ApiImplType1(ApiImpl):
             dte = fuel_system.get("DTE", {})
             ice_value = dte.get("ICE")
 
-            if ice_value is not None:
-                # Check if the value is a number and unreasonably large
-                # A reasonable ICE range should be < 1,000,000 km/miles
-                # Values larger than this are likely corrupted API data
-                if isinstance(ice_value, (int, float)):
-                    # Also check if it exceeds JavaScript's Number.MAX_SAFE_INTEGER
-                    # (2^53 - 1 = 9,007,199,254,740,991) to prevent JSON issues
-                    max_safe_integer = 9007199254740991
-                    max_reasonable_range = 1000000
+            # Check if the value is a number and unreasonably large
+            # A reasonable ICE range should be < 1,000,000 km/miles
+            # Values larger than this are likely corrupted API data
+            if ice_value is not None and isinstance(ice_value, (int, float)):
+                # Also check if it exceeds JavaScript's Number.MAX_SAFE_INTEGER
+                # (2^53 - 1 = 9,007,199,254,740,991) to prevent JSON issues
+                max_safe_integer = 9007199254740991
+                max_reasonable_range = 1000000
 
-                    if ice_value > max_safe_integer or ice_value > max_reasonable_range:
-                        _LOGGER.warning(
-                            f"{DOMAIN} - Invalid ICE value detected ({ice_value}), "
-                            "too large to be valid. Replacing with None. "
-                            "This appears to be corrupted data from Hyundai's API."
-                        )
-                        dte["ICE"] = None
+                if ice_value > max_safe_integer or ice_value > max_reasonable_range:
+                    _LOGGER.warning(
+                        f"{DOMAIN} - Invalid ICE value detected ({ice_value}), "
+                        "too large to be valid. Replacing with None. "
+                        "This appears to be corrupted data from Hyundai's API."
+                    )
+                    dte["ICE"] = None
         except (KeyError, TypeError, AttributeError):  # fmt: skip
             # If the structure doesn't exist or is malformed, silently continue
             # This is defensive programming in case the API structure changes

--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
@@ -5,6 +5,7 @@
 import datetime as dt
 import logging
 import time
+from typing import ClassVar
 
 import certifi
 from requests.adapters import HTTPAdapter
@@ -134,7 +135,7 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
     # Maps transaction IDs to service_type values for action status polling.
     # Horn/hazard commands need HORN_AND_LIGHTS or LIGHTS_ONLY instead of
     # the default REMOTE_POLL.
-    _action_service_types: dict[str, str] = {}
+    _action_service_types: ClassVar[dict[str, str]] = {}
 
     # Cached enrollment/details response. Capabilities, seat configs,
     # generation and model rarely change, so the response is cached for

--- a/hyundai_kia_connect_api/KiaUvoApiAU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiAU.py
@@ -53,7 +53,7 @@ USER_AGENT_MOZILLA: str = "Mozilla/5.0 (Linux; Android 4.1.1; Galaxy Nexus Build
 
 class KiaUvoApiAU(ApiImplType1):
     data_timezone = ZoneInfo("Australia/Sydney")
-    temperature_range = [x * 0.5 for x in range(34, 54)]
+    temperature_range = tuple(x * 0.5 for x in range(34, 54))
 
     def __init__(self, region: int, brand: int, language: str) -> None:
         super().__init__()

--- a/hyundai_kia_connect_api/KiaUvoApiAU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiAU.py
@@ -852,9 +852,7 @@ class KiaUvoApiAU(ApiImplType1):
         return base64.b64encode(result).decode("utf-8")
 
     def _get_device_id(self, stamp):
-        my_hex = "%064x" % random.randrange(  # pylint: disable=consider-using-f-string
-            10**80
-        )
+        my_hex = f"{random.randrange(10**80):064x}"
         registration_id = my_hex[:64]
         url = self.SPA_API_URL + "notifications/register"
         payload = {

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -97,8 +97,8 @@ class RetrySession(requests.Session):
 class KiaUvoApiCA(ApiImpl):
     """KiaUvoApiCA"""
 
-    temperature_range_c_old = [x * 0.5 for x in range(32, 64)]
-    temperature_range_c_new = [x * 0.5 for x in range(28, 64)]
+    temperature_range_c_old = tuple(x * 0.5 for x in range(32, 64))
+    temperature_range_c_new = tuple(x * 0.5 for x in range(28, 64))
     temperature_range_model_year = 2020
 
     def __init__(self, region: int, brand: int, language: str) -> None:

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -431,12 +431,10 @@ class KiaUvoApiCA(ApiImpl):
         # check_and_refresh_token() reusing the stale token, which then failed
         # again in get_vehicles() as an unhandled APIError (kia_uvo#1715).
         token_errors = ["7403", "7602", "7606"]
-        if (
+        return not (
             response["responseHeader"]["responseCode"] == 1
             and response["error"]["errorCode"] in token_errors
-        ):
-            return False
-        return True
+        )
 
     def get_vehicles(self, token: Token) -> list[Vehicle]:
         url = self.API_URL + "vhcllst"

--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -89,7 +89,7 @@ class RetrySession(requests.Session):
                 _LOGGER.debug(
                     f"{DOMAIN} - {method} Other exception not connection reset {attempt + 1}: Connection error ({e})"
                 )
-                raise e
+                raise
 
         raise last_exception
 

--- a/hyundai_kia_connect_api/KiaUvoApiCN.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCN.py
@@ -103,7 +103,7 @@ def _check_response_for_errors(response: dict) -> None:
 
 class KiaUvoApiCN(ApiImplType1):
     data_timezone = ZoneInfo("Asia/Shanghai")
-    temperature_range = [x * 0.5 for x in range(28, 60)]
+    temperature_range = tuple(x * 0.5 for x in range(28, 60))
 
     def __init__(self, region: int, brand: int, language: str) -> None:
         super().__init__()

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -1033,8 +1033,8 @@ class KiaUvoApiEU(ApiImplType1):
                     "vehicle may be offline or returning partial status"
                 )
             return gps_detail
-        except Exception as e:
-            _LOGGER.error(f"{DOMAIN} - _get_location failed: {e}", exc_info=True)
+        except Exception:
+            _LOGGER.exception(f"{DOMAIN} - _get_location failed")
             return None
 
     def _get_forced_vehicle_state(self, token: Token, vehicle: Vehicle) -> dict:
@@ -1299,9 +1299,7 @@ class KiaUvoApiEU(ApiImplType1):
         return base64.b64encode(result).decode("utf-8")
 
     def _get_device_id(self, stamp: str):
-        my_hex = "%064x" % random.randrange(  # pylint: disable=consider-using-f-string
-            10**80
-        )
+        my_hex = f"{random.randrange(10**80):064x}"
         registration_id = my_hex[:64]
         url = self.SPA_API_URL + "notifications/register"
         payload = {

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -1033,8 +1033,8 @@ class KiaUvoApiEU(ApiImplType1):
                     "vehicle may be offline or returning partial status"
                 )
             return gps_detail
-        except Exception:
-            _LOGGER.exception(f"{DOMAIN} - _get_location failed")
+        except Exception as e:
+            _LOGGER.exception(f"{DOMAIN} - _get_location failed: {e}")  # noqa: TRY401
             return None
 
     def _get_forced_vehicle_state(self, token: Token, vehicle: Vehicle) -> dict:

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -81,7 +81,7 @@ SUPPORTED_LANGUAGES_LIST = [
 
 class KiaUvoApiEU(ApiImplType1):
     data_timezone = ZoneInfo("Europe/Berlin")
-    temperature_range = [x * 0.5 for x in range(28, 60)]
+    temperature_range = tuple(x * 0.5 for x in range(28, 60))
 
     def __init__(self, region: int, brand: int, language: str) -> None:
         language = language.lower()

--- a/hyundai_kia_connect_api/KiaUvoApiIN.py
+++ b/hyundai_kia_connect_api/KiaUvoApiIN.py
@@ -72,7 +72,7 @@ SUPPORTED_LANGUAGES_LIST = [
 
 class KiaUvoApiIN(ApiImplType1):
     data_timezone = ZoneInfo("Asia/Kolkata")
-    temperature_range = [x * 0.5 for x in range(28, 60)]
+    temperature_range = tuple(x * 0.5 for x in range(28, 60))
 
     def __init__(self, brand: int) -> None:
         # Strip language variants (e.g. en-Gb)

--- a/hyundai_kia_connect_api/KiaUvoApiIN.py
+++ b/hyundai_kia_connect_api/KiaUvoApiIN.py
@@ -967,9 +967,7 @@ class KiaUvoApiIN(ApiImplType1):
         return base64.b64encode(result).decode("utf-8")
 
     def _get_device_id(self, stamp: str):
-        my_hex = "%064x" % random.randrange(  # pylint: disable=consider-using-f-string
-            10**80
-        )
+        my_hex = f"{random.randrange(10**80):064x}"
         registration_id = my_hex[:64]
         url = self.SPA_API_URL + "notifications/register"
         payload = {

--- a/hyundai_kia_connect_api/Vehicle.py
+++ b/hyundai_kia_connect_api/Vehicle.py
@@ -468,15 +468,18 @@ class Vehicle:
         # https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/931#issuecomment-2381569934
         newest_updated_at = get_safe_local_datetime(value)
         previous_updated_at = self._last_updated_at
-        if newest_updated_at and previous_updated_at:  # both filled
-            if newest_updated_at < previous_updated_at:
-                utcoffset = newest_updated_at.utcoffset()
-                newest_updated_at_corrected = newest_updated_at + utcoffset
-                if newest_updated_at_corrected >= previous_updated_at:
-                    newest_updated_at = newest_updated_at_corrected
-                newest_updated_at = max(
-                    newest_updated_at, previous_updated_at
-                )  # keep old because newer
+        if (
+            newest_updated_at
+            and previous_updated_at
+            and newest_updated_at < previous_updated_at
+        ):
+            utcoffset = newest_updated_at.utcoffset()
+            newest_updated_at_corrected = newest_updated_at + utcoffset
+            if newest_updated_at_corrected >= previous_updated_at:
+                newest_updated_at = newest_updated_at_corrected
+            newest_updated_at = max(
+                newest_updated_at, previous_updated_at
+            )  # keep old because newer
         self._last_updated_at = newest_updated_at
 
     @property

--- a/hyundai_kia_connect_api/VehicleManager.py
+++ b/hyundai_kia_connect_api/VehicleManager.py
@@ -61,8 +61,8 @@ class VehicleManager:
         geocode_api_enable: bool = False,
         geocode_api_use_email: bool = False,
         geocode_provider: int = 1,
-        geocode_api_key: str = None,
-        token: Token = None,
+        geocode_api_key: str | None = None,
+        token: Token | None = None,
         language: str = "en",
     ):
         self.region: int = region

--- a/hyundai_kia_connect_api/VehicleManager.py
+++ b/hyundai_kia_connect_api/VehicleManager.py
@@ -136,7 +136,7 @@ class VehicleManager:
         return self.vehicles[vehicle_id]
 
     def update_all_vehicles_with_cached_state(self) -> None:
-        for vehicle_id in self.vehicles.keys():
+        for vehicle_id in self.vehicles:
             self.update_vehicle_with_cached_state(vehicle_id)
 
     def update_vehicle_with_cached_state(self, vehicle_id: str) -> None:
@@ -156,7 +156,7 @@ class VehicleManager:
             _LOGGER.debug(f"{DOMAIN} - Vehicle Disabled, skipping.")
 
     def check_and_force_update_vehicles(self, force_refresh_interval: int) -> None:
-        for vehicle_id in self.vehicles.keys():
+        for vehicle_id in self.vehicles:
             self.check_and_force_update_vehicle(force_refresh_interval, vehicle_id)
 
     def check_and_force_update_vehicle(
@@ -180,7 +180,7 @@ class VehicleManager:
             self.update_vehicle_with_cached_state(vehicle_id)
 
     def force_refresh_all_vehicles_states(self) -> None:
-        for vehicle_id in self.vehicles.keys():
+        for vehicle_id in self.vehicles:
             self.force_refresh_vehicle_state(vehicle_id)
 
     def force_refresh_vehicle_state(self, vehicle_id: str) -> None:

--- a/hyundai_kia_connect_api/bluelink.py
+++ b/hyundai_kia_connect_api/bluelink.py
@@ -381,7 +381,7 @@ class DateTimeEncoder(json.JSONEncoder):
 
 
 def cmd_info(vm, args):
-    for vehicle_id, vehicle in vm.vehicles.items():
+    for vehicle in vm.vehicles.values():
         print_vehicle(vehicle)
     if args.json:
         data = {id: vehicle_to_dict(v) for id, v in vm.vehicles.items()}
@@ -448,8 +448,8 @@ def main():
     logging.basicConfig(level=logging.DEBUG if args.verbose else logging.ERROR)
 
     # Reverse lookup.
-    region = [k for k, v in const.REGIONS.items() if v == args.region][0]
-    brand = [k for k, v in const.BRANDS.items() if v == args.brand][0]
+    region = next(k for k, v in const.REGIONS.items() if v == args.region)
+    brand = next(k for k, v in const.BRANDS.items() if v == args.brand)
 
     vm = hyundai_kia_connect_api.VehicleManager(
         region=region,

--- a/hyundai_kia_connect_api/utils.py
+++ b/hyundai_kia_connect_api/utils.py
@@ -5,14 +5,14 @@ import datetime
 import logging
 import re
 from enum import IntEnum
-from typing import Any, TypeVar
-
-T = TypeVar("T", bound=IntEnum)
+from typing import Any
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def to_int_enum(enum_class: type[T], value: str | int | T | None) -> T | None:
+def to_int_enum[T: IntEnum](
+    enum_class: type[T], value: str | int | T | None
+) -> T | None:
     """Convert string, int, or existing IntEnum to the specified IntEnum type.
 
     Handles "1" -> 1 -> WINDOW_STATE.OPEN conversions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,20 @@
 [tool.ruff]
 target-version = "py312"
+
+[tool.ruff.lint]
+# ruff 0.16 expanded the default rule set (59 -> 413). We adopt the new
+# defaults but ignore rules that conflict with this library's conventions
+# or need a larger semantic migration (tracked separately).
+ignore = [
+    "N999",   # PascalCase module names (ApiImpl, KiaUvoApiEU, ...) are the
+              # package's public API; kia_uvo imports them directly. Renaming
+              # is a breaking major-version change. Permanent.
+    "BLE001", # `except Exception` is the library's resilience pattern for
+              # flaky vendor HTTP; narrowing would let new exception types
+              # crash the HA integration. Permanent.
+    # DTZ*: naive datetimes in token-expiry + region timestamp handling.
+    # Tz-aware migration is all-or-nothing (mixed aware/naive raises
+    # TypeError on comparison) — needs its own PR with timestamp audit.
+    # Deferred; see follow-up issue.
+    "DTZ001", "DTZ004", "DTZ005", "DTZ006", "DTZ007", "DTZ901",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,6 @@ ignore = [
     # DTZ*: naive datetimes in token-expiry + region timestamp handling.
     # Tz-aware migration is all-or-nothing (mixed aware/naive raises
     # TypeError on comparison) — needs its own PR with timestamp audit.
-    # Deferred; see follow-up issue.
+    # Deferred to a separate tz-aware migration PR.
     "DTZ001", "DTZ004", "DTZ005", "DTZ006", "DTZ007", "DTZ901",
 ]

--- a/scripts/ca_api_diagnostic.py
+++ b/scripts/ca_api_diagnostic.py
@@ -63,7 +63,9 @@ def get_random_device_id() -> str:
     return base64.b64encode(uuid.uuid4().hex.encode()).decode()
 
 
-def make_headers(brand_config: dict, device_id: str, access_token: str = None) -> dict:
+def make_headers(
+    brand_config: dict, device_id: str, access_token: str | None = None
+) -> dict:
     base_url = brand_config["base_url"]
     headers = {
         "User-Agent": "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Mobile Safari/537.36",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """The setup script."""
 
 from setuptools import find_packages, setup

--- a/tests/test_headless_login.py
+++ b/tests/test_headless_login.py
@@ -438,15 +438,15 @@ def test_login_genesis_password_fails_falls_back_to_error():
 
 def _make_token(**overrides) -> Token:
     """Create a Token instance with sensible defaults for testing."""
-    defaults = dict(
-        username="user@test.com",
-        password="MyPassword123!",
-        access_token="Bearer old-access-token",
-        refresh_token="OLDREFRESHTOKEN1234567890123456789012345678",
-        device_id="device-123",
-        valid_until=dt.datetime.now(dt.UTC) + dt.timedelta(hours=1),
-        pin="1234",
-    )
+    defaults = {
+        "username": "user@test.com",
+        "password": "MyPassword123!",
+        "access_token": "Bearer old-access-token",
+        "refresh_token": "OLDREFRESHTOKEN1234567890123456789012345678",
+        "device_id": "device-123",
+        "valid_until": dt.datetime.now(dt.UTC) + dt.timedelta(hours=1),
+        "pin": "1234",
+    }
     defaults.update(overrides)
     return Token(**defaults)
 

--- a/tests/test_type1_refresh_access_token.py
+++ b/tests/test_type1_refresh_access_token.py
@@ -21,15 +21,15 @@ from hyundai_kia_connect_api.Token import Token
 
 
 def _make_token(**overrides) -> Token:
-    defaults = dict(
-        username="user@test.com",
-        password="MyPassword123!",
-        access_token="Bearer old-access-token",
-        refresh_token="OLDREFRESHTOKEN1234567890123456789012345678",
-        device_id="device-123",
-        valid_until=dt.datetime.now(dt.UTC) + dt.timedelta(hours=1),
-        pin="1234",
-    )
+    defaults = {
+        "username": "user@test.com",
+        "password": "MyPassword123!",
+        "access_token": "Bearer old-access-token",
+        "refresh_token": "OLDREFRESHTOKEN1234567890123456789012345678",
+        "device_id": "device-123",
+        "valid_until": dt.datetime.now(dt.UTC) + dt.timedelta(hours=1),
+        "pin": "1234",
+    }
     defaults.update(overrides)
     return Token(**defaults)
 

--- a/tests/us_action_status_test.py
+++ b/tests/us_action_status_test.py
@@ -98,11 +98,13 @@ class TestCheckActionStatus:
         vehicle = _make_vehicle()
         token = _make_token()
 
-        with patch.object(api, "_get_vehicle_headers", return_value={}):
-            with patch("hyundai_kia_connect_api.HyundaiBlueLinkApiUSA.time.sleep"):
-                result = api.check_action_status(
-                    token, vehicle, "tx-123", synchronous=True, timeout=4
-                )
+        with (
+            patch.object(api, "_get_vehicle_headers", return_value={}),
+            patch("hyundai_kia_connect_api.HyundaiBlueLinkApiUSA.time.sleep"),
+        ):
+            result = api.check_action_status(
+                token, vehicle, "tx-123", synchronous=True, timeout=4
+            )
 
         assert result == ORDER_STATUS.TIMEOUT
 

--- a/tests/us_charge_command_test.py
+++ b/tests/us_charge_command_test.py
@@ -99,9 +99,11 @@ class TestStartCharge:
         vehicle = _make_vehicle()
         token = _make_token()
 
-        with caplog.at_level(logging.DEBUG):
-            with patch.object(api, "_get_vehicle_headers", return_value={}):
-                api.start_charge(token, vehicle)
+        with (
+            caplog.at_level(logging.DEBUG),
+            patch.object(api, "_get_vehicle_headers", return_value={}),
+        ):
+            api.start_charge(token, vehicle)
 
         assert (
             "empty response body" in caplog.text.lower()
@@ -175,9 +177,11 @@ class TestStopCharge:
         vehicle = _make_vehicle()
         token = _make_token()
 
-        with caplog.at_level(logging.DEBUG):
-            with patch.object(api, "_get_vehicle_headers", return_value={}):
-                api.stop_charge(token, vehicle)
+        with (
+            caplog.at_level(logging.DEBUG),
+            patch.object(api, "_get_vehicle_headers", return_value={}),
+        ):
+            api.stop_charge(token, vehicle)
 
         assert (
             "empty response body" in caplog.text.lower()

--- a/tests/us_climate_command_test.py
+++ b/tests/us_climate_command_test.py
@@ -91,9 +91,11 @@ class TestStartClimate:
         token = _make_token()
         options = _make_climate_options()
 
-        with caplog.at_level(logging.DEBUG):
-            with patch.object(api, "_get_vehicle_headers", return_value={}):
-                api.start_climate(token, vehicle, options)
+        with (
+            caplog.at_level(logging.DEBUG),
+            patch.object(api, "_get_vehicle_headers", return_value={}),
+        ):
+            api.start_climate(token, vehicle, options)
 
         assert "empty" in caplog.text.lower()
 
@@ -132,8 +134,10 @@ class TestStopClimate:
         vehicle = _make_vehicle()
         token = _make_token()
 
-        with caplog.at_level(logging.DEBUG):
-            with patch.object(api, "_get_vehicle_headers", return_value={}):
-                api.stop_climate(token, vehicle)
+        with (
+            caplog.at_level(logging.DEBUG),
+            patch.object(api, "_get_vehicle_headers", return_value={}),
+        ):
+            api.stop_climate(token, vehicle)
 
         assert "empty" in caplog.text.lower()

--- a/tests/us_lock_command_test.py
+++ b/tests/us_lock_command_test.py
@@ -96,9 +96,11 @@ class TestLockAction:
         vehicle = _make_vehicle()
         token = _make_token()
 
-        with caplog.at_level(logging.DEBUG):
-            with patch.object(api, "_get_vehicle_headers", return_value={}):
-                api.lock_action(token, vehicle, VEHICLE_LOCK_ACTION.LOCK)
+        with (
+            caplog.at_level(logging.DEBUG),
+            patch.object(api, "_get_vehicle_headers", return_value={}),
+        ):
+            api.lock_action(token, vehicle, VEHICLE_LOCK_ACTION.LOCK)
 
         assert "empty" in caplog.text.lower()
 

--- a/tests/us_refresh_access_token_test.py
+++ b/tests/us_refresh_access_token_test.py
@@ -22,14 +22,14 @@ def _make_usa_api() -> HyundaiBlueLinkApiUSA:
 
 def _make_token(**overrides) -> Token:
     """Create a Token instance with sensible defaults for testing."""
-    defaults = dict(
-        username="user@test.com",
-        password="MyPassword123!",
-        access_token="old-access-token",
-        refresh_token="OLDREFRESHTOKEN1234567890123456789012345678",
-        valid_until=dt.datetime.now(dt.UTC) + dt.timedelta(hours=1),
-        pin="1234",
-    )
+    defaults = {
+        "username": "user@test.com",
+        "password": "MyPassword123!",
+        "access_token": "old-access-token",
+        "refresh_token": "OLDREFRESHTOKEN1234567890123456789012345678",
+        "valid_until": dt.datetime.now(dt.UTC) + dt.timedelta(hours=1),
+        "pin": "1234",
+    }
     defaults.update(overrides)
     return Token(**defaults)
 


### PR DESCRIPTION
## Summary

`#1255` (pre-commit autoupdate) bumped ruff to v0.16.0, which expanded the default lint rule set from **59 → 413 rules** (+354). With no `[tool.ruff.lint]` config, every PR rebased onto master inherited a `pre-commit.ci` FAIL from pre-existing code the feature PRs did not touch (#1255 itself merged with pre-commit.ci red; #1253/#1254 passed only because they were checked before #1255 merged).

This PR adopts the new defaults with a documented `ignore` list and fixes the 34 mechanical violations. No behavior change — every transformation is behavior-equivalent or strictly more informative.

## What changed

**Config — `pyproject.toml` (new `[tool.ruff.lint]` block):**
- `N999` — permanent. PascalCase module names (`ApiImpl`, `KiaUvoApiEU`, …) are the package's public API; `kia_uvo` imports them directly. Renaming is a breaking major-version change.
- `BLE001` — permanent. `except Exception` is the library's resilience pattern for flaky vendor HTTP; narrowing would let new exception types crash the HA integration.
- `DTZ001/004/005/006/007/901` — deferred. Naive datetimes in token-expiry + region timestamp handling. Tz-aware migration is all-or-nothing (mixed aware/naive raises `TypeError` on comparison); needs its own PR with a timestamp-comparison audit.

**Code fixes (34 sites, ~15 package + ~10 test files, 1–2 lines each):**
- `SIM102/103/117/118` — collapsible-if, needless-bool, nested-with, `in dict.keys()`.
- `C408` — `dict()` → literal. `RUF015` — `next(iter(...))` over slice. `PERF102` — `.values()`.
- `RUF012` — 6 `temperature_range*` list defaults → `tuple(...)` (instances reassign to `range(...)`; `ClassVar` would forbid that). `_action_service_types` → `ClassVar[dict[str, str]]` (shared class-level cache, mutated per-instance via item assignment).
- `RUF013` — `x: str = None` → `x: str | None` (3 sites incl. `scripts/`).
- `UP031` — `%064x` → f-string (3 region `_get_device_id`); vestigial `# pylint: disable` removed.
- `UP047` — `TypeVar("T", bound=IntEnum)` → PEP 695 `def to_int_enum[T: IntEnum](...)` (bound preserved).
- `G201` — `.error(..., exc_info=True)` → `.exception(...)` (1 site).
- `TRY201` — `raise e` → `raise` (preserves traceback).
- `EXE001` — shebangs removed from `docs/conf.py` + `setup.py` (vestigial); `scripts/ca_api_diagnostic.py` made executable (shebang preserved).
- `I001` — import sort.

## Verification

- `uvx ruff@0.16.0 check hyundai_kia_connect_api/ tests/ scripts/ca_api_diagnostic.py docs/conf.py setup.py` → `All checks passed!`
- `uvx ruff@0.16.0 check --fix …` → no-op (no remaining fixes).
- `pytest tests/ --ignore=tests/integration` → 426 passed, 11 snapshots.
- `pre-commit run --all-files` → green (ruff, ruff-format, codespell, prettier, mypy).
- `#1251` untouched.

## Two minor decisions — would appreciate your call, @cdnninja

1. **G201 `_LOGGER.exception` form (`KiaUvoApiEU.py:1037`)** — the original was `_LOGGER.error(f"... {e}", exc_info=True)`. G201 wants `.exception()`; ruff's `TRY401` then fires on `except Exception as e:` because the binding is "avoidable". I restored `{e}` + `# noqa: TRY401` to keep the exception text in the log **message line** (the original intent — full logs still get the traceback either way). Alternative: drop `{e}` for a clean no-noqa form (exception text lives only in the traceback). I went with preserving message-line info; flag if you prefer the no-noqa form.

2. **DTZ* deferral** — 28 naive-datetime sites (`datetime.now()`, `strptime()` without tz, `datetime.min`) across `Token.py` expiry + all region timestamp handling. Made tz-aware is all-or-nothing (mixed aware/naive raises `TypeError` on the token-expiry comparisons), so I deferred it to a separate PR with a timestamp audit rather than fold a semantic migration into this chore. OK to defer, or would you rather it ride here?

(Out of scope, FYI: 3 `_LOGGER.warning(..., exc_info=True)` sites exist in `HyundaiBlueLinkApiUSA.py`/`KiaUvoApiUSA.py` — G201 only fires on `.error`, so `.warning`-level sites are intentionally untouched.)

## Follow-up

Separate tz-aware datetime migration PR for `DTZ*` (28 sites).