### PR TITLE
fix: decorate check_action_status with @_retry_on_device_id_error

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -938,6 +938,7 @@ class ApiImplType1(ApiImpl):
         _check_response_for_errors(response)
         return response["msgId"]
 
+    @_retry_on_device_id_error
     def check_action_status(
         self,
         token: Token,

--- a/tests/test_device_id_retry.py
+++ b/tests/test_device_id_retry.py
@@ -164,6 +164,7 @@ class TestCheckActionStatusDecorator:
 
         api.session.get = lambda url, headers=None: SimpleNamespace(
             json=lambda: {
+                "retCode": "S",
                 "resCode": "0000",
                 "resMsg": [{"recordId": "action-1", "result": "success"}],
             }

--- a/tests/test_device_id_retry.py
+++ b/tests/test_device_id_retry.py
@@ -1,8 +1,11 @@
 """Tests for _retry_on_device_id_error decorator."""
 
+from types import SimpleNamespace
+
 import pytest
 
-from hyundai_kia_connect_api.ApiImplType1 import _retry_on_device_id_error
+from hyundai_kia_connect_api.ApiImplType1 import ApiImplType1, _retry_on_device_id_error
+from hyundai_kia_connect_api.const import ORDER_STATUS
 from hyundai_kia_connect_api.exceptions import DeviceIDError
 from hyundai_kia_connect_api.Token import Token
 
@@ -108,3 +111,68 @@ class TestRetryOnDeviceIdError:
         with pytest.raises(ValueError, match="some other error"):
             mock_method(mock_self, token)
         assert call_count == 1
+
+
+class TestCheckActionStatusDecorator:
+    """check_action_status must be decorated with @_retry_on_device_id_error.
+
+    On a 4002 (DeviceIDError) during the action-status poll, the decorator
+    re-registers device_id and retries once. The retried poll returns empty
+    resMsg (records live under the invalidated device_id), so the method
+    returns ORDER_STATUS.UNKNOWN instead of propagating the exception.
+    Regression for kia_uvo#1798 / hyundai_kia_connect_api#1190 gap 1.
+    """
+
+    def test_recovers_from_4002_and_reregisters_device_id(self):
+        api = ApiImplType1()
+        api.SPA_API_URL = "https://example.test/"
+        api._get_device_id = lambda stamp: "new-device-id"
+        api._get_stamp = lambda: "stamp"
+        api._get_authenticated_headers = lambda token, ccu: {
+            "Authorization": "Bearer x"
+        }
+
+        responses = [
+            SimpleNamespace(
+                json=lambda: {
+                    "retCode": "F",
+                    "resCode": "4002",
+                    "resMsg": "Invalid request body - Invalid deviceId.",
+                }
+            ),
+            SimpleNamespace(json=lambda: {"resCode": "0000", "resMsg": []}),
+        ]
+        api.session.get = lambda url, headers=None: responses.pop(0)
+
+        token = Token(access_token="at", device_id="old-device-id")
+        vehicle = SimpleNamespace(id="vid", ccu_ccs2_protocol_support=0)
+
+        result = api.check_action_status(token, vehicle, "action-1", synchronous=False)
+
+        assert result == ORDER_STATUS.UNKNOWN
+        assert token.device_id == "new-device-id"
+        assert len(responses) == 0  # both GETs consumed: initial 4002 + retry
+
+    def test_no_error_returns_success(self):
+        api = ApiImplType1()
+        api.SPA_API_URL = "https://example.test/"
+        api._get_device_id = lambda stamp: "new-device-id"
+        api._get_stamp = lambda: "stamp"
+        api._get_authenticated_headers = lambda token, ccu: {
+            "Authorization": "Bearer x"
+        }
+
+        api.session.get = lambda url, headers=None: SimpleNamespace(
+            json=lambda: {
+                "resCode": "0000",
+                "resMsg": [{"recordId": "action-1", "result": "success"}],
+            }
+        )
+
+        token = Token(access_token="at", device_id="old-device-id")
+        vehicle = SimpleNamespace(id="vid", ccu_ccs2_protocol_support=0)
+
+        result = api.check_action_status(token, vehicle, "action-1", synchronous=False)
+
+        assert result == ORDER_STATUS.SUCCESS
+        assert token.device_id == "old-device-id"  # unchanged — no error occurred


### PR DESCRIPTION
## Summary

Decorate `ApiImplType1.check_action_status` with `@_retry_on_device_id_error`, closing gap 1 of #1190.

## Problem

After a control command (lock/climate/charge), `check_action_status` polls `GET /api/v1/spa/notifications/{vehicleId}/records` to confirm completion. On EU, the server invalidates `device_id` after a failed push delivery to the fake GCM `pushRegId`, so the poll returns resCode `4002` → `DeviceIDError` → propagates to the HA coordinator, which logs:

```
Action 'start climate' was sent but confirmation polling failed
... ApiImplType1.py:985 → _check_response_for_errors → DeviceIDError: Invalid request body - Invalid deviceId.
```

The command reaches the car, but HA cannot confirm it. Reported in Hyundai-Kia-Connect/kia_uvo#1798 (EU Kia Sportage PHEV) and [discussion #1764](https://github.com/Hyundai-Kia-Connect/kia_uvo/discussions/1764) (EU Kia EV6), plus the historical tracker (see Related issues).

## Why this was not done in #1155

#1155 (which introduced `@_retry_on_device_id_error` on 17 methods) excluded `check_action_status` with the rationale:

> "check_action_status does NOT get the decorator — it returns ORDER_STATUS enum, not a response that could raise DeviceIDError directly."

That rationale is incorrect: `check_action_status` calls `_check_response_for_errors(response)` (`ApiImplType1.py:980`), which raises `DeviceIDError` on resCode `4002`. The kia_uvo#1798 traceback proves it. This PR corrects that exclusion.

## Scope

- **In scope:** decorate the shared `ApiImplType1.check_action_status`. By inheritance this covers EU (`KiaUvoApiEU`), AU (`KiaUvoApiAU`), and IN (`KiaUvoApiIN`) — all three use the same fake-GCM `notifications/register` mechanism (random 64-hex `pushRegId`, `pushType: "GCM"`, server-assigned `resMsg.deviceId`). The decorator is dormant unless a 4002 occurs, so covering AU/IN is behavior-neutral.
- **Out of scope (remain open in #1190):**
  - **Gap 2 — state reads for AU/IN:** `update_vehicle_with_cached_state` / `force_refresh_vehicle_state` are per-region overrides; EU's are already decorated (#1155), AU/IN's are not. Same mechanism but no AU/IN 4002 reports yet — defer per #1190's "confirm before decorating non-EU". Separate PR if reports surface. (Note: #1190's original "base ApiImpl inherited versions" premise was incorrect — those are `NotImplementedError` stubs; every region overrides.)
  - **Gap 3 — CA/CN:** `_get_device_id(self)` has no `stamp` arg and no `_get_stamp`, so the existing decorator is signature-incompatible. CN also overrides `check_action_status` with its own copy. Needs a stamp-compatible recovery path. Separate work.
  - **USA/BR:** direct `ApiImpl` subclasses with their own `check_action_status`, no `_get_stamp`. Not in #1190's scope; no confirmed 4002.

## Independence from #1153 / #1143

This fixes the `4002` crash only. It does not touch the empty-`resMsg` path (#1143) or the `result=None`-forever path (#1153) — those are distinct failure modes of the same endpoint (`resCode 0000`, no exception) and are unimpeded by this change.

## Mechanism

`check_action_status(synchronous=True)` recurses via `self.check_action_status(..., synchronous=False)`, which resolves to the decorated wrapper — each recursive poll is individually protected. On 4002, the decorator re-registers `device_id` and retries once. The retry poll returns empty `resMsg` (records live under the invalidated device_id) → `ORDER_STATUS.UNKNOWN`. The HA coordinator discards the return value, so the observable effect is only: no `DeviceIDError` escapes → no "confirmation polling failed" traceback. The re-registered `device_id` is fresh for the next poll/refresh cycle.

## Testing

Unit tests in `tests/test_device_id_retry.py` (`TestCheckActionStatusDecorator`):
- 4002 poll → decorator re-registers `device_id`, retry returns `ORDER_STATUS.UNKNOWN`, `token.device_id` updated.
- Normal success poll → `ORDER_STATUS.SUCCESS`, `device_id` unchanged.

`ruff check . && ruff format .` clean; `pre-commit run --all-files` clean; full device-id/action-status regression suite passes (21/21: `test_device_id_retry.py`, `us_action_status_test.py`, `test_ca_device_id_persistence.py`).

## Related issues

This addresses the `DeviceIDError` (resCode 4002) / device_id-invalidation cluster across both repos.

**This repo (hyundai_kia_connect_api):**
- #1190 — decorator coverage gaps (this PR closes gap 1)
- #1155 — introduced `@_retry_on_device_id_error` (the decorator this PR extends)
- #1143 — root-cause writeup: empty `resMsg` from stale device_id
- #1683 — coordinator auto-recovery from DeviceIDError (open, HA-side complement)
- #1742 — EU Kia: invalid deviceId on token refresh overnight (open)
- #1538, #672, #660 — EU DeviceIDError reports (action send / overnight / cached state)
- #1153 — check_action_status PENDING-forever (distinct failure mode, not fixed here)

**kia_uvo (HA integration):**
- Hyundai-Kia-Connect/kia_uvo#1798 — EU Kia Sportage PHEV: `DeviceIDError` traceback on action-status polling (the live report)
- Hyundai-Kia-Connect/kia_uvo#564 — EU Kia EV6: check_action_status empty `resMsg` / "No action found"
- Hyundai-Kia-Connect/kia_uvo#424 — EU Kia: Invalid deviceId after start/stop_charge → force_refresh
- [Discussion #1764](https://github.com/Hyundai-Kia-Connect/kia_uvo/discussions/1764) — EU Kia EV6: `DeviceIDError` on action-status poll after a successful write

Closes gap 1 of #1190.
