### PR TITLE
fix(BR): surface 4xx signin errors and read status from CCS2 endpoint

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
@@ -9,26 +9,22 @@ from datetime import timedelta
 from time import sleep
 from urllib.parse import parse_qs, urljoin, urlparse
 
-from .ApiImpl import (
-    ApiImpl,
-    ApiImplSession,
-    ClimateRequestOptions,
-    WindowRequestOptions,
-)
+from requests import Response
+
+from .ApiImpl import ApiImplSession, ClimateRequestOptions, WindowRequestOptions
+from .ApiImplType1 import ApiImplType1
 from .const import (
     BRAND_HYUNDAI,
     BRANDS,
-    DISTANCE_UNITS,
     DOMAIN,
     ENGINE_TYPES,
     ORDER_STATUS,
-    SEAT_STATUS,
     VEHICLE_LOCK_ACTION,
     WINDOW_STATE,
 )
 from .exceptions import APIError, AuthenticationError
 from .Token import Token
-from .utils import get_index_into_hex_temp, normalize_battery_soc, parse_date_br
+from .utils import get_index_into_hex_temp
 from .Vehicle import DayTripCounts, DayTripInfo, MonthTripInfo, TripInfo, Vehicle
 
 _LOGGER = logging.getLogger(__name__)
@@ -53,10 +49,17 @@ _SIGNIN_STEP_MESSAGES = {
 }
 
 
-class HyundaiBlueLinkApiBR(ApiImpl):
-    """Brazilian Hyundai BlueLink API implementation."""
+class HyundaiBlueLinkApiBR(ApiImplType1):
+    """Brazilian Hyundai BlueLink API implementation.
+
+    Extends ApiImplType1 to reuse its CCS2 status parser
+    (``_update_vehicle_properties_ccs2``); BR overrides its own auth, headers,
+    endpoint selection and force-refresh flow.
+    """
 
     supports_window_control: bool = True
+    # BR does not implement valet mode; keep it off (ApiImplType1 defaults True).
+    supports_valet_mode: bool = False
     data_timezone = dt.timezone(dt.timedelta(hours=-3))  # Brazil (BRT/BRST)
 
     def __init__(self, region: int, brand: int, language: str = "pt-BR"):
@@ -109,6 +112,44 @@ class HyundaiBlueLinkApiBR(ApiImpl):
         headers["Authorization"] = f"Bearer {token.access_token}"
         return headers
 
+    def _raise_auth_error(self, response: Response, context: str) -> None:
+        """Surface a readable auth error for non-2xx BR auth responses.
+
+        Reads the response body (JSON: ``{step}``, ``{errCode, errMsg}``, or
+        arbitrary) and raises ``AuthenticationError``. Falls back to a short body
+        snippet when the body is not JSON. No-op for status < 400. Only
+        step/errCode/errMsg are surfaced — the whole body is never dumped.
+        """
+        if response.status_code < 400:
+            return
+        try:
+            data = response.json()
+        except ValueError:
+            snippet = (response.text or "")[:200]
+            raise AuthenticationError(
+                f"Brazilian Hyundai {context} failed: HTTP {response.status_code}. "
+                f"Response not JSON: {snippet!r}"
+            ) from None
+        step = data.get("step")
+        reason = _SIGNIN_STEP_MESSAGES.get(step)
+        if reason is not None:
+            raise AuthenticationError(
+                f"Brazilian Hyundai login incomplete: {reason} "
+                f"({context} step={step}). Complete this in the Bluelink app "
+                "or web portal, then retry."
+            )
+        err_code = data.get("errCode") or data.get("errorCode")
+        err_msg = data.get("errMsg") or data.get("errorMessage")
+        if err_code or err_msg:
+            raise AuthenticationError(
+                f"Brazilian Hyundai {context} failed: "
+                f"errCode={err_code!r}, errMsg={err_msg!r}"
+            )
+        raise AuthenticationError(
+            f"Brazilian Hyundai {context} failed: HTTP {response.status_code} "
+            f"(keys={sorted(data.keys())})"
+        )
+
     def _get_cookies(self) -> dict:
         """Request cookies from the API for authentication."""
         params = {
@@ -120,7 +161,7 @@ class HyundaiBlueLinkApiBR(ApiImpl):
         url = self._build_api_url("/user/oauth2/authorize")
         _LOGGER.debug(f"{DOMAIN} - Requesting cookies from {url}")
         response = self.session.get(url, params=params)
-        response.raise_for_status()
+        self._raise_auth_error(response, "cookie request")
         # The session cookie ('account') is set during the 302 redirect, so it
         # lives in the session cookie jar rather than on the final response.
         return self.session.cookies.get_dict()
@@ -148,7 +189,7 @@ class HyundaiBlueLinkApiBR(ApiImpl):
         }
 
         response = self.session.post(url, json=data, cookies=cookies, headers=headers)
-        response.raise_for_status()
+        self._raise_auth_error(response, "signin")
         response_data = response.json()
 
         redirect_url = response_data.get("redirectUrl")
@@ -195,7 +236,7 @@ class HyundaiBlueLinkApiBR(ApiImpl):
         }
 
         response = self.session.post(url, data=body, headers=headers)
-        response.raise_for_status()
+        self._raise_auth_error(response, "token request")
         return response.json()
 
     def login(
@@ -267,195 +308,60 @@ class HyundaiBlueLinkApiBR(ApiImpl):
 
         return result
 
-    def _get_vehicle_state(
-        self, token: Token, vehicle: Vehicle, force_refresh: bool = False
-    ) -> dict:
-        """Get vehicle state (cached or forced refresh)."""
-        url = self._build_api_url(f"/spa/vehicles/{vehicle.id}")
+    def _get_cached_vehicle_state(self, token: Token, vehicle: Vehicle) -> dict:
+        """Return the server-cached CCS2 vehicle status (does not wake the car).
 
-        if not vehicle.ccu_ccs2_protocol_support:
-            url = url + "/status/latest"
-        else:
-            url = url + "/ccs2/carstatus/latest"
-
+        BR vehicles report ``ccuCCS2ProtocolSupport: 0`` but the cached status
+        is served in CCS2 format at ``/ccs2/carstatus/latest`` (including
+        location). The legacy ``/status/latest`` endpoint is the remote-control
+        command result on BR and always returns 503 / resCode 5031.
+        """
+        url = self._build_api_url(f"/spa/vehicles/{vehicle.id}/ccs2/carstatus/latest")
         headers = self._get_authenticated_headers(token)
-        if force_refresh:
-            headers["REFRESH"] = "true"
-
-        _LOGGER.debug(f"{DOMAIN} - Getting vehicle state (force={force_refresh})")
         response = self.session.get(url, headers=headers)
         response.raise_for_status()
-        return response.json()["resMsg"]
-
-    def _get_vehicle_location(self, token: Token, vehicle: Vehicle) -> dict:
-        """Get vehicle location."""
-        url = self._build_api_url(f"/spa/vehicles/{vehicle.id}/location/park")
-        headers = self._get_authenticated_headers(token)
-
-        try:
-            response = self.session.get(url, headers=headers)
-            response.raise_for_status()
-            location_data = response.json()["resMsg"]
-            _LOGGER.debug(f"{DOMAIN} - Got vehicle location")
-            return location_data
-        except Exception as e:
-            _LOGGER.warning(f"{DOMAIN} - Failed to get vehicle location: {e}")
-            return None
-
-    def _update_vehicle_properties(self, vehicle: Vehicle, state: dict) -> None:
-        """Update vehicle properties from state."""
-        # Parse timestamp
-        if state.get("time"):
-            vehicle.last_updated_at = parse_date_br(state["time"], self.data_timezone)
-        else:
-            vehicle.last_updated_at = dt.datetime.now(self.data_timezone)
-
-        # Basic vehicle status
-        vehicle.engine_is_running = state.get("engine", False)
-        vehicle.air_control_is_on = state.get("airCtrlOn", False)
-
-        # Battery (12V car battery, not EV battery)
-        if battery := state.get("battery"):
-            vehicle.car_battery_percentage = normalize_battery_soc(
-                battery.get("batSoc")
-            )
-
-        # Temperature
-        if air_temp := state.get("airTemp"):
-            temp_value = air_temp.get("value")
-            temp_unit = air_temp.get("unit")
-            # Handle special values: "00H" means off, or hex temperature values
-            # For now, only set if it's a valid numeric value
-            if temp_value and temp_value != "00H":
-                try:
-                    # Try to parse as hex if it contains 'H'
-                    if "H" in str(temp_value):
-                        # Will be handled in future if needed
-                        pass
-                    else:
-                        vehicle.air_temperature = (temp_value, temp_unit)
-                except (ValueError, TypeError, KeyError):  # fmt: skip
-                    pass
-
-        # Fuel information
-        vehicle.fuel_level = state.get("fuelLevel")
-        vehicle.fuel_level_is_low = state.get("lowFuelLight", False)
-
-        # Driving range (DTE = Distance To Empty)
-        if dte := state.get("dte"):
-            vehicle.fuel_driving_range = (
-                dte.get("value"),
-                DISTANCE_UNITS.get(dte.get("unit")),
-            )
-
-        # Doors
-        door_state = state.get("doorOpen", {})
-        vehicle.is_locked = state.get("doorLock", True)
-        vehicle.front_left_door_is_open = bool(door_state.get("frontLeft"))
-        vehicle.front_right_door_is_open = bool(door_state.get("frontRight"))
-        vehicle.back_left_door_is_open = bool(door_state.get("backLeft"))
-        vehicle.back_right_door_is_open = bool(door_state.get("backRight"))
-        vehicle.hood_is_open = state.get("hoodOpen", False)
-        vehicle.trunk_is_open = state.get("trunkOpen", False)
-
-        # Windows
-        window_state = state.get("windowOpen", {})
-        vehicle.front_left_window_is_open = bool(window_state.get("frontLeft"))
-        vehicle.front_right_window_is_open = bool(window_state.get("frontRight"))
-        vehicle.back_left_window_is_open = bool(window_state.get("backLeft"))
-        vehicle.back_right_window_is_open = bool(window_state.get("backRight"))
-
-        # Climate control
-        vehicle.defrost_is_on = state.get("defrost", False)
-
-        # Steering wheel heat: 0=off, 1=on, 2=unknown/not available
-        steer_heat = state.get("steerWheelHeat", 0)
-        vehicle.steering_wheel_heater_is_on = steer_heat == 1
-
-        # Side/back window heat: 0=off, 1=on, 2=unknown
-        side_heat = state.get("sideBackWindowHeat", 0)
-        vehicle.back_window_heater_is_on = side_heat == 1
-
-        # Seat heater/ventilation status
-        # Values: 0=off, 1=level1, 2=level2, 3=level3, etc.
-        seat_state = state.get("seatHeaterVentState", {})
-        vehicle.front_left_seat_status = SEAT_STATUS.get(
-            seat_state.get("drvSeatHeatState")
-        )
-        vehicle.front_right_seat_status = SEAT_STATUS.get(
-            seat_state.get("astSeatHeatState")
-        )
-        vehicle.rear_left_seat_status = SEAT_STATUS.get(
-            seat_state.get("rlSeatHeatState")
-        )
-        vehicle.rear_right_seat_status = SEAT_STATUS.get(
-            seat_state.get("rrSeatHeatState")
-        )
-
-        # Tire pressure warnings
-        # Note: Brazilian Creta only has "all" indicator, not individual sensors
-        tire_lamp = state.get("tirePressureLamp", {})
-        vehicle.tire_pressure_all_warning_is_on = bool(
-            tire_lamp.get("tirePressureLampAll")
-        )
-
-        # Set individual tire warnings to match "all" if they don't exist
-        # (Some vehicles may have individual sensors)
-        tire_all = bool(tire_lamp.get("tirePressureLampAll"))
-        vehicle.tire_pressure_rear_left_warning_is_on = bool(
-            tire_lamp.get("tirePressureWarningLampRearLeft", tire_all)
-        )
-        vehicle.tire_pressure_front_left_warning_is_on = bool(
-            tire_lamp.get("tirePressureWarningLampFrontLeft", tire_all)
-        )
-        vehicle.tire_pressure_front_right_warning_is_on = bool(
-            tire_lamp.get("tirePressureWarningLampFrontRight", tire_all)
-        )
-        vehicle.tire_pressure_rear_right_warning_is_on = bool(
-            tire_lamp.get("tirePressureWarningLampRearRight", tire_all)
-        )
-
-        # Warnings and alerts
-        vehicle.washer_fluid_warning_is_on = state.get("washerFluidStatus", False)
-        vehicle.brake_fluid_warning_is_on = state.get("breakOilStatus", False)
-        vehicle.smart_key_battery_warning_is_on = state.get(
-            "smartKeyBatteryWarning", False
-        )
-
-        # Store raw data for future use
-        vehicle.data = state
-
-    def _update_vehicle_location(self, vehicle: Vehicle, location_data: dict) -> None:
-        """Update vehicle location from location data."""
-        if not location_data:
-            return
-
-        coord = location_data.get("coord", {})
-        lat = coord.get("lat")
-        lon = coord.get("lng") or coord.get("lon")
-        time_str = location_data.get("time")
-
-        if lat and lon:
-            location_time = (
-                parse_date_br(time_str, self.data_timezone) if time_str else None
-            )
-            vehicle.location = (lat, lon, location_time)
+        return response.json()["resMsg"]["state"]["Vehicle"]
 
     def update_vehicle_with_cached_state(self, token: Token, vehicle: Vehicle) -> None:
-        """Update vehicle with cached state from API."""
-        state = self._get_vehicle_state(token, vehicle, force_refresh=False)
-        location_data = self._get_vehicle_location(token, vehicle)
-
-        self._update_vehicle_properties(vehicle, state)
-        self._update_vehicle_location(vehicle, location_data)
+        """Update with the server-cached CCS2 state (does not wake the car)."""
+        state = self._get_cached_vehicle_state(token, vehicle)
+        self._update_vehicle_properties_ccs2(vehicle, state)
 
     def force_refresh_vehicle_state(self, token: Token, vehicle: Vehicle) -> None:
-        """Force refresh vehicle state (wakes up the vehicle)."""
-        state = self._get_vehicle_state(token, vehicle, force_refresh=True)
-        location_data = self._get_vehicle_location(token, vehicle)
+        """Force a fresh reading from the vehicle (wakes the car).
 
-        self._update_vehicle_properties(vehicle, state)
-        self._update_vehicle_location(vehicle, location_data)
+        BR CCS2 force is asynchronous: ``GET /ccs2/carstatus`` only acknowledges,
+        then the vehicle pushes a fresh snapshot to ``/ccs2/carstatus/latest``.
+        Wake, wait for the car to report, then read the cached snapshot. If the
+        snapshot's ``lastUpdateTime`` did not advance, the car did not report in
+        time — do not apply stale data; raise so the coordinator surfaces
+        ``UpdateFailed`` and entities go unavailable until the next poll.
+        """
+        headers = self._get_authenticated_headers(token)
+        latest_url = self._build_api_url(
+            f"/spa/vehicles/{vehicle.id}/ccs2/carstatus/latest"
+        )
+        trigger_url = self._build_api_url(f"/spa/vehicles/{vehicle.id}/ccs2/carstatus")
+
+        # Baseline: current cached lastUpdateTime before waking.
+        pre = self.session.get(latest_url, headers=headers)
+        pre.raise_for_status()
+        baseline_ts = pre.json()["resMsg"].get("lastUpdateTime")
+
+        # Wake the vehicle; errors propagate so a failed wake does not fall
+        # through to a stale /latest apply.
+        self.session.get(trigger_url, headers=headers).raise_for_status()
+        sleep(25)
+
+        response = self.session.get(latest_url, headers=headers)
+        response.raise_for_status()
+        resmsg = response.json()["resMsg"]
+        if resmsg.get("lastUpdateTime") == baseline_ts:
+            raise APIError(
+                "Brazilian Hyundai force refresh did not return fresh data "
+                "in time; vehicle may be unreachable."
+            )
+        self._update_vehicle_properties_ccs2(vehicle, resmsg["state"]["Vehicle"])
 
     def _ensure_control_token(self, token: Token) -> str:
         """Ensure we have a valid control token for remote commands."""

--- a/tests/fixtures/br_hyundai_creta_2025_ccs2_cached.json
+++ b/tests/fixtures/br_hyundai_creta_2025_ccs2_cached.json
@@ -1,0 +1,304 @@
+{
+    "_fixture_meta": {
+        "description": "BR Hyundai Creta 2025 (ICE, reports ccuCCS2ProtocolSupport=0) cached status from /ccs2/carstatus/latest. Anonymized: GeoCoord replaced with a placeholder, no VIN/tokens.",
+        "expected": {
+            "car_battery_percentage": 59,
+            "engine_is_running": false,
+            "fuel_level": 20,
+            "is_locked": true,
+            "odometer": 6208.1,
+            "odometer_unit": "km",
+            "total_driving_range": 102.0,
+            "total_driving_range_unit": "km"
+        },
+        "source": "GET /api/v1/spa/vehicles/{id}/ccs2/carstatus/latest"
+    },
+    "resMsg": {
+        "lastUpdateTime": "20260717174232",
+        "state": {
+            "Vehicle": {
+                "Body": {
+                    "Hood": {
+                        "Open": 0
+                    },
+                    "Lights": {
+                        "DischargeAlert": {
+                            "State": 0
+                        },
+                        "Front": {
+                            "HeadLamp": {
+                                "SystemWarning": 0
+                            },
+                            "Left": {
+                                "High": {
+                                    "Warning": 0
+                                },
+                                "Low": {
+                                    "Warning": 0
+                                },
+                                "TurnSignal": {
+                                    "Warning": 0
+                                }
+                            },
+                            "Right": {
+                                "High": {
+                                    "Warning": 0
+                                },
+                                "Low": {
+                                    "Warning": 0
+                                },
+                                "TurnSignal": {
+                                    "Warning": 0
+                                }
+                            }
+                        },
+                        "Hazard": {
+                            "Alert": 0
+                        },
+                        "Rear": {
+                            "Left": {
+                                "StopLamp": {
+                                    "Warning": 0
+                                },
+                                "TurnSignal": {
+                                    "Warning": 0
+                                }
+                            },
+                            "Right": {
+                                "StopLamp": {
+                                    "Warning": 0
+                                },
+                                "TurnSignal": {
+                                    "Warning": 0
+                                }
+                            }
+                        },
+                        "TailLamp": {
+                            "Alert": 0
+                        }
+                    },
+                    "Trunk": {
+                        "Open": 0
+                    },
+                    "Windshield": {
+                        "Front": {
+                            "Defog": {
+                                "State": 0
+                            },
+                            "WasherFluid": {
+                                "LevelLow": 0
+                            }
+                        },
+                        "Rear": {
+                            "Defog": {
+                                "State": 0
+                            }
+                        }
+                    }
+                },
+                "Cabin": {
+                    "Door": {
+                        "Row1": {
+                            "Driver": {
+                                "Lock": 0,
+                                "Open": 0
+                            },
+                            "Passenger": {
+                                "Lock": 0,
+                                "Open": 0
+                            }
+                        },
+                        "Row2": {
+                            "Left": {
+                                "Lock": 0,
+                                "Open": 0
+                            },
+                            "Right": {
+                                "Lock": 0,
+                                "Open": 0
+                            }
+                        }
+                    },
+                    "HVAC": {
+                        "Row1": {
+                            "Driver": {
+                                "Blower": {
+                                    "SpeedLevel": 0
+                                },
+                                "Temperature": {
+                                    "Unit": 0,
+                                    "Value": "OFF"
+                                }
+                            }
+                        },
+                        "Temperature": {
+                            "RangeType": 1
+                        }
+                    },
+                    "Seat": {
+                        "Row1": {
+                            "Driver": {
+                                "Climate": {
+                                    "State": 2
+                                }
+                            },
+                            "Passenger": {
+                                "Climate": {
+                                    "State": 2
+                                }
+                            }
+                        },
+                        "Row2": {
+                            "Left": {
+                                "Climate": {
+                                    "State": 2
+                                }
+                            },
+                            "Right": {
+                                "Climate": {
+                                    "State": 2
+                                }
+                            }
+                        }
+                    },
+                    "SteeringWheel": {
+                        "Heat": {
+                            "State": 0
+                        }
+                    },
+                    "Window": {
+                        "Row1": {
+                            "Driver": {
+                                "Open": 0
+                            },
+                            "Passenger": {
+                                "Open": 0
+                            }
+                        },
+                        "Row2": {
+                            "Left": {
+                                "Open": 0
+                            },
+                            "Right": {
+                                "Open": 0
+                            }
+                        }
+                    }
+                },
+                "Chassis": {
+                    "Axle": {
+                        "Tire": {
+                            "PressureLow": 0
+                        }
+                    },
+                    "Brake": {
+                        "Fluid": {
+                            "Warning": 0
+                        }
+                    }
+                },
+                "Date": "20260717174232.585",
+                "Drivetrain": {
+                    "FuelSystem": {
+                        "DTE": {
+                            "Total": 102,
+                            "Unit": 1
+                        },
+                        "FuelLevel": 20,
+                        "LowFuelWarning": 0
+                    },
+                    "InternalCombustionEngine": {
+                        "OilLevelWarning": 0
+                    },
+                    "Odometer": 6208.1,
+                    "Transmission": {
+                        "ParkingPosition": 1
+                    }
+                },
+                "DrivingReady": 0,
+                "Electronics": {
+                    "AutoCut": {
+                        "BatteryPreWarning": 0,
+                        "DeliveryMode": 1,
+                        "PowerMode": 2
+                    },
+                    "Battery": {
+                        "Charging": {
+                            "WarningLevel": 65
+                        },
+                        "Level": 59,
+                        "SensorReliability": 0
+                    },
+                    "FOB": {
+                        "LowBattery": 0
+                    },
+                    "PowerSupply": {
+                        "Accessory": 0
+                    }
+                },
+                "Green": {
+                    "ChargingInformation": {
+                        "SequenceDetails": 510,
+                        "SequenceSubcode": -1
+                    },
+                    "Reservation": {
+                        "Departure": {
+                            "Schedule1": {
+                                "Fri": 0,
+                                "Mon": 0,
+                                "Sat": 0,
+                                "Sun": 0,
+                                "Thu": 0,
+                                "Tue": 0,
+                                "Wed": 0
+                            },
+                            "Schedule2": {
+                                "Fri": 0,
+                                "Mon": 0,
+                                "Sat": 0,
+                                "Sun": 0,
+                                "Thu": 0,
+                                "Tue": 0,
+                                "Wed": 0
+                            }
+                        },
+                        "OffPeakTime": {
+                            "Mode": 1
+                        }
+                    }
+                },
+                "Location": {
+                    "GeoCoord": {
+                        "Altitude": 700,
+                        "Latitude": -23.5,
+                        "Longitude": -46.6,
+                        "Type": 0
+                    },
+                    "Speed": {
+                        "Unit": 0,
+                        "Value": 0
+                    },
+                    "TimeStamp": {
+                        "Day": 17,
+                        "Hour": 17,
+                        "Min": 42,
+                        "Mon": 7,
+                        "Sec": 30,
+                        "Year": 2026
+                    }
+                },
+                "RemoteControl": {
+                    "SleepMode": 0
+                },
+                "Service": {
+                    "ConnectedCar": {
+                        "RemoteControl": {
+                            "Available": 1,
+                            "WaitingTime": 168
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/test_br_login.py
+++ b/tests/test_br_login.py
@@ -1,0 +1,127 @@
+"""Tests for Brazilian Hyundai BlueLink auth error handling.
+
+Regression for kia_uvo #1792 / #1515: the BR signin endpoint returns HTTP 400
+(with a JSON body describing the failure) for password-expired / blocked /
+verification-required accounts. Previously ``raise_for_status()`` raised a raw
+``HTTPError`` before the body was parsed, so users saw "400 Client Error: Bad
+Request for url: .../user/signin" with no actionable reason.
+
+These tests cover ``_raise_auth_error`` across the three BR auth call-sites
+(``_get_cookies``, ``_get_authorization_code``, ``_get_auth_response``) plus the
+existing HTTP 200 + ``{step:N}`` path (#1239) as a regression guard.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from hyundai_kia_connect_api.const import BRAND_HYUNDAI, BRANDS, REGION_BRAZIL, REGIONS
+from hyundai_kia_connect_api.exceptions import AuthenticationError
+from hyundai_kia_connect_api.HyundaiBlueLinkApiBR import HyundaiBlueLinkApiBR
+
+_BR_REGION = next(k for k, v in REGIONS.items() if v == REGION_BRAZIL)
+_HYUNDAI_BRAND = next(k for k, v in BRANDS.items() if v == BRAND_HYUNDAI)
+
+
+def _resp(status_code: int, json_data: dict | None = None, text: str = "") -> MagicMock:
+    r = MagicMock()
+    r.status_code = status_code
+    if json_data is not None:
+        r.json.return_value = json_data
+    else:
+        r.json.side_effect = ValueError("not JSON")
+    r.text = text
+    return r
+
+
+@pytest.fixture
+def br_api() -> HyundaiBlueLinkApiBR:
+    return HyundaiBlueLinkApiBR(region=_BR_REGION, brand=_HYUNDAI_BRAND)
+
+
+class TestRaiseAuthError:
+    """Unit-test the helper directly."""
+
+    def test_no_op_on_success(self, br_api):
+        # 2xx must not raise.
+        br_api._raise_auth_error(_resp(200, {"redirectUrl": "x"}), "signin")
+
+    def test_400_step_surfaces_readable_reason(self, br_api):
+        with pytest.raises(AuthenticationError, match="password has expired"):
+            br_api._raise_auth_error(_resp(400, {"step": 5}), "signin")
+
+    def test_400_errcode_errmsg(self, br_api):
+        with pytest.raises(AuthenticationError, match="errCode=4003"):
+            br_api._raise_auth_error(
+                _resp(400, {"errCode": 4003, "errMsg": "Invalid credentials"}), "signin"
+            )
+
+    def test_400_non_json_falls_back_to_snippet(self, br_api):
+        # Cloudflare / WAF HTML response, no JSON body.
+        with pytest.raises(AuthenticationError, match="Response not JSON"):
+            br_api._raise_auth_error(
+                _resp(403, None, text="<html>Attention Required</html>"),
+                "cookie request",
+            )
+
+    def test_400_unknown_shape_lists_keys_only(self, br_api):
+        with pytest.raises(AuthenticationError, match="keys="):
+            br_api._raise_auth_error(_resp(400, {"foo": "bar"}), "token request")
+
+
+class TestGetAuthorizationCode:
+    """The signin call-site: 4xx must surface the body, not a raw HTTPError."""
+
+    def test_400_step5_raises_authentication_error_not_httperror(self, br_api):
+        br_api.session = MagicMock()
+        br_api.session.post.return_value = _resp(400, {"step": 5})
+        with pytest.raises(AuthenticationError, match="password has expired"):
+            br_api._get_authorization_code({}, "user@example.com", "pass")
+
+    def test_400_errcode_raises_authentication_error(self, br_api):
+        br_api.session = MagicMock()
+        br_api.session.post.return_value = _resp(
+            400, {"errCode": 4003, "errMsg": "Invalid credentials"}
+        )
+        with pytest.raises(AuthenticationError, match="errCode=4003"):
+            br_api._get_authorization_code({}, "user@example.com", "pass")
+
+    def test_400_non_json_raises_with_snippet(self, br_api):
+        br_api.session = MagicMock()
+        br_api.session.post.return_value = _resp(400, None, text="<html>blocked</html>")
+        with pytest.raises(AuthenticationError, match="Response not JSON"):
+            br_api._get_authorization_code({}, "user@example.com", "pass")
+
+    def test_200_step5_still_handled_regression_guard(self, br_api):
+        """#1239 fixed the HTTP 200 + {step:N} path; this guard ensures the new
+        4xx helper did not break it."""
+        br_api.session = MagicMock()
+        br_api.session.post.return_value = _resp(200, {"step": 5})
+        with pytest.raises(AuthenticationError, match="password has expired"):
+            br_api._get_authorization_code({}, "user@example.com", "pass")
+
+    def test_200_redirect_url_returns_code(self, br_api):
+        br_api.session = MagicMock()
+        br_api.session.post.return_value = _resp(
+            200, {"redirectUrl": "https://br-ccapi.hyundai.com.br/cb?code=ABC123"}
+        )
+        code = br_api._get_authorization_code({}, "user@example.com", "pass")
+        assert code == "ABC123"
+
+
+class TestGetCookies:
+    def test_400_non_json_raises_authentication_error(self, br_api):
+        br_api.session = MagicMock()
+        br_api.session.get.return_value = _resp(400, None, text="<html>error</html>")
+        with pytest.raises(AuthenticationError, match="cookie request"):
+            br_api._get_cookies()
+
+
+class TestGetAuthResponse:
+    def test_400_errcode_raises_authentication_error(self, br_api):
+        br_api.session = MagicMock()
+        br_api.session.post.return_value = _resp(
+            400, {"errCode": 4001, "errMsg": "Invalid grant"}
+        )
+        with pytest.raises(AuthenticationError, match="token request"):
+            br_api._get_auth_response("some-auth-code")

--- a/tests/test_br_vehicle_properties.py
+++ b/tests/test_br_vehicle_properties.py
@@ -1,0 +1,206 @@
+"""Tests for the Brazilian Hyundai BlueLink API.
+
+Covers:
+  * the cached-status endpoint (regression for the /status/latest 503 bug),
+  * the asynchronous force-refresh flow (wake + sleep + read + staleness guard),
+  * CCS2 status parsing driven by a JSON fixture.
+
+BR reports ``ccuCCS2ProtocolSupport: 0`` but serves status in CCS2 format at
+``/ccs2/carstatus/latest``, so BR extends ``ApiImplType1`` and reuses its
+``_update_vehicle_properties_ccs2`` parser.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hyundai_kia_connect_api.const import BRAND_HYUNDAI, BRANDS, REGION_BRAZIL, REGIONS
+from hyundai_kia_connect_api.HyundaiBlueLinkApiBR import HyundaiBlueLinkApiBR
+from hyundai_kia_connect_api.Vehicle import Vehicle
+from tests.fixture_helpers import discover_fixtures, get_fixture_expected, load_fixture
+
+BR_FIXTURE_FILES = discover_fixtures("br_")
+
+_BR_REGION = next(k for k, v in REGIONS.items() if v == REGION_BRAZIL)
+_HYUNDAI_BRAND = next(k for k, v in BRANDS.items() if v == BRAND_HYUNDAI)
+
+
+def _response(json_data):
+    resp = MagicMock()
+    resp.json.return_value = json_data
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def _fixture_state():
+    """Return the CCS2 state.Vehicle dict from the first BR fixture."""
+    data = load_fixture(BR_FIXTURE_FILES[0])
+    return data["resMsg"]["state"]["Vehicle"]
+
+
+@pytest.fixture
+def br_api() -> HyundaiBlueLinkApiBR:
+    return HyundaiBlueLinkApiBR(region=_BR_REGION, brand=_HYUNDAI_BRAND)
+
+
+@pytest.fixture
+def token() -> MagicMock:
+    tok = MagicMock()
+    tok.access_token = "test-access-token"
+    tok.device_id = "test-device-id"
+    return tok
+
+
+def _called_urls(session_get):
+    urls = []
+    for call in session_get.call_args_list:
+        urls.append(call.args[0] if call.args else call.kwargs["url"])
+    return urls
+
+
+class TestBRInheritance:
+    def test_extends_apiimpltype1_and_reuses_ccs2_parser(self, br_api):
+        # BR must inherit the CCS2 parser rather than duplicate it.
+        assert hasattr(br_api, "_update_vehicle_properties_ccs2")
+        assert type(br_api).__mro__[1].__name__ == "ApiImplType1"
+
+    def test_valet_mode_disabled(self, br_api):
+        # ApiImplType1 defaults valet mode on; BR must keep it off.
+        assert br_api.supports_valet_mode is False
+
+
+class TestBRCachedEndpoint:
+    """The cached read must use /ccs2/carstatus/latest (never /status*)."""
+
+    def test_cached_state_uses_ccs2_latest(self, br_api, token):
+        state = _fixture_state()
+        br_api.session = MagicMock()
+        br_api.session.get.return_value = _response(
+            {"resMsg": {"state": {"Vehicle": state}}}
+        )
+        vehicle = Vehicle(id="VID", ccu_ccs2_protocol_support=0)
+
+        br_api.update_vehicle_with_cached_state(token, vehicle)
+
+        urls = _called_urls(br_api.session.get)
+        assert any(u.endswith("/spa/vehicles/VID/ccs2/carstatus/latest") for u in urls)
+        assert not any("/status/latest" in u for u in urls)
+        assert not any(u.endswith("/status") for u in urls)
+        # Parsed via the inherited CCS2 parser.
+        assert vehicle.car_battery_percentage == 59
+
+
+class TestBRForceRefresh:
+    """Force refresh: baseline /latest, wake /ccs2/carstatus, sleep(25),
+    read /latest; apply only if lastUpdateTime advanced, else raise (no stale
+    apply)."""
+
+    def _state_payload(self, state, last_update):
+        return {"resMsg": {"lastUpdateTime": last_update, "state": {"Vehicle": state}}}
+
+    def test_force_wakes_sleeps_reads_and_applies_fresh(self, br_api, token):
+        state = _fixture_state()
+        ack = {"retCode": "S", "resCode": "0000"}
+        baseline = self._state_payload(state, "T1")
+        fresh = self._state_payload(state, "T2")
+
+        latest_read = {"n": 0}
+
+        def _get(url, headers=None):
+            if url.endswith("/ccs2/carstatus") and not url.endswith("/latest"):
+                return _response(ack)
+            latest_read["n"] += 1
+            return _response(baseline if latest_read["n"] == 1 else fresh)
+
+        br_api.session = MagicMock()
+        br_api.session.get.side_effect = _get
+        vehicle = Vehicle(id="VID", ccu_ccs2_protocol_support=0)
+
+        sleep_calls = []
+        with patch(
+            "hyundai_kia_connect_api.HyundaiBlueLinkApiBR.sleep",
+            side_effect=lambda s: sleep_calls.append(s),
+        ):
+            br_api.force_refresh_vehicle_state(token, vehicle)
+
+        urls = _called_urls(br_api.session.get)
+        # baseline /latest, wake /ccs2/carstatus, post /latest
+        assert len(urls) == 3
+        assert urls[0].endswith("/ccs2/carstatus/latest")
+        assert urls[1].endswith("/ccs2/carstatus")
+        assert urls[2].endswith("/ccs2/carstatus/latest")
+        assert sleep_calls == [25]
+        assert vehicle.car_battery_percentage == 59
+
+    def test_force_raises_when_snapshot_did_not_advance(self, br_api, token):
+        """If lastUpdateTime is unchanged after the wake+sleep, the car did not
+        report — do not apply stale data, raise APIError (audit-1: don't mask
+        unknown as current)."""
+        state = _fixture_state()
+        same = self._state_payload(state, "T1")
+        ack = {"retCode": "S", "resCode": "0000"}
+
+        def _get(url, headers=None):
+            if url.endswith("/ccs2/carstatus") and not url.endswith("/latest"):
+                return _response(ack)
+            return _response(same)  # baseline and post are identical
+
+        br_api.session = MagicMock()
+        br_api.session.get.side_effect = _get
+        vehicle = Vehicle(id="VID", ccu_ccs2_protocol_support=0)
+
+        with (
+            patch("hyundai_kia_connect_api.HyundaiBlueLinkApiBR.sleep"),
+            pytest.raises(Exception, match="did not return fresh data"),
+        ):
+            br_api.force_refresh_vehicle_state(token, vehicle)
+
+        # Stale state was not applied.
+        assert vehicle.car_battery_percentage is None
+
+
+@pytest.fixture
+def properties_api() -> HyundaiBlueLinkApiBR:
+    api = HyundaiBlueLinkApiBR.__new__(HyundaiBlueLinkApiBR)
+    api.data_timezone = HyundaiBlueLinkApiBR.data_timezone
+    return api
+
+
+@pytest.fixture
+def vehicle() -> Vehicle:
+    return Vehicle()
+
+
+@pytest.mark.parametrize("fixture_file", BR_FIXTURE_FILES, ids=BR_FIXTURE_FILES)
+class TestBRUpdateVehicleProperties:
+    def _parse(self, properties_api, vehicle, fixture_file):
+        data = load_fixture(fixture_file)
+        state = data["resMsg"]["state"]["Vehicle"]
+        properties_api._update_vehicle_properties_ccs2(vehicle, state)
+        return get_fixture_expected(data)
+
+    def test_battery_and_engine(self, properties_api, vehicle, fixture_file):
+        expected = self._parse(properties_api, vehicle, fixture_file)
+        assert vehicle.car_battery_percentage == expected["car_battery_percentage"]
+        assert bool(vehicle.engine_is_running) == expected["engine_is_running"]
+
+    def test_is_locked(self, properties_api, vehicle, fixture_file):
+        expected = self._parse(properties_api, vehicle, fixture_file)
+        assert vehicle.is_locked == expected["is_locked"]
+
+    def test_fuel_and_range(self, properties_api, vehicle, fixture_file):
+        expected = self._parse(properties_api, vehicle, fixture_file)
+        assert vehicle.fuel_level == expected["fuel_level"]
+        assert vehicle.total_driving_range == expected["total_driving_range"]
+        assert vehicle._total_driving_range_unit == expected["total_driving_range_unit"]
+
+    def test_odometer(self, properties_api, vehicle, fixture_file):
+        expected = self._parse(properties_api, vehicle, fixture_file)
+        assert vehicle.odometer == expected["odometer"]
+        assert vehicle._odometer_unit == expected["odometer_unit"]
+
+    def test_last_updated_and_location_set(self, properties_api, vehicle, fixture_file):
+        self._parse(properties_api, vehicle, fixture_file)
+        # CCS2 'Date' populates last_updated_at (not now()), and location is parsed.
+        assert vehicle.last_updated_at is not None
+        assert vehicle.location is not None


### PR DESCRIPTION
## What changed

**Login (4xx error handling):** `_raise_auth_error` reads the response body before raising, so 4xx from `/user/signin` (and `/oauth2/authorize`, `/oauth2/token`) surfaces a readable `AuthenticationError` instead of a raw `HTTPError`. The BR backend returns HTTP 400 for password-expired (step 5), `errCode`/`errMsg`, or non-JSON WAF responses. This extends #1239 (which only handled HTTP 200 + `{step:N}`) to 4xx, across all three BR auth call-sites (`_get_cookies`, `_get_authorization_code`, `_get_auth_response`).

**Status (CCS2 endpoint):** BR extends `ApiImplType1` and reads cached status from `/ccs2/carstatus/latest`, reusing `_update_vehicle_properties_ccs2`. BR vehicles report `ccuCCS2ProtocolSupport: 0` but the cached status is served in CCS2 format (including location); the legacy `/status/latest` endpoint is the remote-control command result on BR and always returns 503 / resCode 5031. Force refresh uses the #1250 wake+sleep+read pattern with a `lastUpdateTime` guard: if the snapshot did not advance after the wake, raise `APIError` (→ `UpdateFailed` → entities unavailable) rather than apply stale data. `supports_valet_mode = False` (BR has no valet). Drops the legacy flat status parser (~190 lines).

## Supersedes

Supersedes #1240 — credit to @paulogabrielfs for the CCS2-endpoint investigation and the anonymized Creta fixture. Force-refresh is rebuilt on the merged #1250 wake+sleep+read pattern instead of #1240's poll-until-timestamp loop.

## Related issues

**hyundai_kia_connect_api:** #1239 (the 200+step fix this extends to 4xx), #1240 (superseded), #1250 (force-refresh pattern), #1256 (ruff 0.16 base this branches from)
**kia_uvo:** Hyundai-Kia-Connect/kia_uvo#1792 (BR connect failure — both the 503 status and 400 login cases), Hyundai-Kia-Connect/kia_uvo#1515

## Test plan

- [x] `pytest tests/test_br_vehicle_properties.py tests/test_br_login.py -q` — 22 passed
- [x] `pytest tests/ -q` (excluding local-only browser/integration tests) — 448 passed, 11 snapshots
- [x] `ruff check` / `ruff format` / `pre-commit run` — all pass
- [ ] Live validation welcome: a BR account hitting the 400 on `/user/signin` should now see the actionable message (e.g. "password has expired"); cached status should load without the 503/5031.