### PR TITLE
fix(CCS2): start_climate sideRearMirrorHeating + RHD front seat swap

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -1181,6 +1181,13 @@ class ApiImplType1(ApiImpl):
                 + vehicle.id
                 + "/ccs2/control/temperature"
             )
+            # For RHD vehicles the driver sits on the right, so the front
+            # physical seats map to passenger/driver respectively.
+            drv_seat_loc = self._get_drv_seat_loc(vehicle)
+            if drv_seat_loc == "R":
+                drv_seat, psg_seat = options.front_right_seat, options.front_left_seat
+            else:
+                drv_seat, psg_seat = options.front_left_seat, options.front_right_seat
             payload = {
                 "command": "start",
                 "ignitionDuration": options.duration,
@@ -1190,10 +1197,10 @@ class ApiImplType1(ApiImpl):
                 # heating 1/2/4 engage the rear-window + side-mirror heaters;
                 # 0 (off) and 3 (steering wheel only) leave them off.
                 "sideRearMirrorHeating": 1 if options.heating in (1, 2, 4) else 0,
-                "drvSeatLoc": self._get_drv_seat_loc(vehicle),
+                "drvSeatLoc": drv_seat_loc,
                 "seatClimateInfo": {
-                    "drvSeatClimateState": options.front_left_seat,
-                    "psgSeatClimateState": options.front_right_seat,
+                    "drvSeatClimateState": drv_seat,
+                    "psgSeatClimateState": psg_seat,
                     "rrSeatClimateState": options.rear_right_seat,
                     "rlSeatClimateState": options.rear_left_seat,
                 },

--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -1187,7 +1187,9 @@ class ApiImplType1(ApiImpl):
                 "strgWhlHeating": options.steering_wheel,
                 "hvacTempType": 1,
                 "hvacTemp": options.set_temp,
-                "sideRearMirrorHeating": 1,
+                # heating 1/2/4 engage the rear-window + side-mirror heaters;
+                # 0 (off) and 3 (steering wheel only) leave them off.
+                "sideRearMirrorHeating": 1 if options.heating in (1, 2, 4) else 0,
                 "drvSeatLoc": self._get_drv_seat_loc(vehicle),
                 "seatClimateInfo": {
                     "drvSeatClimateState": options.front_left_seat,

--- a/tests/test_ccs2_climate_payload.py
+++ b/tests/test_ccs2_climate_payload.py
@@ -89,3 +89,59 @@ class TestSideRearMirrorHeating:
     def test_heating_eu_steering_side_back_enables(self):
         options = ClimateRequestOptions(set_temp=21, heating=1)
         assert self._heating(options) == 1
+
+
+class TestRhdSeatSwap:
+    """For RHD (drvSeatLoc == "R") the front driver/passenger seats are swapped.
+
+    The HA service fields flseat/frseat are physical (front-left/right). The
+    API fields drvSeatClimateState/psgSeatClimateState are logical
+    (driver/passenger). For RHD vehicles the driver sits on the right, so the
+    physical front-right seat is the driver. Regression for
+    Hyundai-Kia-Connect/kia_uvo#1447 (UK Ioniq 5: frseat activated passenger).
+    """
+
+    def setup_method(self):
+        self.api = _make_api()
+
+    def _seat_info(self, vehicle, options):
+        return _post_payload(self.api, vehicle, options)["seatClimateInfo"]
+
+    def test_lhd_driver_is_front_left(self):
+        """LHD: driver sits on the left -> drvSeatClimateState = front_left."""
+        from hyundai_kia_connect_api.const import DISTANCE_UNITS
+
+        vehicle = _make_vehicle(ccs2=True)
+        vehicle._odometer_unit = DISTANCE_UNITS[1]  # km -> LHD
+        options = ClimateRequestOptions(
+            set_temp=21, front_left_seat=1, front_right_seat=2
+        )
+        info = self._seat_info(vehicle, options)
+        assert info["drvSeatClimateState"] == 1  # front_left
+        assert info["psgSeatClimateState"] == 2  # front_right
+
+    def test_rhd_driver_is_front_right(self):
+        """RHD: driver sits on the right -> drvSeatClimateState = front_right."""
+        from hyundai_kia_connect_api.const import DISTANCE_UNITS
+
+        vehicle = _make_vehicle(ccs2=True)
+        vehicle._odometer_unit = DISTANCE_UNITS[2]  # miles -> RHD (UK)
+        options = ClimateRequestOptions(
+            set_temp=21, front_left_seat=1, front_right_seat=2
+        )
+        info = self._seat_info(vehicle, options)
+        assert info["drvSeatClimateState"] == 2  # front_right -> driver
+        assert info["psgSeatClimateState"] == 1  # front_left -> passenger
+
+    def test_rhd_rear_seats_not_swapped(self):
+        """Rear seats are physical left/right and must NOT be swapped for RHD."""
+        from hyundai_kia_connect_api.const import DISTANCE_UNITS
+
+        vehicle = _make_vehicle(ccs2=True)
+        vehicle._odometer_unit = DISTANCE_UNITS[2]  # RHD
+        options = ClimateRequestOptions(
+            set_temp=21, rear_left_seat=3, rear_right_seat=4
+        )
+        info = self._seat_info(vehicle, options)
+        assert info["rlSeatClimateState"] == 3
+        assert info["rrSeatClimateState"] == 4

--- a/tests/test_ccs2_climate_payload.py
+++ b/tests/test_ccs2_climate_payload.py
@@ -1,0 +1,91 @@
+"""Tests for the CCS2 start_climate payload (ApiImplType1, EU/AU/IN/CN/BR).
+
+Covers the ``sideRearMirrorHeating`` correctness bug in the CCS2 branch of
+``ApiImplType1.start_climate``: it was hardcoded to ``1``, so the rear-window
++ side-mirror heaters turned on for every climate start regardless of the
+``heating`` option. It must be derived from ``options.heating`` (on for
+1/2/4, off for 0 and steering-only 3), mirroring the Kia USA logic. See
+Hyundai-Kia-Connect/hyundai_kia_connect_api#1195 and
+Hyundai-Kia-Connect/kia_uvo#1739.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from hyundai_kia_connect_api.ApiImpl import ClimateRequestOptions
+from hyundai_kia_connect_api.KiaUvoApiEU import KiaUvoApiEU
+from hyundai_kia_connect_api.Token import Token
+from hyundai_kia_connect_api.Vehicle import Vehicle
+
+
+class _FakeResponse:
+    """Minimal fake for requests.Response with the fields start_climate reads."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def _make_api():
+    """Create a KiaUvoApiEU (CCS2-capable, base _get_drv_seat_loc) sans network."""
+    api = object.__new__(KiaUvoApiEU)
+    api.SPA_API_URL = "https://example/api/v1/spa/"
+    api.SPA_API_URL_V2 = "https://example/api/v2/spa/"
+    api.session = MagicMock()
+    return api
+
+
+def _make_vehicle(ccs2: bool = True) -> Vehicle:
+    v = Vehicle()
+    v.id = "test-vehicle-id"
+    v.name = "Kona EV"
+    v.ccu_ccs2_protocol_support = ccs2
+    return v
+
+
+def _make_token():
+    return MagicMock(spec=Token)
+
+
+def _post_payload(api, vehicle, options):
+    """Call start_climate on the CCS2 path and return the sent JSON payload."""
+    api.session.post.return_value = _FakeResponse(
+        {"retCode": "S", "resCode": "0000", "msgId": "test-msg"}
+    )
+    with (
+        patch.object(api, "_get_control_headers", return_value={}),
+    ):
+        api.start_climate(_make_token(), vehicle, options)
+    return api.session.post.call_args.kwargs["json"]
+
+
+class TestSideRearMirrorHeating:
+    """sideRearMirrorHeating must follow options.heating, not be hardcoded 1."""
+
+    def setup_method(self):
+        self.api = _make_api()
+        self.vehicle = _make_vehicle(ccs2=True)
+
+    def _heating(self, options):
+        return _post_payload(self.api, self.vehicle, options)["sideRearMirrorHeating"]
+
+    def test_heating_off_disables_rear_mirror(self):
+        options = ClimateRequestOptions(set_temp=21, heating=0)
+        assert self._heating(options) == 0
+
+    def test_heating_rear_window_only_enables(self):
+        options = ClimateRequestOptions(set_temp=21, heating=2)
+        assert self._heating(options) == 1
+
+    def test_heating_steering_only_disables_rear_mirror(self):
+        options = ClimateRequestOptions(set_temp=21, heating=3)
+        assert self._heating(options) == 0
+
+    def test_heating_steering_side_back_enables(self):
+        options = ClimateRequestOptions(set_temp=21, heating=4)
+        assert self._heating(options) == 1
+
+    def test_heating_eu_steering_side_back_enables(self):
+        options = ClimateRequestOptions(set_temp=21, heating=1)
+        assert self._heating(options) == 1


### PR DESCRIPTION
## Summary

Two correctness fixes in the CCS2 branch of `ApiImplType1.start_climate` (reached by `KiaUvoApiEU` and `KiaUvoApiAU` for CCS2 vehicles — `ccu_ccs2_protocol_support` true). IN/CN override `start_climate` with their own `/control/engine` path and are unaffected; BR/USA/CA are not `ApiImplType1` subclasses.

### Commit 1 — `sideRearMirrorHeating` derived from `options.heating`

The CCS2 branch hardcoded `sideRearMirrorHeating: 1`, so the rear-window + side-mirror heaters turned on for every climate start regardless of the `heating` option (`heating=0` still enabled them). Derive it instead, mirroring the Kia USA `rearWindow`/`sideMirror` logic: on for `1`/`2`/`4`, off for `0` and steering-only `3`.

Closes Hyundai-Kia-Connect/hyundai_kia_connect_api#1195. Relates to Hyundai-Kia-Connect/kia_uvo#1739.

### Commit 2 — swap front driver/passenger seats for RHD

`seatClimateInfo` mapped `drvSeatClimateState` from `front_left_seat` and `psgSeatClimateState` from `front_right_seat` unconditionally — an LHD assumption. For RHD vehicles (`drvSeatLoc == "R"`, driver on the right) this inverted the seats: `frseat` activated the passenger. Swap the front seats when `drvSeatLoc` is `"R"`; rear seats are physical left/right and stay unchanged. LHD behaviour is unaffected.

This is the complement to the existing `_get_drv_seat_loc` fix: that tells the car which side the driver is on (the `drvSeatLoc` field); this maps the HA physical seats (`flseat`/`frseat`) to the logical `drv`/`psg` seats consistently with that side.

Closes Hyundai-Kia-Connect/kia_uvo#1447.

## ⚠️ Verification basis for the RHD swap — please confirm

The swap assumes the car interprets `drvSeatClimateState`/`psgSeatClimateState` as **logical** driver/passenger seats remapped by `drvSeatLoc` (i.e. `drvSeatLoc="R"` + `drvSeatClimateState=X` heats the right/driver seat with `X`). This is supported by the #1447 report (UK Ioniq 5, filed *after* the `drvSeatLoc` fix was in place): with `drvSeatLoc` correct, `frseat` still activated the passenger — i.e. the car remaps `drv`/`psg` by `drvSeatLoc`, and the pre-fix `front_left→drv` mapping heated the wrong seat.

That evidence is from a single vehicle (UK Ioniq 5). AU CCS2 (also RHD, same CCSP/CCS2 protocol) is assumed to interpret the same way but has no seat-swap report. **Maintainer/reporter confirmation that this matches app/vehicle behaviour — especially for AU — would be welcome.** If the car instead treats `drvSeatClimateState` as a fixed physical seat (not remapped by `drvSeatLoc`), the swap direction would need revisiting.

The status **read** side uses physical `flSeatHeatState`/`frSeatHeatState` keys (side-agnostic), so it is correct as-is; only the **write** side carried the LHD assumption, and this PR brings write into consistency with the physical read.

## Testing

New `tests/test_ccs2_climate_payload.py` (8 tests, payload assertions against the CCS2 `start_climate` payload):
- `sideRearMirrorHeating`: off for `heating=0`/`3`, on for `1`/`2`/`4`.
- RHD: `drvSeatClimateState = front_right_seat`, `psgSeatClimateState = front_left_seat`; rear seats unchanged.
- LHD: `drvSeatClimateState = front_left_seat` (unchanged behaviour, regression guard).

`ruff` (0.16.0) + `pre-commit` clean; full suite green (436 + 11 snapshots). `mypy --strict` introduces no new errors on the touched lines.

## Related

- Hyundai-Kia-Connect/hyundai_kia_connect_api#1195 — `sideRearMirrorHeating` hardcoded (commit 1)
- Hyundai-Kia-Connect/kia_uvo#1739 — EU EV4 rear/mirror always on (commit 1, same root cause)
- Hyundai-Kia-Connect/kia_uvo#1447 — UK RHD Ioniq 5 seat reversal (commit 2)