### PR TITLE
fix(CCS2): parse ev_driving_range for PHEV from DTE.EV

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -655,7 +655,16 @@ class ApiImplType1(ApiImpl):
                 vehicle.total_driving_range,
                 vehicle.total_driving_range_unit,
             )
-        # TODO: vehicle.ev_driving_range for non EV
+        elif vehicle.engine_type == ENGINE_TYPES.PHEV:
+            # PHEV reports the electric-only range separately in DTE.EV
+            # (DTE.Total includes the ICE range). HEV/ICE have no plug and no
+            # EV-only range, so ev_driving_range stays None for them.
+            ev_range = get_child_value(state, "Drivetrain.FuelSystem.DTE.EV")
+            if ev_range is not None:
+                vehicle.ev_driving_range = (
+                    float(ev_range),
+                    vehicle.total_driving_range_unit,
+                )
 
         vehicle.washer_fluid_warning_is_on = get_child_value(
             state, "Body.Windshield.Front.WasherFluid.LevelLow"

--- a/tests/test_ccs2_ev_driving_range.py
+++ b/tests/test_ccs2_ev_driving_range.py
@@ -1,0 +1,65 @@
+"""Tests for ev_driving_range parsing in CCS2 (_update_vehicle_properties_ccs2).
+
+PHEV vehicles report a separate electric-only range in ``DTE.EV`` (distinct
+from ``DTE.Total``, which includes the ICE range). The CCS2 status parser set
+``ev_driving_range`` only for pure EV (where it equals total_driving_range);
+PHEV left it None. The fix reads ``Drivetrain.FuelSystem.DTE.EV`` for PHEV.
+
+Confirmed against the EU Kia Sportage PHEV 2027 CCS2 fixture:
+``DTE: {Total: 600, Unit: 1, EV: 47, ICE: 551}`` — 47 km electric-only range,
+600 km total. HEV/ICE have no plug and no EV-only range, so ev_driving_range
+stays None.
+"""
+
+import pytest
+
+from hyundai_kia_connect_api.ApiImplType1 import ApiImplType1
+from hyundai_kia_connect_api.const import ENGINE_TYPES
+from hyundai_kia_connect_api.Vehicle import Vehicle
+from tests.fixture_helpers import load_fixture
+
+SPORTAGE_PHEV_FIXTURE = "eu_kia_sportage_phev_2027_ccs2.json"
+
+
+@pytest.fixture
+def ccs2_api() -> ApiImplType1:
+    api = ApiImplType1.__new__(ApiImplType1)
+    api.data_timezone = None
+    api.temperature_range = [x * 0.5 for x in range(28, 60)]
+    return api
+
+
+def _parse(api, engine_type) -> Vehicle:
+    vehicle = Vehicle()
+    vehicle.engine_type = engine_type
+    state = load_fixture(SPORTAGE_PHEV_FIXTURE)
+    api._update_vehicle_properties_ccs2(vehicle, state)
+    return vehicle
+
+
+class TestEvDrivingRangePhev:
+    def test_phev_ev_driving_range_from_dte_ev(self, ccs2_api):
+        """PHEV: ev_driving_range is the electric-only DTE.EV, not DTE.Total."""
+        vehicle = _parse(ccs2_api, ENGINE_TYPES.PHEV)
+        assert vehicle.total_driving_range == 600.0
+        assert vehicle.ev_driving_range == 47.0
+        # Unit follows DTE.Unit (same as total_driving_range_unit).
+        assert vehicle.ev_driving_range_unit == vehicle.total_driving_range_unit
+
+    def test_phev_total_driving_range_still_dte_total(self, ccs2_api):
+        """total_driving_range is unchanged: always DTE.Total."""
+        vehicle = _parse(ccs2_api, ENGINE_TYPES.PHEV)
+        assert vehicle.total_driving_range == 600.0
+
+    def test_ice_ev_driving_range_stays_none(self, ccs2_api):
+        """ICE/HEV have no EV-only range: ev_driving_range stays None even
+        when the status (here a PHEV's) happens to carry a DTE.EV field."""
+        vehicle = _parse(ccs2_api, ENGINE_TYPES.ICE)
+        assert vehicle.total_driving_range == 600.0
+        assert vehicle.ev_driving_range is None
+
+    def test_ev_ev_driving_range_equals_total(self, ccs2_api):
+        """Pure EV: ev_driving_range equals total_driving_range (unchanged)."""
+        vehicle = _parse(ccs2_api, ENGINE_TYPES.EV)
+        assert vehicle.ev_driving_range == 600.0
+        assert vehicle.ev_driving_range == vehicle.total_driving_range


### PR DESCRIPTION
## Summary

The CCS2 status parser (`ApiImplType1._update_vehicle_properties_ccs2`) set `ev_driving_range` only for pure EV (where it equals `total_driving_range`). For PHEV it was left `None`, even though PHEV status reports the electric-only range separately in `Drivetrain.FuelSystem.DTE.EV` (distinct from `DTE.Total`, which includes the ICE range).

For PHEV, read `DTE.EV` into `ev_driving_range`, reusing `total_driving_range_unit` (same `DTE.Unit`). HEV/ICE have no plug and no EV-only range, so `ev_driving_range` stays `None` for them. Pure EV behaviour is unchanged.

## Why this is safe / verified

Confirmed against the EU Kia Sportage PHEV 2027 CCS2 fixture — `DTE = {Total: 600, Unit: 1, EV: 47, ICE: 551}`:
- PHEV → `ev_driving_range = 47`, `total_driving_range = 600` (electric-only vs total)
- HEV (no plug) → `ev_driving_range` stays `None` even if a `DTE.EV` field is present in the status (we only read it for PHEV)
- Pure EV → `ev_driving_range == total_driving_range` (unchanged)

This fills the `# TODO: vehicle.ev_driving_range for non EV` at `ApiImplType1.py:658` for the PHEV case. The HEV/ICE None behaviour is the correct terminal state (no EV-only range exists for them), so the TODO is resolved.

## Testing

New `tests/test_ccs2_ev_driving_range.py` (4 tests, using the real Sportage PHEV fixture):
- PHEV: `ev_driving_range == 47.0` from `DTE.EV`, `total_driving_range == 600.0` from `DTE.Total`.
- PHEV: unit follows `DTE.Unit`.
- ICE: `ev_driving_range is None` (no PHEV/EV branch reads `DTE.EV`).
- EV: `ev_driving_range == total_driving_range` (unchanged, regression guard).

`ruff` (0.16.0) + `pre-commit` clean; full suite green; `mypy --strict` introduces no new errors on the touched lines.