### PR TITLE
fix: use freshest Hyundai USA odometer value

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
@@ -28,7 +28,13 @@ from .const import (
     VEHICLE_LOCK_ACTION,
 )
 from .Token import Token
-from .utils import get_child_value, get_float, normalize_battery_soc, parse_datetime
+from .utils import (
+    float_or_none,
+    get_child_value,
+    get_float,
+    normalize_battery_soc,
+    parse_datetime,
+)
 from .Vehicle import (
     DailyDrivingStats,
     DayTripCounts,
@@ -438,8 +444,14 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
                     )
                 ],
             )
+        odometer_values = (
+            float_or_none(get_child_value(state, "vehicleDetails.odometer")),
+            float_or_none(get_child_value(state, "vehicleStatus.odometer")),
+        )
         vehicle.odometer = (
-            get_child_value(state, "vehicleDetails.odometer"),
+            max(
+                (value for value in odometer_values if value is not None), default=None
+            ),
             DISTANCE_UNITS[3],
         )
         vehicle.car_battery_percentage = normalize_battery_soc(

--- a/tests/test_bluelink_usa_vehicle_properties.py
+++ b/tests/test_bluelink_usa_vehicle_properties.py
@@ -118,3 +118,29 @@ def test_bluelink_air_temp_off_yields_none(
     bluelink_api._update_vehicle_properties(vehicle, bluelink_status_with_air_temp_off)
     assert vehicle.air_temperature is None
     assert vehicle._air_temperature_value is None
+
+
+@pytest.mark.parametrize(
+    ("details_odometer", "status_odometer", "expected"),
+    [
+        (12000, 12035, 12035.0),
+        (14000.4, 9000, 14000.4),
+        (12000, None, 12000.0),
+        (None, 12035, 12035.0),
+        ("unknown", 12035, 12035.0),
+        (None, None, None),
+    ],
+)
+def test_bluelink_odometer_uses_highest_valid_value(
+    bluelink_api, details_odometer, status_odometer, expected
+):
+    """Use the freshest valid odometer when Hyundai's USA fields disagree."""
+    state = {
+        "vehicleDetails": {"odometer": details_odometer},
+        "vehicleStatus": {"odometer": status_odometer},
+    }
+
+    vehicle = Vehicle()
+    bluelink_api._update_vehicle_properties(vehicle, state)
+
+    assert vehicle.odometer == expected


### PR DESCRIPTION
### Summary

- fixes #1263
- parse both `vehicleDetails.odometer` and `vehicleStatus.odometer` for Hyundai
  USA vehicles
- use the highest valid value so stale enrollment details do not mask current
  cached status
- preserve a higher details/trip value for EV responses where the status field
  is lower
- add regression coverage for disagreeing, missing, and malformed values

### Background

A Hyundai USA ICE response was observed with a stale odometer under
`vehicleDetails` and a newer odometer under `vehicleStatus`. The parser read only
the details value, so Home Assistant kept reporting the old mileage while other
vehicle-status properties updated normally.

The parser already replaces an odometer with a higher EV trip reading later in
the update path. Selecting the highest numeric value from the two base response
fields follows the same monotonic-odometer behavior.

### Testing

```text
493 passed, 14 snapshots passed
ruff check: passed
ruff format --check: passed
git diff --check: passed
```

### Privacy

Regression values are synthetic. The contribution contains no VIN, account
identifier, coordinates, authentication data, or raw personal vehicle payload.
