### PR TITLE
fix(US/Hyundai): read realTimePower for ev_charging_power

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
@@ -560,8 +560,12 @@ class HyundaiBlueLinkApiUSA(ApiImpl):
         vehicle.ev_battery_is_plugged_in = get_child_value(
             state, "vehicleStatus.evStatus.batteryPlugin"
         )
+        # `realTimePower` is instantaneous charging power, and is what
+        # KiaUvoApiUSA and ApiImplType1 report for `ev_charging_power`. The
+        # sibling `batteryStndChrgPower` is *standard*/AC charge power: it holds
+        # the AC rate through a DC fast charge, so it never reports one.
         vehicle.ev_charging_power = get_child_value(
-            state, "vehicleStatus.evStatus.batteryStndChrgPower"
+            state, "vehicleStatus.evStatus.realTimePower"
         )
         ChargeDict = get_child_value(
             state, "vehicleStatus.evStatus.reservChargeInfos.targetSOClist"

--- a/tests/__snapshots__/test_vehicle_snapshots.ambr
+++ b/tests/__snapshots__/test_vehicle_snapshots.ambr
@@ -224,7 +224,7 @@
     'ev_charge_limits_dc': 80,
     'ev_charge_port_door_is_open': None,
     'ev_charging_current': None,
-    'ev_charging_power': 0.0,
+    'ev_charging_power': None,
     'ev_driving_range': 240,
     'ev_driving_range_unit': 'mi',
     'ev_estimated_current_charge_duration': 0,

--- a/tests/fixtures/us_hyundai_ioniq_5_2024_cached.json
+++ b/tests/fixtures/us_hyundai_ioniq_5_2024_cached.json
@@ -16,7 +16,8 @@
             "engine_is_running": false,
             "is_locked": true,
             "ev_battery_is_charging": false,
-            "ev_battery_is_plugged_in": 0
+            "ev_battery_is_plugged_in": 0,
+            "ev_charging_power": null
         }
     },
     "vehicleStatus": {

--- a/tests/test_bluelink_usa_vehicle_properties.py
+++ b/tests/test_bluelink_usa_vehicle_properties.py
@@ -80,6 +80,12 @@ class TestBlueLinkUSAUpdateVehicleProperties:
         assert vehicle.ev_battery_is_charging == expected["ev_battery_is_charging"]
         assert vehicle.ev_battery_is_plugged_in == expected["ev_battery_is_plugged_in"]
 
+    def test_ev_charging_power(self, bluelink_api, vehicle, fixture_file):
+        data = load_fixture(fixture_file)
+        expected = get_fixture_expected(data)
+        bluelink_api._update_vehicle_properties(vehicle, data)
+        assert vehicle.ev_charging_power == expected["ev_charging_power"]
+
     def test_data_is_stored(self, bluelink_api, vehicle, fixture_file):
         data = load_fixture(fixture_file)
         bluelink_api._update_vehicle_properties(vehicle, data)
@@ -99,6 +105,54 @@ def bluelink_status_with_air_temp_off():
             "airTemp": {"value": "OFF", "unit": 1, "hvacTempType": 1},
         },
     }
+
+
+def test_bluelink_dc_charging_power_reads_real_time_power(bluelink_api):
+    """`ev_charging_power` must come from `realTimePower`, not `batteryStndChrgPower`.
+
+    `batteryStndChrgPower` is *standard* (AC) charge power. During a DC fast
+    charge it keeps reporting the AC rate, so a Hyundai USA vehicle could never
+    observe a fast charge at all — the field is flat across the one event it is
+    being read for. `realTimePower` is instantaneous, and is already the source
+    used by KiaUvoApiUSA and ApiImplType1 for this same attribute.
+
+    The two values are deliberately different here: with the old key this
+    asserts 10.9 (the vehicle's AC ceiling) instead of 58.7, which is the
+    signature of the bug rather than a rounding difference.
+    """
+    vehicle = Vehicle()
+    state = {
+        "vehicleStatus": {
+            "evStatus": {
+                "batteryCharge": True,
+                "batteryStndChrgPower": 10.9,
+                "realTimePower": 58.7,
+            },
+        },
+    }
+    bluelink_api._update_vehicle_properties(vehicle, state)
+    assert vehicle.ev_charging_power == 58.7
+
+
+def test_bluelink_charging_power_none_when_real_time_power_absent(bluelink_api):
+    """`realTimePower` is absent while idle, so `ev_charging_power` is None.
+
+    Reading `realTimePower` directly — as KiaUvoApiUSA does — returns None when
+    the field is missing, rather than substituting the stale AC rate carried by
+    `batteryStndChrgPower`.
+    """
+    vehicle = Vehicle()
+    state = {
+        "vehicleStatus": {
+            "evStatus": {
+                "batteryCharge": False,
+                "batteryStndChrgPower": 0.0,
+                "realTimePower": None,
+            },
+        },
+    }
+    bluelink_api._update_vehicle_properties(vehicle, state)
+    assert vehicle.ev_charging_power is None
 
 
 def test_bluelink_air_temp_off_yields_none(


### PR DESCRIPTION
## Problem

The Hyundai USA path sources `ev_charging_power` from `vehicleStatus.evStatus.batteryStndChrgPower`, which is *standard* (AC) charge power. It holds the AC rate throughout a DC fast charge, so a Hyundai USA vehicle never observes one — the field is flat across the single event it is being read for.

`realTimePower` sits beside it in the same `evStatus` object and carries the instantaneous rate for both AC and DC charging. It is already the source used by `KiaUvoApiUSA` and by `ApiImplType1` (the CCS2 path) for this same attribute, so this makes the Hyundai USA path agree with its siblings rather than introducing a new field.

## Idle behaviour

`realTimePower` is absent while the vehicle is idle, so `ev_charging_power` is `None` there rather than the stale AC value `batteryStndChrgPower` would report. This matches `KiaUvoApiUSA`, which reads `realTimePower` directly with no fallback.

## Tests

- `test_bluelink_dc_charging_power_reads_real_time_power` — the regression gate. A payload where the two fields deliberately differ; it asserts `58.7` (`realTimePower`) rather than `10.9` (the AC ceiling), so it fails on `master` for the right reason rather than a rounding difference.
- `test_bluelink_charging_power_none_when_real_time_power_absent` — the idle path returns `None`.
- The parametrized `test_ev_charging_power` and the Hyundai USA vehicle snapshot are updated so the idle fixture expects `None`.
