### PR TITLE
fix(EU): detect IdP WAF block on login step 1 and raise a clear error

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -35,6 +35,7 @@ from .const import (
     VALET_MODE_ACTION,
 )
 from .exceptions import (
+    APIError,
     AuthenticationError,
     ConsentRequiredError,
 )
@@ -227,7 +228,25 @@ class KiaUvoApiEU(ApiImplType1):
             f"?response_type=code&client_id={client_id}"
             f"&redirect_uri={redirect_uri}&lang=en&state=ccsp&country=de"
         )
-        s.get(auth_url, allow_redirects=True)
+        r = s.get(auth_url, allow_redirects=True)
+        # The IdP edge/WAF can reject the authorize request before any credential
+        # is sent, redirecting to /error?status=400 with an "abusing request"
+        # body. This is a server-side block on the registered redirect_uri (its
+        # non-standard :8080 port), not a credentials problem — see issue #1273.
+        # Detect it here so we fail with an explicit message instead of the
+        # misleading "Check username and password" raised further down.
+        if (
+            "classified as an abusing request" in r.text
+            or "abusing" in r.url.lower()
+            or "/error?status=400" in r.url
+        ):
+            raise APIError(
+                "The Hyundai/Kia IdP rejected the OAuth authorize request before "
+                "login (server-side WAF: 'abusing request'). This is NOT a "
+                "credentials problem — do not change your password. It is a "
+                "server-side block on the registered redirect_uri. See "
+                "https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1273"
+            )
 
         # Step 2: Get RSA public key for password encryption
         resp = s.get(f"{host}/auth/api/v1/accounts/certs")


### PR DESCRIPTION
Since ~2026-08-11 the EU IdP WAF rejects **step 1** of `_login_with_password()` (`GET /auth/api/v2/user/oauth2/authorize`) **before any credential is sent**, because the registered `redirect_uri` carries a non-standard `:8080` port. The request 302-redirects to `/error?status=400` with an `"abusing request"` body, so no session cookies are set and the later signin bounces back to the login page — surfacing the misleading `AuthenticationError: Check username and password`.

Root cause and reproduction are documented in #1273 (blocked with `:8080`, passes without a port but then the IdP correctly rejects the port-less URI). URL-encoding the colon (`%3A8080`) does **not** bypass it either — the WAF normalises before matching.

### What this PR does
This does **not** fix the login itself (the block is server-side on Hyundai/Kia). It only detects the block right after step 1 and raises an explicit `APIError` instead of the misleading credentials message, so users stop resetting perfectly valid passwords.

- Captures the step-1 response and checks for the `"abusing request"` / `/error?status=400` signal (it surfaces in both `r.text` and the followed `r.url`).
- Raises `APIError` (not `AuthenticationError`) on purpose: it is not a credentials failure and must not trigger retry-on-bad-credentials logic. `APIError` (rather than `ServiceTemporaryUnavailable`) also avoids retry loops hammering a WAF that is already blocking us.
- No behavioural change on the happy path: when step 1 is not blocked, the response is discarded exactly as before.

Refs #1273.