### PR TITLE
fix(eu): CCI login for Genesis + drop dead legacy login

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -156,11 +156,12 @@ class KiaUvoApiEU(ApiImplType1):
                 "https://accounts-eu.genesis.com/realms/eugenesisidm/ga-api/redirect2"
             )
 
-        # OneApp/CCI login flow (EU Hyundai + Kia) — bypasses the IDPConnect WAF
-        # that blocks the legacy 6d477c38/:8080 authorize (#1273). Genesis keeps
-        # the legacy flow (PORT=443, not WAF-affected).
+        # OneApp/CCI login flow (EU Hyundai/Kia/Genesis) — bypasses the IDPConnect
+        # WAF that blocks the legacy authorize by client_id (#1273). All three EU
+        # brands are blocked (Genesis PORT=443 is not spared — the WAF blocks by
+        # client_id, not port).
         self._use_cci_login: bool = False
-        if BRANDS[self.brand] in (BRAND_HYUNDAI, BRAND_KIA):
+        if BRANDS[self.brand] in (BRAND_HYUNDAI, BRAND_KIA, BRAND_GENESIS):
             self._use_cci_login = True
             if BRANDS[self.brand] == BRAND_HYUNDAI:
                 self.ONEAPP_CLIENT_ID: str = "4f4953b5-02e1-4dbc-8599-87e983ee1be5"
@@ -168,12 +169,18 @@ class KiaUvoApiEU(ApiImplType1):
                 self.CCI_API_URL: str = "https://cci-api-eu.hyundai.com"
                 self._cci_package_id: str = "com.hyundai.oneapp.eu"
                 self._cci_client_name: str = "hyundai"
-            else:  # BRAND_KIA
+            elif BRANDS[self.brand] == BRAND_KIA:
                 self.ONEAPP_CLIENT_ID: str = "01b36c86-79e8-486c-8009-15f2ad88d670"
                 self.ONEAPP_REDIRECT_URI: str = "https://oneapp.kia.com/redirect"
                 self.CCI_API_URL: str = "https://cci-api-eu.kia.com"
                 self._cci_package_id: str = "com.kia.oneapp.eu"
                 self._cci_client_name: str = "kia"
+            else:  # BRAND_GENESIS
+                self.ONEAPP_CLIENT_ID: str = "50e3b8b0-ced5-43b7-8a42-f86ac92fe50e"
+                self.ONEAPP_REDIRECT_URI: str = "https://oneapp.genesis.com/redirect"
+                self.CCI_API_URL: str = "https://cci-api-eu.genesis.com"
+                self._cci_package_id: str = "com.genesis.oneapp.eu"
+                self._cci_client_name: str = "genesis"
             self.CCI_DOMAIN_API_URL: str = self.CCI_API_URL + "/domain/api/"
             self._cci_client_version: str = "1.3.3"
             self._cci_client_os_version: str = (

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -159,36 +159,33 @@ class KiaUvoApiEU(ApiImplType1):
         # OneApp/CCI login flow (EU Hyundai/Kia/Genesis) — bypasses the IDPConnect
         # WAF that blocks the legacy authorize by client_id (#1273). All three EU
         # brands are blocked (Genesis PORT=443 is not spared — the WAF blocks by
-        # client_id, not port).
-        self._use_cci_login: bool = False
-        if BRANDS[self.brand] in (BRAND_HYUNDAI, BRAND_KIA, BRAND_GENESIS):
-            self._use_cci_login = True
-            if BRANDS[self.brand] == BRAND_HYUNDAI:
-                self.ONEAPP_CLIENT_ID: str = "4f4953b5-02e1-4dbc-8599-87e983ee1be5"
-                self.ONEAPP_REDIRECT_URI: str = "https://oneapp.hyundai.com/redirect"
-                self.CCI_API_URL: str = "https://cci-api-eu.hyundai.com"
-                self._cci_package_id: str = "com.hyundai.oneapp.eu"
-                self._cci_client_name: str = "hyundai"
-            elif BRANDS[self.brand] == BRAND_KIA:
-                self.ONEAPP_CLIENT_ID: str = "01b36c86-79e8-486c-8009-15f2ad88d670"
-                self.ONEAPP_REDIRECT_URI: str = "https://oneapp.kia.com/redirect"
-                self.CCI_API_URL: str = "https://cci-api-eu.kia.com"
-                self._cci_package_id: str = "com.kia.oneapp.eu"
-                self._cci_client_name: str = "kia"
-            else:  # BRAND_GENESIS
-                self.ONEAPP_CLIENT_ID: str = "50e3b8b0-ced5-43b7-8a42-f86ac92fe50e"
-                self.ONEAPP_REDIRECT_URI: str = "https://oneapp.genesis.com/redirect"
-                self.CCI_API_URL: str = "https://cci-api-eu.genesis.com"
-                self._cci_package_id: str = "com.genesis.oneapp.eu"
-                self._cci_client_name: str = "genesis"
-            self.CCI_DOMAIN_API_URL: str = self.CCI_API_URL + "/domain/api/"
-            self._cci_client_version: str = "1.3.3"
-            self._cci_client_os_version: str = (
-                "27" if BRANDS[self.brand] == BRAND_KIA else "18.7"
-            )
-            self._cci_notification_provider: str = (
-                "IOS_APPSTORE" if BRANDS[self.brand] == BRAND_KIA else "APNS"
-            )
+        # client_id, not port), so all three use the CCI flow.
+        if BRANDS[self.brand] == BRAND_HYUNDAI:
+            self.ONEAPP_CLIENT_ID: str = "4f4953b5-02e1-4dbc-8599-87e983ee1be5"
+            self.ONEAPP_REDIRECT_URI: str = "https://oneapp.hyundai.com/redirect"
+            self.CCI_API_URL: str = "https://cci-api-eu.hyundai.com"
+            self._cci_package_id: str = "com.hyundai.oneapp.eu"
+            self._cci_client_name: str = "hyundai"
+        elif BRANDS[self.brand] == BRAND_KIA:
+            self.ONEAPP_CLIENT_ID: str = "01b36c86-79e8-486c-8009-15f2ad88d670"
+            self.ONEAPP_REDIRECT_URI: str = "https://oneapp.kia.com/redirect"
+            self.CCI_API_URL: str = "https://cci-api-eu.kia.com"
+            self._cci_package_id: str = "com.kia.oneapp.eu"
+            self._cci_client_name: str = "kia"
+        else:  # BRAND_GENESIS
+            self.ONEAPP_CLIENT_ID: str = "50e3b8b0-ced5-43b7-8a42-f86ac92fe50e"
+            self.ONEAPP_REDIRECT_URI: str = "https://oneapp.genesis.com/redirect"
+            self.CCI_API_URL: str = "https://cci-api-eu.genesis.com"
+            self._cci_package_id: str = "com.genesis.oneapp.eu"
+            self._cci_client_name: str = "genesis"
+        self.CCI_DOMAIN_API_URL: str = self.CCI_API_URL + "/domain/api/"
+        self._cci_client_version: str = "1.3.3"
+        self._cci_client_os_version: str = (
+            "27" if BRANDS[self.brand] == BRAND_KIA else "18.7"
+        )
+        self._cci_notification_provider: str = (
+            "IOS_APPSTORE" if BRANDS[self.brand] == BRAND_KIA else "APNS"
+        )
 
         self.session = ApiImplSession()
 
@@ -252,21 +249,17 @@ class KiaUvoApiEU(ApiImplType1):
     def _login_with_password(
         self, username: str, password: str, device_id: str
     ) -> dict:
-        """Headless login using username + plaintext password.
+        """Headless login using username + plaintext password (OneApp/CCI flow).
 
-        EU Hyundai/Kia use the OneApp/CCI flow (client_id 4f4953b5 / 01b36c86)
-        which bypasses the IDPConnect WAF that blocks the legacy 6d477c38
-        authorize with :8080 redirect (#1273). Genesis keeps the legacy flow.
-
-        Returns a dict with access_token, refresh_token, expires_in and — for
-        the CCI flow — the CCI token fields needed for refresh.
+        All EU brands (Hyundai/Kia/Genesis) use the OneApp/CCI flow, which
+        bypasses the IDPConnect WAF that blocks the legacy authorize by client_id
+        (#1273). Returns a dict with access_token, refresh_token, expires_in and
+        the CCI token fields needed for refresh.
 
         Raises:
             AuthenticationError: If login fails.
         """
-        if self._use_cci_login:
-            return self._login_with_password_cci(username, password, device_id)
-        return self._login_with_password_legacy(username, password)
+        return self._login_with_password_cci(username, password, device_id)
 
     def _cci_timezone_offset(self) -> str:
         """Current UTC offset of the EU data timezone as '+HH:MM'."""
@@ -497,132 +490,6 @@ class KiaUvoApiEU(ApiImplType1):
         else:
             ccs_valid_until = dt.datetime.now(dt.UTC) + dt.timedelta(seconds=3600)
         return ccs_token, ccs_valid_until
-
-    def _login_with_password_legacy(self, username: str, password: str) -> dict:
-        """Legacy IDPConnect password login (6d477c38 / fdc85c00).
-
-        Used by Genesis EU (PORT=443, not WAF-affected) and as a fallback.
-        WAF-blocked for Hyundai/Kia (the :8080 redirect is rejected).
-        """
-        host = self.LOGIN_FORM_HOST
-        client_id = self.CCSP_SERVICE_ID
-        client_secret = self.CCS_SERVICE_SECRET
-        redirect_uri = self._oauth_redirect_uri
-
-        # The _CCS_APP_AOS suffix is required — without it, the IDPConnect
-        # authorize endpoint returns "400 Bad Request".
-        mobile_ua = USER_AGENT_MOZILLA + "_CCS_APP_AOS"
-
-        s = ApiImplSession()
-        s.headers.update({"User-Agent": mobile_ua})
-
-        # Step 1: Load authorize page to get session cookies
-        auth_url = (
-            f"{host}/auth/api/v2/user/oauth2/authorize"
-            f"?response_type=code&client_id={client_id}"
-            f"&redirect_uri={redirect_uri}&lang=en&state=ccsp&country=de"
-        )
-        s.get(auth_url, allow_redirects=True)
-
-        # Step 2: Get RSA public key for password encryption
-        resp = s.get(f"{host}/auth/api/v1/accounts/certs")
-        if resp.status_code != 200:
-            raise AuthenticationError(
-                f"API error: failed to fetch RSA certs: HTTP {resp.status_code}. "
-                "This may indicate a Hyundai API change."
-            )
-        jwk = resp.json().get("retValue", {})
-        kid = jwk.get("kid", "")
-
-        # Convert JWK to RSA key
-        n_bytes = base64.urlsafe_b64decode(jwk["n"] + "==")
-        e_bytes = base64.urlsafe_b64decode(jwk["e"] + "==")
-        n = int.from_bytes(n_bytes, "big")
-        e = int.from_bytes(e_bytes, "big")
-        key = RSA.construct((n, e))
-        cipher = PKCS1_v1_5.new(key)
-        encrypted_pw = cipher.encrypt(password.encode("utf-8")).hex()
-
-        # Step 3: POST signin with encrypted password
-        resp = s.post(
-            f"{host}/auth/account/signin",
-            data={
-                "client_id": client_id,
-                "encryptedPassword": "true",
-                "password": encrypted_pw,
-                "redirect_uri": redirect_uri,
-                "scope": "",
-                "nonce": "",
-                "state": "ccsp",
-                "username": username,
-                "connector_session_key": "",
-                "kid": kid,
-                "_csrf": "",
-            },
-            allow_redirects=False,
-        )
-
-        if resp.status_code != 302:
-            raise AuthenticationError(
-                f"Signin failed: HTTP {resp.status_code} — {resp.text[:300]}. "
-                "Check username and password."
-            )
-
-        location = resp.headers.get("location", "")
-        code_list = parse_qs(urlparse(location).query).get("code")
-        if not code_list:
-            if "error" in location.lower():
-                error_desc = parse_qs(urlparse(location).query).get(
-                    "error_description", ["unknown"]
-                )[0]
-                raise AuthenticationError(
-                    f"Authentication rejected: {error_desc}. "
-                    "Check username and password."
-                )
-            if "/web/v1/user/authorization" in location:
-                raise ConsentRequiredError(
-                    "Account consent is required. Please log in via a browser "
-                    "once to accept the terms, then use the refresh token."
-                )
-            if "authorize" in location:
-                raise AuthenticationError(
-                    "Authentication failed — returned to login page. "
-                    "Check username and password."
-                )
-            raise AuthenticationError(
-                f"API error: unexpected redirect after signin: {location[:250]}"
-            )
-
-        code = code_list[0]
-
-        # Step 4: Exchange authorization code for tokens
-        resp = s.post(
-            f"{host}/auth/api/v2/user/oauth2/token",
-            data={
-                "grant_type": "authorization_code",
-                "code": code,
-                "redirect_uri": redirect_uri,
-                "client_id": client_id,
-                "client_secret": client_secret,
-            },
-        )
-
-        if resp.status_code != 200:
-            raise AuthenticationError(
-                f"API error: token exchange failed: HTTP {resp.status_code} — "
-                f"{resp.text[:200]}. This may indicate a Hyundai API change."
-            )
-
-        tokens = resp.json()
-        access_token = tokens["token_type"] + " " + tokens["access_token"]
-        refresh_token = tokens["refresh_token"]
-        expires_in = int(tokens.get("expires_in", 86400))
-
-        return {
-            "access_token": access_token,
-            "refresh_token": refresh_token,
-            "expires_in": expires_in,
-        }
 
     def refresh_access_token(self, token: Token) -> Token:
         """Refresh access token using the stored refresh token.

--- a/tests/test_headless_login.py
+++ b/tests/test_headless_login.py
@@ -431,6 +431,49 @@ def test_login_genesis_password_fails_falls_back_to_error():
         api.login("user@test.com", "MyPassword123!")
 
 
+def test_genesis_uses_cci_login_constants():
+    """Genesis EU has OneApp/CCI constants and _use_cci_login=True (WAF bypass)."""
+    api = _make_eu_api(brand=3)  # Genesis
+    assert api._use_cci_login is True
+    assert api.ONEAPP_CLIENT_ID == "50e3b8b0-ced5-43b7-8a42-f86ac92fe50e"
+    assert api.ONEAPP_REDIRECT_URI == "https://oneapp.genesis.com/redirect"
+    assert api.CCI_API_URL == "https://cci-api-eu.genesis.com"
+    assert api.CCI_DOMAIN_API_URL == "https://cci-api-eu.genesis.com/domain/api/"
+    assert api._cci_package_id == "com.genesis.oneapp.eu"
+    assert api._cci_client_name == "genesis"
+
+
+def test_genesis_login_routes_to_login_with_password_with_device_id():
+    """Genesis _login_with_password routes to the CCI flow (not legacy)."""
+    api = _make_eu_api(brand=3)  # Genesis
+
+    cci_return = {
+        "access_token": "Bearer genesis-ccs-token",
+        "refresh_token": "GENESISCCIREFRESHTOKEN1234567890123456789012345678901234567890",
+        "expires_in": 3600,
+        "valid_until": dt.datetime.now(dt.UTC) + dt.timedelta(hours=1),
+        "cci_access_token": "genesis-cci-at",
+        "exchangeable_token": "genesis-exch",
+        "exchangeable_refresh_token": "genesis-exch-rt",
+        "non_ccs_token": "genesis-nonccs",
+        "non_ccs_refresh_token": "genesis-nonccs-rt",
+        "id_token": "genesis-id",
+    }
+    with (
+        patch.object(
+            api, "_login_with_password_cci", return_value=cci_return
+        ) as mock_cci,
+        patch.object(api, "_login_with_password_legacy") as mock_legacy,
+    ):
+        result = api._login_with_password(
+            "user@test.com", "MyPassword123!", "device-123"
+        )
+
+    mock_cci.assert_called_once_with("user@test.com", "MyPassword123!", "device-123")
+    mock_legacy.assert_not_called()
+    assert result is cci_return
+
+
 # ── refresh_access_token() tests ───────────────────────────────
 
 

--- a/tests/test_headless_login.py
+++ b/tests/test_headless_login.py
@@ -10,8 +10,7 @@ from hyundai_kia_connect_api.exceptions import AuthenticationError, ConsentRequi
 from hyundai_kia_connect_api.KiaUvoApiEU import KiaUvoApiEU
 from hyundai_kia_connect_api.Token import Token
 
-# ── Helper: patches for _login_with_password() tests ─────────────
-# RSA/PKCS1v15 crypto is not under test, so we mock it out.
+# ── Helpers ─────────────────────────────────────────────────────
 
 
 def _mock_crypto():
@@ -32,95 +31,86 @@ def _make_eu_api(brand: int = 1) -> KiaUvoApiEU:
     return KiaUvoApiEU(region=1, brand=brand, language="en")
 
 
-# ── _login_with_password() error paths ──────────────────────────
+def _certs_response() -> MagicMock:
+    """A 200 certs response with a fake JWK."""
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {
+        "retValue": {
+            "kid": "test-kid",
+            "n": "AJRQISPa0AJRQISPa0AJRQISPa0AJRQISPa0AJRQISPa0A",
+            "e": "AQAB",
+        }
+    }
+    return resp
+
+
+def _cci_session(certs_resp: MagicMock, signin_resp: MagicMock) -> MagicMock:
+    """A mock ApiImplSession for CCI login steps 1-3 (authorize, certs, signin).
+
+    The authorize response is a non-WAF page (empty text, clean url) so the
+    WAF-detection check in _login_with_password_cci does not trigger.
+    """
+    authorize_resp = MagicMock(text="", url="https://idpconnect-eu.kia.com/authorize")
+    session = MagicMock()
+    session.get.side_effect = [authorize_resp, certs_resp]
+    session.post.return_value = signin_resp
+    return session
+
+
+def _signin_resp(location: str) -> MagicMock:
+    """A 302 signin response with the given Location header."""
+    resp = MagicMock(status_code=302)
+    resp.headers = {"location": location}
+    return resp
+
+
+# ── _login_with_password_cci() error paths ─────────────────────
 
 
 def test_login_with_password_certs_endpoint_fails():
     """Certs endpoint returns non-200 -> AuthenticationError."""
     api = _make_eu_api(brand=1)
-
-    mock_response = MagicMock()
-    mock_response.status_code = 500
-
-    mock_session = MagicMock()
-    mock_session.get.return_value = mock_response
-
     with ExitStack() as stack:
         stack.enter_context(
             patch(
                 "hyundai_kia_connect_api.KiaUvoApiEU.ApiImplSession",
-                return_value=mock_session,
+                return_value=_cci_session(MagicMock(status_code=500), MagicMock()),
             )
         )
         for p in _mock_crypto():
             stack.enter_context(p)
         with pytest.raises(AuthenticationError, match="failed to fetch RSA certs"):
-            api._login_with_password_legacy("user@test.com", "password")
+            api._login_with_password_cci("user@test.com", "password", "device-1")
 
 
 def test_login_with_password_signin_returns_non_302():
-    """Signin endpoint returns 200 instead of 302 -> AuthenticationError."""
+    """Signin returns 200 instead of 302 -> AuthenticationError."""
     api = _make_eu_api(brand=1)
-
-    certs_resp = MagicMock()
-    certs_resp.status_code = 200
-    certs_resp.json.return_value = {
-        "retValue": {
-            "kid": "test-kid",
-            "n": "AJRQISPa0AJRQISPa0AJRQISPa0AJRQISPa0AJRQISPa0A",
-            "e": "AQAB",
-        }
-    }
-
-    signin_resp = MagicMock()
-    signin_resp.status_code = 200
-    signin_resp.text = "Login page"
-
-    mock_session = MagicMock()
-    # _login_with_password calls s.get() twice (authorize, certs) then s.post() (signin)
-    mock_session.get.side_effect = [MagicMock(), certs_resp]
-    mock_session.post.return_value = signin_resp
-
+    signin_resp = MagicMock(status_code=200, text="Login page")
     with ExitStack() as stack:
         stack.enter_context(
             patch(
                 "hyundai_kia_connect_api.KiaUvoApiEU.ApiImplSession",
-                return_value=mock_session,
+                return_value=_cci_session(_certs_response(), signin_resp),
             )
         )
         for p in _mock_crypto():
             stack.enter_context(p)
         with pytest.raises(AuthenticationError, match="Signin failed"):
-            api._login_with_password_legacy("user@test.com", "password")
+            api._login_with_password_cci("user@test.com", "password", "device-1")
 
 
 def test_login_with_password_signin_no_code_in_redirect():
     """Signin redirect has no code parameter -> AuthenticationError."""
     api = _make_eu_api(brand=1)
-
-    certs_resp = MagicMock()
-    certs_resp.status_code = 200
-    certs_resp.json.return_value = {
-        "retValue": {
-            "kid": "test-kid",
-            "n": "AJRQISPa0AJRQISPa0AJRQISPa0AJRQISPa0AJRQISPa0A",
-            "e": "AQAB",
-        }
-    }
-
-    signin_resp = MagicMock()
-    signin_resp.status_code = 302
-    signin_resp.headers = {"location": "https://example.com/login?no_code=true"}
-
-    mock_session = MagicMock()
-    mock_session.get.side_effect = [MagicMock(), certs_resp]
-    mock_session.post.return_value = signin_resp
-
     with ExitStack() as stack:
         stack.enter_context(
             patch(
                 "hyundai_kia_connect_api.KiaUvoApiEU.ApiImplSession",
-                return_value=mock_session,
+                return_value=_cci_session(
+                    _certs_response(),
+                    _signin_resp("https://example.com/login?no_code=true"),
+                ),
             )
         )
         for p in _mock_crypto():
@@ -128,209 +118,169 @@ def test_login_with_password_signin_no_code_in_redirect():
         with pytest.raises(
             AuthenticationError, match="unexpected redirect after signin"
         ):
-            api._login_with_password_legacy("user@test.com", "password")
+            api._login_with_password_cci("user@test.com", "password", "device-1")
 
 
 def test_login_with_password_signin_error_in_redirect():
     """Signin redirect contains error parameter -> AuthenticationError."""
     api = _make_eu_api(brand=1)
-
-    certs_resp = MagicMock()
-    certs_resp.status_code = 200
-    certs_resp.json.return_value = {
-        "retValue": {
-            "kid": "test-kid",
-            "n": "AJRQISPa0AJRQISPa0AJRQISPa0AJRQISPa0AJRQISPa0A",
-            "e": "AQAB",
-        }
-    }
-
-    signin_resp = MagicMock()
-    signin_resp.status_code = 302
-    signin_resp.headers = {
-        "location": (
-            "https://example.com/callback?error=access_denied"
-            "&error_description=Invalid+credentials"
-        )
-    }
-
-    mock_session = MagicMock()
-    mock_session.get.side_effect = [MagicMock(), certs_resp]
-    mock_session.post.return_value = signin_resp
-
     with ExitStack() as stack:
         stack.enter_context(
             patch(
                 "hyundai_kia_connect_api.KiaUvoApiEU.ApiImplSession",
-                return_value=mock_session,
+                return_value=_cci_session(
+                    _certs_response(),
+                    _signin_resp(
+                        "https://example.com/callback?error=access_denied"
+                        "&error_description=Invalid+credentials"
+                    ),
+                ),
             )
         )
         for p in _mock_crypto():
             stack.enter_context(p)
         with pytest.raises(AuthenticationError, match="Authentication rejected"):
-            api._login_with_password_legacy("user@test.com", "wrong-password")
+            api._login_with_password_cci("user@test.com", "wrong-password", "device-1")
 
 
 def test_login_with_password_signin_redirect_to_login_page():
     """Signin redirects back to authorize page -> AuthenticationError."""
     api = _make_eu_api(brand=1)
-
-    certs_resp = MagicMock()
-    certs_resp.status_code = 200
-    certs_resp.json.return_value = {
-        "retValue": {
-            "kid": "test-kid",
-            "n": "AJRQISPa0AJRQISPa0AJRQISPa0AJRQISPa0AJRQISPa0A",
-            "e": "AQAB",
-        }
-    }
-
-    signin_resp = MagicMock()
-    signin_resp.status_code = 302
-    signin_resp.headers = {
-        "location": (
-            "https://idpconnect-eu.kia.com/auth/api/v2/user/oauth2/authorize?state=ccsp"
-        )
-    }
-
-    mock_session = MagicMock()
-    mock_session.get.side_effect = [MagicMock(), certs_resp]
-    mock_session.post.return_value = signin_resp
-
     with ExitStack() as stack:
         stack.enter_context(
             patch(
                 "hyundai_kia_connect_api.KiaUvoApiEU.ApiImplSession",
-                return_value=mock_session,
+                return_value=_cci_session(
+                    _certs_response(),
+                    _signin_resp(
+                        "https://idpconnect-eu.kia.com/auth/api/v2/user/oauth2/authorize?state=ccsp"
+                    ),
+                ),
             )
         )
         for p in _mock_crypto():
             stack.enter_context(p)
         with pytest.raises(AuthenticationError, match="returned to login page"):
-            api._login_with_password_legacy("user@test.com", "password")
+            api._login_with_password_cci("user@test.com", "password", "device-1")
 
 
 def test_login_with_password_signin_consent_spa_redirect():
-    """Kia EU redirects to /web/v1/user/authorization SPA (consent page)."""
+    """Signin redirects to /web/v1/user/authorization SPA (consent page)."""
     api = _make_eu_api(brand=1)
-
-    certs_resp = MagicMock()
-    certs_resp.status_code = 200
-    certs_resp.json.return_value = {
-        "retValue": {
-            "kid": "test-kid",
-            "n": "AJRQISPa0AJRQISPa0AJRQISPa0AJRQISPa0AJRQISPa0A",
-            "e": "AQAB",
-        }
-    }
-
-    signin_resp = MagicMock()
-    signin_resp.status_code = 302
-    signin_resp.headers = {
-        "location": "https://prd.eu-ccapi.kia.com:8080/web/v1/user/authorization"
-    }
-
-    mock_session = MagicMock()
-    mock_session.get.side_effect = [MagicMock(), certs_resp]
-    mock_session.post.return_value = signin_resp
-
     with ExitStack() as stack:
         stack.enter_context(
             patch(
                 "hyundai_kia_connect_api.KiaUvoApiEU.ApiImplSession",
-                return_value=mock_session,
+                return_value=_cci_session(
+                    _certs_response(),
+                    _signin_resp(
+                        "https://prd.eu-ccapi.kia.com/web/v1/user/authorization"
+                    ),
+                ),
             )
         )
         for p in _mock_crypto():
             stack.enter_context(p)
         with pytest.raises(ConsentRequiredError, match="consent is required"):
-            api._login_with_password_legacy("user@test.com", "password")
+            api._login_with_password_cci("user@test.com", "password", "device-1")
 
 
-def test_login_with_password_token_exchange_fails():
-    """Token exchange returns non-200 -> AuthenticationError."""
+def test_login_with_password_waf_block_detected():
+    """Authorize returns the WAF block page -> AuthenticationError with #1273 ref."""
     api = _make_eu_api(brand=1)
-
-    certs_resp = MagicMock()
-    certs_resp.status_code = 200
-    certs_resp.json.return_value = {
-        "retValue": {
-            "kid": "test-kid",
-            "n": "AJRQISPa0AJRQISPa0AJRQISPa0AJRQISPa0AJRQISPa0A",
-            "e": "AQAB",
-        }
-    }
-
-    signin_resp = MagicMock()
-    signin_resp.status_code = 302
-    signin_resp.headers = {"location": "https://example.com/callback?code=abc123"}
-
-    token_resp = MagicMock()
-    token_resp.status_code = 400
-    token_resp.text = "Bad request"
-
-    mock_session = MagicMock()
-    mock_session.get.side_effect = [MagicMock(), certs_resp]
-    mock_session.post.side_effect = [signin_resp, token_resp]
-
+    authorize_resp = MagicMock(
+        text="It was classified as an abusing request and blocked",
+        url="https://idpconnect-eu.kia.com/error?status=400",
+    )
+    session = MagicMock()
+    session.get.return_value = authorize_resp
     with ExitStack() as stack:
         stack.enter_context(
             patch(
                 "hyundai_kia_connect_api.KiaUvoApiEU.ApiImplSession",
-                return_value=mock_session,
+                return_value=session,
             )
         )
         for p in _mock_crypto():
             stack.enter_context(p)
-        with pytest.raises(AuthenticationError, match="token exchange failed"):
-            api._login_with_password_legacy("user@test.com", "password")
+        with pytest.raises(AuthenticationError, match="abusing request"):
+            api._login_with_password_cci("user@test.com", "password", "device-1")
+
+
+def test_login_with_password_cci_token_exchange_fails():
+    """CCI token endpoint returns non-200 -> AuthenticationError."""
+    api = _make_eu_api(brand=1)
+    token_resp = MagicMock(status_code=400, text="Bad request")
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                "hyundai_kia_connect_api.KiaUvoApiEU.ApiImplSession",
+                return_value=_cci_session(
+                    _certs_response(),
+                    _signin_resp("https://example.com/cb?code=abc123"),
+                ),
+            )
+        )
+        for p in _mock_crypto():
+            stack.enter_context(p)
+        stack.enter_context(
+            patch(
+                "hyundai_kia_connect_api.KiaUvoApiEU.requests.post",
+                return_value=token_resp,
+            )
+        )
+        with pytest.raises(AuthenticationError, match="CCI token exchange failed"):
+            api._login_with_password_cci("user@test.com", "password", "device-1")
 
 
 def test_login_with_password_success():
-    """Full successful _login_with_password flow returns correct tokens."""
+    """Full CCI login flow returns access_token, refresh_token and CCI fields."""
     api = _make_eu_api(brand=2)  # Hyundai
-
-    certs_resp = MagicMock()
-    certs_resp.status_code = 200
-    certs_resp.json.return_value = {
-        "retValue": {
-            "kid": "test-kid",
-            "n": "AJRQISPa0AJRQISPa0AJRQISPa0AJRQISPa0AJRQISPa0A",
-            "e": "AQAB",
-        }
+    cci_token_resp = MagicMock(status_code=200)
+    cci_token_resp.json.return_value = {
+        "accessToken": "cci-access",
+        "refreshToken": "CCIREFRESHTOKEN1234567890123456789012345678901234567890",
+        "exchangeableAccessToken": "exch-at",
+        "exchangeableRefreshToken": "exch-rt",
+        "nonCcsToken": "nonccs",
+        "nonCcsRefreshToken": "nonccs-rt",
+        "idToken": "id-tok",
+        "expiresIn": 3599,
     }
-
-    signin_resp = MagicMock()
-    signin_resp.status_code = 302
-    signin_resp.headers = {"location": "https://example.com/callback?code=abc123"}
-
-    token_resp = MagicMock()
-    token_resp.status_code = 200
-    token_resp.json.return_value = {
-        "token_type": "Bearer",
-        "access_token": "test-access-token",
-        "refresh_token": "TESTRFTOKEN12345678901234567890123456789012345678",
-        "expires_in": 86400,
+    exchange_resp = MagicMock(status_code=200)
+    exchange_resp.json.return_value = {
+        "accessToken": "ccs-token",
+        "expiresTime": 9999999999999,
     }
-
-    mock_session = MagicMock()
-    mock_session.get.side_effect = [MagicMock(), certs_resp]
-    mock_session.post.side_effect = [signin_resp, token_resp]
-
     with ExitStack() as stack:
         stack.enter_context(
             patch(
                 "hyundai_kia_connect_api.KiaUvoApiEU.ApiImplSession",
-                return_value=mock_session,
+                return_value=_cci_session(
+                    _certs_response(),
+                    _signin_resp("https://example.com/cb?code=abc123"),
+                ),
             )
         )
         for p in _mock_crypto():
             stack.enter_context(p)
-        info = api._login_with_password_legacy("user@test.com", "password")
+        stack.enter_context(
+            patch(
+                "hyundai_kia_connect_api.KiaUvoApiEU.requests.post",
+                side_effect=[cci_token_resp, exchange_resp],
+            )
+        )
+        info = api._login_with_password_cci("user@test.com", "password", "device-1")
 
-    assert info["access_token"] == "Bearer test-access-token"
-    assert info["refresh_token"] == "TESTRFTOKEN12345678901234567890123456789012345678"
-    assert info["expires_in"] == 86400
+    assert info["access_token"] == "Bearer ccs-token"
+    assert (
+        info["refresh_token"]
+        == "CCIREFRESHTOKEN1234567890123456789012345678901234567890"
+    )
+    assert info["cci_access_token"] == "cci-access"
+    assert info["exchangeable_token"] == "exch-at"
+    assert info["non_ccs_token"] == "nonccs"
+    assert info["id_token"] == "id-tok"
 
 
 # ── KiaUvoApiEU.login() flow routing ────────────────────────
@@ -361,7 +311,7 @@ def test_login_refresh_token_flow():
 
 
 def test_login_plaintext_password_calls_login_with_password():
-    """Plaintext password for Kia invokes _login_with_password()."""
+    """Plaintext password invokes _login_with_password(user, pw, device_id)."""
     api = _make_eu_api(brand=1)  # Kia
 
     with (
@@ -432,9 +382,8 @@ def test_login_genesis_password_fails_falls_back_to_error():
 
 
 def test_genesis_uses_cci_login_constants():
-    """Genesis EU has OneApp/CCI constants and _use_cci_login=True (WAF bypass)."""
+    """Genesis EU has the OneApp/CCI constants (WAF bypass)."""
     api = _make_eu_api(brand=3)  # Genesis
-    assert api._use_cci_login is True
     assert api.ONEAPP_CLIENT_ID == "50e3b8b0-ced5-43b7-8a42-f86ac92fe50e"
     assert api.ONEAPP_REDIRECT_URI == "https://oneapp.genesis.com/redirect"
     assert api.CCI_API_URL == "https://cci-api-eu.genesis.com"
@@ -444,7 +393,7 @@ def test_genesis_uses_cci_login_constants():
 
 
 def test_genesis_login_routes_to_login_with_password_with_device_id():
-    """Genesis _login_with_password routes to the CCI flow (not legacy)."""
+    """Genesis _login_with_password delegates to the CCI flow with device_id."""
     api = _make_eu_api(brand=3)  # Genesis
 
     cci_return = {
@@ -459,18 +408,14 @@ def test_genesis_login_routes_to_login_with_password_with_device_id():
         "non_ccs_refresh_token": "genesis-nonccs-rt",
         "id_token": "genesis-id",
     }
-    with (
-        patch.object(
-            api, "_login_with_password_cci", return_value=cci_return
-        ) as mock_cci,
-        patch.object(api, "_login_with_password_legacy") as mock_legacy,
-    ):
+    with patch.object(
+        api, "_login_with_password_cci", return_value=cci_return
+    ) as mock_cci:
         result = api._login_with_password(
             "user@test.com", "MyPassword123!", "device-123"
         )
 
     mock_cci.assert_called_once_with("user@test.com", "MyPassword123!", "device-123")
-    mock_legacy.assert_not_called()
     assert result is cci_return
 
 


### PR DESCRIPTION
## What

Two changes, both enabled by Genesis joining the CCI flow:

### 1. CCI login for Genesis (fixes Genesis EU login — WAF-blocked like Hyundai/Kia)

Genesis EU legacy authorize (`client_id 3020afa2`, PORT=443) is WAF-blocked the same way as Hyundai/Kia — the IDPConnect WAF blocks by `client_id`, not port. PR #1277 covered Hyundai+Kia but left Genesis on the legacy flow (wrong assumption that PORT=443 was spared).

Extend the OneApp/CCI flow to Genesis: `client_id 50e3b8b0`, `oneapp.genesis.com/redirect`, `cci-api-eu.genesis.com`. The CCS token is accepted by the existing legacy `prd-eu-ccapi.genesis.com:443` vehicle endpoints, so no vehicle/control changes.

### 2. Drop dead legacy login (now that all EU brands use CCI)

With Genesis on CCI, all three EU brands log in via `_login_with_password_cci`, so the brand-conditional guard (`_use_cci_login`) and `_login_with_password_legacy` are dead code — removed:
- `_login_with_password` always delegates to `_login_with_password_cci`.
- `_login_with_password_legacy` deleted.
- `_use_cci_login` flag + the `BRANDS[...] in (...)` guard deleted; CCI constants set unconditionally per brand.

**Kept:** `_get_access_token` (legacy 48-char refresh_token grant) — still used by the 48-char refresh path in `login()`/`refresh_access_token()` for backward compat with pre-WAF persisted tokens.

## Verification

- **Live-verified Genesis** login + `refresh_access_token` via `VehicleManager` (account has a Hyundai + Genesis login; 0 Genesis vehicles — auth+token+refresh OK). Re-verified after the cleanup.
- `ruff check` + `ruff format` clean (all 78 tracked files).
- `pytest`: 531 passed, 15 snapshots passed.
- cdnninja-style self-audit (8-point): surgical (EU only), no dead code (legacy login removed, 48-char refresh kept), typed exceptions preserved, pattern conformance (reuses brand-agnostic CCI methods).

## Tests

- Legacy error-path tests repurposed to `_login_with_password_cci` (steps 1-3 are identical), plus a new WAF-block-detection test for the CCI authorize step.
- Routing + refresh tests unchanged.

Fixes #1273 (Genesis). Follow-up to #1277 (Hyundai+Kia).