### PR TITLE
fix(eu): CCS token expiresTime is a TTL in seconds, not a ms epoch

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -481,11 +481,12 @@ class KiaUvoApiEU(ApiImplType1):
             raise AuthenticationError(
                 f"CCS token exchange returned no accessToken: {resp.text[:200]}"
             )
-        # expiresTime is a ms epoch when present; fall back to +1h.
-        expires_ms = data.get("expiresTime")
-        if expires_ms:
-            ccs_valid_until = dt.datetime.fromtimestamp(
-                int(expires_ms) / 1000, tz=dt.UTC
+        # expiresTime is the CCS token TTL in seconds (e.g. 86400 = 24h), not an
+        # epoch. Treat it as a relative duration from now; fall back to +1h.
+        expires_in = data.get("expiresTime")
+        if expires_in:
+            ccs_valid_until = dt.datetime.now(dt.UTC) + dt.timedelta(
+                seconds=int(expires_in)
             )
         else:
             ccs_valid_until = dt.datetime.now(dt.UTC) + dt.timedelta(seconds=3600)

--- a/tests/test_headless_login.py
+++ b/tests/test_headless_login.py
@@ -250,7 +250,7 @@ def test_login_with_password_success():
     exchange_resp = MagicMock(status_code=200)
     exchange_resp.json.return_value = {
         "accessToken": "ccs-token",
-        "expiresTime": 9999999999999,
+        "expiresTime": 86400,
     }
     with ExitStack() as stack:
         stack.enter_context(
@@ -281,6 +281,11 @@ def test_login_with_password_success():
     assert info["exchangeable_token"] == "exch-at"
     assert info["non_ccs_token"] == "nonccs"
     assert info["id_token"] == "id-tok"
+    # expiresTime is a TTL in seconds (86400 = 24h), so valid_until is ~24h
+    # from now — not an epoch in 1970.
+    now = dt.datetime.now(dt.UTC)
+    assert info["valid_until"] > now
+    assert (info["valid_until"] - now).total_seconds() == pytest.approx(86400, abs=5)
 
 
 # ── KiaUvoApiEU.login() flow routing ────────────────────────


### PR DESCRIPTION
## Bug

The CCS token-exchange response's `expiresTime` field is a **relative TTL in seconds** (e.g. `86400` = 24h, matching the CCS access token JWT `exp - iat`), **not a millisecond epoch**.

`_exchange_ccs_token` (added in #1277, present in #1278) treated it as ms:

```python
ccs_valid_until = dt.datetime.fromtimestamp(int(expires_ms) / 1000, tz=dt.UTC)
```

`int(86400) / 1000 = 86.4` → `fromtimestamp(86.4)` = **1970-01-01**. So every refresh-issued CCS token's `valid_until` landed in 1970 — the token always looked expired, and the coordinator refreshed on **every API call** instead of roughly once per hour.

## Fix

`expiresTime` is a duration from now:

```python
expires_in = data.get("expiresTime")
ccs_valid_until = dt.datetime.now(dt.UTC) + dt.timedelta(seconds=int(expires_in))
```

## Verification

- Live: `valid_until` is now `+24h`, `expired=False` (was 1970).
- `ruff check` + `ruff format` clean (all 78 tracked files).
- `pytest`: 531 passed, 15 snapshots.
- Added a `valid_until` assertion to the CCI success test (mock `expiresTime: 86400` → valid_until ~24h from now, not 1970).

Follow-up to #1277 / #1278. This was missed in #1278 (the fix commit landed on the branch after it merged).