### PR TITLE
feat(EU): Add EV battery state of health percentage retrieval

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -872,6 +872,9 @@ class KiaUvoApiEU(ApiImplType1):
         vehicle.ev_battery_percentage = get_child_value(
             state, "vehicleStatus.evStatus.batteryStatus"
         )
+        vehicle.ev_battery_soh_percentage = get_child_value(
+            state, "vehicleStatus.evStatus.batterySoh"
+        )
         vehicle.ev_battery_is_charging = get_child_value(
             state, "vehicleStatus.evStatus.batteryCharge"
         )


### PR DESCRIPTION
Adds the ability to retrieve the EV battery's State of Health (SoH) as a percentage for Europe. Everything was already there; the value simply needed to be retrieved.