### PR TITLE
fix(BR): surface 4xx body on /spa/vehicles instead of raw HTTPError

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
@@ -12,7 +12,7 @@ from urllib.parse import parse_qs, urljoin, urlparse
 from requests import Response
 
 from .ApiImpl import ApiImplSession, ClimateRequestOptions, WindowRequestOptions
-from .ApiImplType1 import ApiImplType1
+from .ApiImplType1 import ApiImplType1, _check_response_for_errors
 from .const import (
     BRAND_HYUNDAI,
     BRANDS,
@@ -150,6 +150,43 @@ class HyundaiBlueLinkApiBR(ApiImplType1):
             f"(keys={sorted(data.keys())})"
         )
 
+    def _raise_api_error(self, response: Response, context: str) -> None:
+        """Surface a readable API error for non-2xx BR SPA responses.
+
+        Counterpart of ``_raise_auth_error`` for non-auth endpoints (vehicles,
+        cached status): reads the body and raises ``APIError`` — or a typed
+        subclass via the SPA-envelope classifier — instead of a raw
+        ``HTTPError``, so the config flow / logs show *why* the server rejected
+        the request (kia_uvo #1846 / #1395: ``/spa/vehicles`` returned a bare
+        ``400 Bad Request`` with the body discarded). No-op for status < 400.
+        """
+        if response.status_code < 400:
+            return
+        try:
+            data = response.json()
+        except ValueError:
+            snippet = (response.text or "")[:200]
+            raise APIError(
+                f"Brazilian Hyundai {context} failed: HTTP {response.status_code}. "
+                f"Response not JSON: {snippet!r}"
+            ) from None
+        # SPA envelope (retCode/resCode/resMsg) → reuse the typed classifier
+        # (DeviceIDError, DuplicateRequestError, ServiceTemporaryUnavailable, …)
+        # so callers keep the existing retry / re-auth semantics.
+        if any(k in data for k in ("retCode", "resCode", "resMsg")):
+            _check_response_for_errors(data)
+        err_code = data.get("errCode") or data.get("errorCode")
+        err_msg = data.get("errMsg") or data.get("errorMessage")
+        if err_code or err_msg:
+            raise APIError(
+                f"Brazilian Hyundai {context} failed: "
+                f"errCode={err_code!r}, errMsg={err_msg!r}"
+            )
+        raise APIError(
+            f"Brazilian Hyundai {context} failed: HTTP {response.status_code} "
+            f"(keys={sorted(data.keys())})"
+        )
+
     def _get_cookies(self) -> dict:
         """Request cookies from the API for authentication."""
         params = {
@@ -272,7 +309,7 @@ class HyundaiBlueLinkApiBR(ApiImplType1):
         headers = self._get_authenticated_headers(token)
 
         response = self.session.get(url, headers=headers)
-        response.raise_for_status()
+        self._raise_api_error(response, "get vehicles")
         response_data = response.json()
         _LOGGER.debug(f"{DOMAIN} - Got vehicles response")
         if "resMsg" not in response_data or "vehicles" not in response_data.get(
@@ -319,7 +356,7 @@ class HyundaiBlueLinkApiBR(ApiImplType1):
         url = self._build_api_url(f"/spa/vehicles/{vehicle.id}/ccs2/carstatus/latest")
         headers = self._get_authenticated_headers(token)
         response = self.session.get(url, headers=headers)
-        response.raise_for_status()
+        self._raise_api_error(response, "cached status")
         return response.json()["resMsg"]["state"]["Vehicle"]
 
     def update_vehicle_with_cached_state(self, token: Token, vehicle: Vehicle) -> None:

--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
@@ -150,43 +150,6 @@ class HyundaiBlueLinkApiBR(ApiImplType1):
             f"(keys={sorted(data.keys())})"
         )
 
-    def _raise_api_error(self, response: Response, context: str) -> None:
-        """Surface a readable API error for non-2xx BR SPA responses.
-
-        Counterpart of ``_raise_auth_error`` for non-auth endpoints (vehicles,
-        cached status): reads the body and raises ``APIError`` — or a typed
-        subclass via the SPA-envelope classifier — instead of a raw
-        ``HTTPError``, so the config flow / logs show *why* the server rejected
-        the request (kia_uvo #1846 / #1395: ``/spa/vehicles`` returned a bare
-        ``400 Bad Request`` with the body discarded). No-op for status < 400.
-        """
-        if response.status_code < 400:
-            return
-        try:
-            data = response.json()
-        except ValueError:
-            snippet = (response.text or "")[:200]
-            raise APIError(
-                f"Brazilian Hyundai {context} failed: HTTP {response.status_code}. "
-                f"Response not JSON: {snippet!r}"
-            ) from None
-        # SPA envelope (retCode/resCode/resMsg) → reuse the typed classifier
-        # (DeviceIDError, DuplicateRequestError, ServiceTemporaryUnavailable, …)
-        # so callers keep the existing retry / re-auth semantics.
-        if any(k in data for k in ("retCode", "resCode", "resMsg")):
-            _check_response_for_errors(data)
-        err_code = data.get("errCode") or data.get("errorCode")
-        err_msg = data.get("errMsg") or data.get("errorMessage")
-        if err_code or err_msg:
-            raise APIError(
-                f"Brazilian Hyundai {context} failed: "
-                f"errCode={err_code!r}, errMsg={err_msg!r}"
-            )
-        raise APIError(
-            f"Brazilian Hyundai {context} failed: HTTP {response.status_code} "
-            f"(keys={sorted(data.keys())})"
-        )
-
     def _get_cookies(self) -> dict:
         """Request cookies from the API for authentication."""
         params = {
@@ -308,16 +271,13 @@ class HyundaiBlueLinkApiBR(ApiImplType1):
         url = self._build_api_url("/spa/vehicles")
         headers = self._get_authenticated_headers(token)
 
-        response = self.session.get(url, headers=headers)
-        self._raise_api_error(response, "get vehicles")
-        response_data = response.json()
+        response = self.session.get(url, headers=headers).json()
         _LOGGER.debug(f"{DOMAIN} - Got vehicles response")
-        if "resMsg" not in response_data or "vehicles" not in response_data.get(
-            "resMsg", {}
-        ):
+        _check_response_for_errors(response)
+        if "resMsg" not in response or "vehicles" not in response.get("resMsg", {}):
             raise APIError("Missing resMsg or vehicles in response")
         result = []
-        for entry in response_data["resMsg"]["vehicles"]:
+        for entry in response["resMsg"]["vehicles"]:
             # Map vehicle type to engine type
             vehicle_type = entry["type"]
             if vehicle_type == "GN":
@@ -355,9 +315,9 @@ class HyundaiBlueLinkApiBR(ApiImplType1):
         """
         url = self._build_api_url(f"/spa/vehicles/{vehicle.id}/ccs2/carstatus/latest")
         headers = self._get_authenticated_headers(token)
-        response = self.session.get(url, headers=headers)
-        self._raise_api_error(response, "cached status")
-        return response.json()["resMsg"]["state"]["Vehicle"]
+        response = self.session.get(url, headers=headers).json()
+        _check_response_for_errors(response)
+        return response["resMsg"]["state"]["Vehicle"]
 
     def update_vehicle_with_cached_state(self, token: Token, vehicle: Vehicle) -> None:
         """Update with the server-cached CCS2 state (does not wake the car)."""

--- a/tests/test_br_login.py
+++ b/tests/test_br_login.py
@@ -16,7 +16,11 @@ from unittest.mock import MagicMock
 import pytest
 
 from hyundai_kia_connect_api.const import BRAND_HYUNDAI, BRANDS, REGION_BRAZIL, REGIONS
-from hyundai_kia_connect_api.exceptions import AuthenticationError
+from hyundai_kia_connect_api.exceptions import (
+    APIError,
+    AuthenticationError,
+    DeviceIDError,
+)
 from hyundai_kia_connect_api.HyundaiBlueLinkApiBR import HyundaiBlueLinkApiBR
 
 _BR_REGION = next(k for k, v in REGIONS.items() if v == REGION_BRAZIL)
@@ -125,3 +129,97 @@ class TestGetAuthResponse:
         )
         with pytest.raises(AuthenticationError, match="token request"):
             br_api._get_auth_response("some-auth-code")
+
+
+class TestRaiseApiError:
+    """Unit-test the SPA-endpoint helper directly (counterpart of auth helper)."""
+
+    def test_no_op_on_success(self, br_api):
+        br_api._raise_api_error(
+            _resp(200, {"resMsg": {"vehicles": []}}), "get vehicles"
+        )
+
+    def test_400_errcode_errmsg_raises_api_error(self, br_api):
+        with pytest.raises(APIError, match="errCode=4004"):
+            br_api._raise_api_error(
+                _resp(400, {"errCode": 4004, "errMsg": "Duplicate request"}),
+                "get vehicles",
+            )
+
+    def test_400_spa_envelope_reuses_typed_classifier(self, br_api):
+        # SPA envelope with retCode F + resCode 4002 → DeviceIDError, not a
+        # generic APIError, so the device-id retry semantics stay intact.
+        with pytest.raises(DeviceIDError):
+            br_api._raise_api_error(
+                _resp(
+                    400, {"retCode": "F", "resCode": "4002", "resMsg": "bad deviceId"}
+                ),
+                "get vehicles",
+            )
+
+    def test_400_non_json_falls_back_to_snippet(self, br_api):
+        with pytest.raises(APIError, match="Response not JSON"):
+            br_api._raise_api_error(
+                _resp(400, None, text="<html>Bad Request</html>"), "get vehicles"
+            )
+
+    def test_400_unknown_shape_lists_keys_only(self, br_api):
+        with pytest.raises(APIError, match="keys="):
+            br_api._raise_api_error(_resp(400, {"foo": "bar"}), "cached status")
+
+    def test_403_raises_api_error_not_authentication_error(self, br_api):
+        # A vehicles-endpoint 403 is an API error, not an auth error: the token
+        # was accepted at login; this must not be misclassified as auth failure.
+        with pytest.raises(APIError):
+            br_api._raise_api_error(
+                _resp(403, {"errCode": 4031, "errMsg": "Forbidden"}), "get vehicles"
+            )
+
+
+class TestGetVehicles:
+    """The vehicles call-site: 4xx must surface the body, not a raw HTTPError.
+
+    Regression for kia_uvo #1846 / #1395: ``GET /spa/vehicles`` returned a bare
+    ``400 Bad Request`` (body discarded by ``raise_for_status``).
+    """
+
+    def test_400_errcode_raises_api_error_not_httperror(self, br_api):
+        br_api.session = MagicMock()
+        br_api.session.get.return_value = _resp(
+            400, {"errCode": 4009, "errMsg": "No vehicles enrolled"}
+        )
+        token = MagicMock()
+        with pytest.raises(APIError, match="get vehicles"):
+            br_api.get_vehicles(token)
+
+    def test_400_non_json_raises_api_error_with_snippet(self, br_api):
+        br_api.session = MagicMock()
+        br_api.session.get.return_value = _resp(400, None, text="<html>error</html>")
+        token = MagicMock()
+        with pytest.raises(APIError, match="Response not JSON"):
+            br_api.get_vehicles(token)
+
+    def test_200_vehicles_returned(self, br_api):
+        br_api.session = MagicMock()
+        br_api.session.get.return_value = _resp(
+            200,
+            {
+                "resMsg": {
+                    "vehicles": [
+                        {
+                            "vehicleId": "v1",
+                            "nickname": "My Car",
+                            "vehicleName": "Creta",
+                            "regDate": "20240101",
+                            "vin": "VIN123",
+                            "type": "GN",
+                            "ccuCCS2ProtocolSupport": 0,
+                        }
+                    ]
+                }
+            },
+        )
+        token = MagicMock()
+        vehicles = br_api.get_vehicles(token)
+        assert len(vehicles) == 1
+        assert vehicles[0].id == "v1"

--- a/tests/test_br_login.py
+++ b/tests/test_br_login.py
@@ -17,9 +17,9 @@ import pytest
 
 from hyundai_kia_connect_api.const import BRAND_HYUNDAI, BRANDS, REGION_BRAZIL, REGIONS
 from hyundai_kia_connect_api.exceptions import (
-    APIError,
     AuthenticationError,
     DeviceIDError,
+    InvalidAPIResponseError,
 )
 from hyundai_kia_connect_api.HyundaiBlueLinkApiBR import HyundaiBlueLinkApiBR
 
@@ -131,73 +131,32 @@ class TestGetAuthResponse:
             br_api._get_auth_response("some-auth-code")
 
 
-class TestRaiseApiError:
-    """Unit-test the SPA-endpoint helper directly (counterpart of auth helper)."""
-
-    def test_no_op_on_success(self, br_api):
-        br_api._raise_api_error(
-            _resp(200, {"resMsg": {"vehicles": []}}), "get vehicles"
-        )
-
-    def test_400_errcode_errmsg_raises_api_error(self, br_api):
-        with pytest.raises(APIError, match="errCode=4004"):
-            br_api._raise_api_error(
-                _resp(400, {"errCode": 4004, "errMsg": "Duplicate request"}),
-                "get vehicles",
-            )
-
-    def test_400_spa_envelope_reuses_typed_classifier(self, br_api):
-        # SPA envelope with retCode F + resCode 4002 → DeviceIDError, not a
-        # generic APIError, so the device-id retry semantics stay intact.
-        with pytest.raises(DeviceIDError):
-            br_api._raise_api_error(
-                _resp(
-                    400, {"retCode": "F", "resCode": "4002", "resMsg": "bad deviceId"}
-                ),
-                "get vehicles",
-            )
-
-    def test_400_non_json_falls_back_to_snippet(self, br_api):
-        with pytest.raises(APIError, match="Response not JSON"):
-            br_api._raise_api_error(
-                _resp(400, None, text="<html>Bad Request</html>"), "get vehicles"
-            )
-
-    def test_400_unknown_shape_lists_keys_only(self, br_api):
-        with pytest.raises(APIError, match="keys="):
-            br_api._raise_api_error(_resp(400, {"foo": "bar"}), "cached status")
-
-    def test_403_raises_api_error_not_authentication_error(self, br_api):
-        # A vehicles-endpoint 403 is an API error, not an auth error: the token
-        # was accepted at login; this must not be misclassified as auth failure.
-        with pytest.raises(APIError):
-            br_api._raise_api_error(
-                _resp(403, {"errCode": 4031, "errMsg": "Forbidden"}), "get vehicles"
-            )
-
-
 class TestGetVehicles:
-    """The vehicles call-site: 4xx must surface the body, not a raw HTTPError.
+    """The vehicles call-site: BR now follows the Type1 pattern (``.json()`` +
+    ``_check_response_for_errors``) instead of a bare ``raise_for_status()``,
+    so a SPA-envelope 4xx surfaces a typed error instead of a raw ``HTTPError``.
 
     Regression for kia_uvo #1846 / #1395: ``GET /spa/vehicles`` returned a bare
     ``400 Bad Request`` (body discarded by ``raise_for_status``).
     """
 
-    def test_400_errcode_raises_api_error_not_httperror(self, br_api):
+    def test_400_spa_envelope_raises_typed_error_not_httperror(self, br_api):
+        # SPA envelope (retCode F + resCode 4002) → DeviceIDError via the shared
+        # classifier, preserving device-id retry semantics — not a raw HTTPError.
         br_api.session = MagicMock()
         br_api.session.get.return_value = _resp(
-            400, {"errCode": 4009, "errMsg": "No vehicles enrolled"}
+            400, {"retCode": "F", "resCode": "4002", "resMsg": "Invalid deviceId"}
         )
-        token = MagicMock()
-        with pytest.raises(APIError, match="get vehicles"):
-            br_api.get_vehicles(token)
+        with pytest.raises(DeviceIDError):
+            br_api.get_vehicles(MagicMock())
 
-    def test_400_non_json_raises_api_error_with_snippet(self, br_api):
+    def test_400_unknown_shape_raises_apierror_not_httperror(self, br_api):
+        # A non-SPA JSON body falls through the shared classifier to
+        # InvalidAPIResponseError — still not a raw HTTPError.
         br_api.session = MagicMock()
-        br_api.session.get.return_value = _resp(400, None, text="<html>error</html>")
-        token = MagicMock()
-        with pytest.raises(APIError, match="Response not JSON"):
-            br_api.get_vehicles(token)
+        br_api.session.get.return_value = _resp(400, {"errCode": 4009, "errMsg": "x"})
+        with pytest.raises(InvalidAPIResponseError):
+            br_api.get_vehicles(MagicMock())
 
     def test_200_vehicles_returned(self, br_api):
         br_api.session = MagicMock()
@@ -219,7 +178,6 @@ class TestGetVehicles:
                 }
             },
         )
-        token = MagicMock()
-        vehicles = br_api.get_vehicles(token)
+        vehicles = br_api.get_vehicles(MagicMock())
         assert len(vehicles) == 1
         assert vehicles[0].id == "v1"

--- a/tests/test_br_vehicle_properties.py
+++ b/tests/test_br_vehicle_properties.py
@@ -27,6 +27,7 @@ _HYUNDAI_BRAND = next(k for k, v in BRANDS.items() if v == BRAND_HYUNDAI)
 
 def _response(json_data):
     resp = MagicMock()
+    resp.status_code = 200
     resp.json.return_value = json_data
     resp.raise_for_status.return_value = None
     return resp


### PR DESCRIPTION
## Problem

`GET /spa/vehicles` returned a bare `400 Bad Request` with the response body discarded (`raise_for_status()`), so users saw `400 Client Error: Bad Request for url: https://br-ccapi.hyundai.com.br/api/v1/spa/vehicles` with no actionable reason.

Reported in [Hyundai-Kia-Connect/kia_uvo#1846](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1846). Same recurring symptom as [Hyundai-Kia-Connect/kia_uvo#1395](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1395) (Nov 2025, closed by stale-bot, never root-caused): login succeeds — the OAuth2 token is issued — but the vehicles call fails opaquely.

BR was the **only** Type1 region using `raise_for_status()` on SPA endpoints. Every other region (EU, CA, AU, IN, CN, USA) and the base `ApiImplType1` use `.json()` + `_check_response_for_errors()` — so a SPA-envelope 4xx is classified into a typed error (`DeviceIDError`, `DuplicateRequestError`, …) instead of a raw `HTTPError`.

## Change (revised per review)

An earlier revision added a `_raise_api_error` helper. @cdnninja flagged it as clunky vs. the established pattern — correctly. This revision **drops the helper** and conforms BR to the Type1 pattern:

- `get_vehicles`: `self.session.get(...).json()` → `_check_response_for_errors(response)` → parse. No `raise_for_status()`.
- `_get_cached_vehicle_state` (`/spa/vehicles/{id}/ccs2/carstatus/latest`): same pattern.

The shared `_check_response_for_errors` already classifies SPA envelopes into typed exceptions and logs unknown response shapes, so a vehicles 4xx now surfaces a readable typed error (and the body for unknown shapes) instead of a bare `400 Bad Request`. No region-specific helper, no second body-reading method.

The auth helper `_raise_auth_error` from #1259 stays — the auth endpoints (`/user/oauth2/*`, `/user/signin`) return a different schema (`step`/`errCode`/`errMsg`, non-JSON WAF), for which no Type1 standard applies; that was reviewed and merged in #1259.

## What this does NOT do

This is a **diagnostic** fix, not a root-cause fix. The root cause of the `/spa/vehicles` 400 is still unknown (account-state / server-side flakiness, as in #1395). But with this change the next reporter sees a typed error / the response body instead of a bare `400 Bad Request`, which is the prerequisite to diagnosing it.

## Verification

- `ruff check .` ✅ · `ruff format --check .` ✅ · pre-commit ✅
- `pytest tests/` → 534 passed (15 snapshots)
- New `TestGetVehicles`: SPA-envelope 4xx → typed `DeviceIDError` (not raw `HTTPError`), non-SPA 4xx → `InvalidAPIResponseError` (not raw `HTTPError`), 200 success path.
- `test_br_vehicle_properties._response` helper now sets `status_code = 200` (realistic success mock; required because the conforming path no longer calls `raise_for_status()`).

## Related

- [Hyundai-Kia-Connect/kia_uvo#1846](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1846) — this report
- [Hyundai-Kia-Connect/kia_uvo#1395](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1395) — same symptom, closed stale
- #1259 — BR auth 4xx + CCS2 status (does not cover `get_vehicles`)