### PR TITLE
fix: register Brazilian Bluelink device IDs

### DIFF
--- a/hyundai_kia_connect_api/ApiImpl.py
+++ b/hyundai_kia_connect_api/ApiImpl.py
@@ -35,6 +35,9 @@ _LOGGER = logging.getLogger(__name__)
 @dataclass
 class ClimateRequestOptions:
     set_temp: float = None
+    # Optional wire-format code for APIs whose temperature scale is not a
+    # direct Celsius value (for example, Brazilian LOW/HIGH endpoints).
+    temp_code: str = None
     duration: int = None
     defrost: bool = None
     climate: bool = None

--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
@@ -4,7 +4,9 @@
 
 import datetime as dt
 import logging
+import time
 import typing as ty
+import uuid
 from datetime import timedelta
 from time import sleep
 from urllib.parse import parse_qs, urljoin, urlparse
@@ -73,9 +75,10 @@ class HyundaiBlueLinkApiBR(ApiImplType1):
         self.base_url = "br-ccapi.hyundai.com.br"
         self.api_url = f"https://{self.base_url}/api/v1/"
         self.api_v2_url = f"https://{self.base_url}/api/v2/"
-        self.ccsp_device_id = "c6e5815b-3057-4e5e-95d5-e3d5d1d2093e"
+        self.ccsp_device_id: str | None = None
+        self._registration_uuid = str(uuid.uuid4())
         self.ccsp_service_id = "03f7df9b-7626-4853-b7bd-ad1e8d722bd5"
-        self.ccsp_application_id = "513a491a-0d7c-4d6a-ac03-a2df127d73b0"
+        self.ccsp_application_id = "213a491a-0d7c-4d6a-ac03-a2df127d73b0"
         self.basic_authorization_header = (
             "Basic MDNmN2RmOWItNzYyNi00ODUzLWI3YmQtYWQxZThkNzIyYmQ1On"
             "lRejJiYzZDbjhPb3ZWT1I3UkRXd3hUcVZ3V0czeUtCWUZEZzBIc09Yc3l4eVBsSA=="
@@ -102,6 +105,74 @@ class HyundaiBlueLinkApiBR(ApiImplType1):
     def _build_api_v2_url(self, path: str) -> str:
         """Build API v2 URL from path."""
         return urljoin(self.api_v2_url, path.lstrip("/"))
+
+    def _get_device_id(self, stamp: str | None = None) -> str:
+        """Register and cache a Brazilian Bluelink device identifier.
+
+        The Android application registers a local UUID with the notification
+        endpoint before authenticating. The returned ``deviceId`` is required
+        by subsequent vehicle reads and control commands. ``stamp`` is accepted
+        for compatibility with the shared device-id retry interface; Brazil
+        does not send a Stamp header for this request.
+        """
+        del stamp
+        if self.ccsp_device_id:
+            return self.ccsp_device_id
+
+        url = self._build_api_url("/spa/notifications/register")
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json; charset=UTF-8",
+            "User-Agent": "okhttp/4.12.0",
+            "ccsp-service-id": self.ccsp_service_id,
+            "ccsp-application-id": self.ccsp_application_id,
+            "offset": "-3",
+        }
+        payload = {
+            "uuid": self._registration_uuid,
+            "pushRegId": f"dummy-push-{int(time.time() * 1000)}",
+            "pushType": "GCM",
+        }
+
+        _LOGGER.debug("%s - Registering Brazilian Bluelink device", DOMAIN)
+        response = self.session.post(url, json=payload, headers=headers)
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise APIError(
+                "Brazilian Hyundai device registration returned invalid JSON."
+            ) from exc
+        if not isinstance(data, dict):
+            raise APIError(
+                "Brazilian Hyundai device registration returned an unexpected JSON response."
+            )
+
+        if response.status_code >= 400:
+            raise APIError(
+                "Brazilian Hyundai device registration failed: "
+                f"HTTP {response.status_code}, retCode={data.get('retCode')!r}, "
+                f"resCode={data.get('resCode')!r}."
+            )
+
+        if data.get("retCode") != "S" or data.get("resCode") != "0000":
+            raise APIError(
+                "Brazilian Hyundai device registration was rejected: "
+                f"retCode={data.get('retCode')!r}, resCode={data.get('resCode')!r}."
+            )
+
+        response_message = data.get("resMsg")
+        device_id = (
+            response_message.get("deviceId")
+            if isinstance(response_message, dict)
+            else None
+        )
+        if not isinstance(device_id, str) or not device_id:
+            raise APIError(
+                "Brazilian Hyundai device registration did not return a deviceId."
+            )
+
+        self.ccsp_device_id = device_id
+        return device_id
 
     def _get_authenticated_headers(self, token: Token) -> dict:
         """Get headers with authentication."""
@@ -249,6 +320,7 @@ class HyundaiBlueLinkApiBR(ApiImplType1):
         """Login to Brazilian Hyundai API."""
         _LOGGER.debug(f"{DOMAIN} - Logging in to Brazilian API")
 
+        device_id = self._get_device_id()
         cookies = self._get_cookies()
         authorization_code = self._get_authorization_code(cookies, username, password)
         auth_response = self._get_auth_response(authorization_code)
@@ -262,7 +334,7 @@ class HyundaiBlueLinkApiBR(ApiImplType1):
             valid_until=expires_at,
             username=username,
             password=password,
-            device_id=self.ccsp_device_id,
+            device_id=device_id,
             pin=pin,
         )
 

--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
@@ -656,7 +656,9 @@ class HyundaiBlueLinkApiBR(ApiImplType1):
         if options.temp_code is not None:
             temp_code = options.temp_code.upper()
             if re.fullmatch(r"[0-9A-F]{2}H", temp_code) is None:
-                raise ValueError("temp_code must be a two-digit hexadecimal code ending in H")
+                raise ValueError(
+                    "temp_code must be a two-digit hexadecimal code ending in H"
+                )
         else:
             if options.set_temp is None:
                 options.set_temp = 21  # 21°C default

--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
@@ -4,6 +4,7 @@
 
 import datetime as dt
 import logging
+import re
 import time
 import typing as ty
 import uuid
@@ -638,8 +639,6 @@ class HyundaiBlueLinkApiBR(ApiImplType1):
         url = self._build_api_v2_url(f"spa/vehicles/{vehicle.id}/control/engine")
 
         # Set defaults
-        if options.set_temp is None:
-            options.set_temp = 21  # 21°C default
         if options.duration is None:
             options.duration = 10  # 10 minutes default
         if options.defrost is None:
@@ -651,10 +650,18 @@ class HyundaiBlueLinkApiBR(ApiImplType1):
         if options.front_left_seat is None:
             options.front_left_seat = 0
 
-        # Convert temperature to hex code
-        # BR API uses direct Celsius value converted to hex
-        temp_celsius = int(options.set_temp)
-        temp_code = get_index_into_hex_temp(temp_celsius)
+        # Most BR vehicles use direct Celsius values. Some models expose a
+        # vehicle-specific scale (including LOW/HIGH) instead; callers that
+        # have that confirmed mapping can supply its already-encoded code.
+        if options.temp_code is not None:
+            temp_code = options.temp_code.upper()
+            if re.fullmatch(r"[0-9A-F]{2}H", temp_code) is None:
+                raise ValueError("temp_code must be a two-digit hexadecimal code ending in H")
+        else:
+            if options.set_temp is None:
+                options.set_temp = 21  # 21°C default
+            temp_celsius = int(options.set_temp)
+            temp_code = get_index_into_hex_temp(temp_celsius)
 
         # Map seat heating level (0-5 in ClimateRequestOptions to 0-8 for BR API)
         # 0=off, 1-3=heat levels, 4-5=cool levels (BR uses similar mapping)

--- a/tests/test_br_climate_temp_code.py
+++ b/tests/test_br_climate_temp_code.py
@@ -1,0 +1,58 @@
+"""Brazilian climate requests can use a confirmed vehicle-specific tempCode."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from hyundai_kia_connect_api.ApiImpl import ClimateRequestOptions
+from hyundai_kia_connect_api.HyundaiBlueLinkApiBR import HyundaiBlueLinkApiBR
+from hyundai_kia_connect_api.Vehicle import Vehicle
+
+
+class _Response:
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return {"retCode": "S", "msgId": "test-message"}
+
+
+def _api() -> HyundaiBlueLinkApiBR:
+    api = object.__new__(HyundaiBlueLinkApiBR)
+    api.api_v2_url = "https://example.test/api/v2/"
+    api.ccsp_device_id = "test-device"
+    api.session = MagicMock()
+    api.session.post.return_value = _Response()
+    return api
+
+
+def _payload(options: ClimateRequestOptions) -> dict:
+    api = _api()
+    vehicle = Vehicle(id="vehicle-id", ccu_ccs2_protocol_support=0)
+    token = MagicMock()
+    token.device_id = "test-device"
+    with (
+        patch.object(api, "_ensure_control_token", return_value="control-token"),
+        patch.object(api, "_get_authenticated_headers", return_value={}),
+    ):
+        api.start_climate(token, vehicle, options)
+    return api.session.post.call_args.kwargs["json"]
+
+
+class BrazilianClimateTempCodeTests(unittest.TestCase):
+    def test_uses_confirmed_raw_temperature_code(self):
+        payload = _payload(ClimateRequestOptions(temp_code="feh"))
+
+        self.assertEqual(payload["tempCode"], "FEH")
+
+    def test_keeps_legacy_direct_celsius_encoding_without_raw_code(self):
+        payload = _payload(ClimateRequestOptions(set_temp=21))
+
+        self.assertEqual(payload["tempCode"], "15H")
+
+    def test_rejects_an_invalid_raw_temperature_code(self):
+        with self.assertRaisesRegex(ValueError, "temp_code"):
+            _payload(ClimateRequestOptions(temp_code="HIGH"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_br_login.py
+++ b/tests/test_br_login.py
@@ -148,7 +148,7 @@ class TestDeviceRegistration:
 
         assert device_id == "registered-device"
         assert br_api.ccsp_device_id == "registered-device"
-        url, = br_api.session.post.call_args.args
+        (url,) = br_api.session.post.call_args.args
         request = br_api.session.post.call_args.kwargs
         assert url.endswith("/api/v1/spa/notifications/register")
         assert request["headers"] == {

--- a/tests/test_br_login.py
+++ b/tests/test_br_login.py
@@ -11,12 +11,12 @@ These tests cover ``_raise_auth_error`` across the three BR auth call-sites
 existing HTTP 200 + ``{step:N}`` path (#1239) as a regression guard.
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from hyundai_kia_connect_api.const import BRAND_HYUNDAI, BRANDS, REGION_BRAZIL, REGIONS
-from hyundai_kia_connect_api.exceptions import AuthenticationError
+from hyundai_kia_connect_api.exceptions import APIError, AuthenticationError
 from hyundai_kia_connect_api.HyundaiBlueLinkApiBR import HyundaiBlueLinkApiBR
 
 _BR_REGION = next(k for k, v in REGIONS.items() if v == REGION_BRAZIL)
@@ -125,3 +125,94 @@ class TestGetAuthResponse:
         )
         with pytest.raises(AuthenticationError, match="token request"):
             br_api._get_auth_response("some-auth-code")
+
+
+class TestDeviceRegistration:
+    def test_registers_device_with_android_contract(self, br_api):
+        br_api.session = MagicMock()
+        br_api._registration_uuid = "local-uuid"
+        br_api.session.post.return_value = _resp(
+            200,
+            {
+                "retCode": "S",
+                "resCode": "0000",
+                "resMsg": {"deviceId": "registered-device"},
+            },
+        )
+
+        with patch(
+            "hyundai_kia_connect_api.HyundaiBlueLinkApiBR.time.time",
+            return_value=123.456,
+        ):
+            device_id = br_api._get_device_id()
+
+        assert device_id == "registered-device"
+        assert br_api.ccsp_device_id == "registered-device"
+        url, = br_api.session.post.call_args.args
+        request = br_api.session.post.call_args.kwargs
+        assert url.endswith("/api/v1/spa/notifications/register")
+        assert request["headers"] == {
+            "Accept": "application/json",
+            "Content-Type": "application/json; charset=UTF-8",
+            "User-Agent": "okhttp/4.12.0",
+            "ccsp-service-id": "03f7df9b-7626-4853-b7bd-ad1e8d722bd5",
+            "ccsp-application-id": "213a491a-0d7c-4d6a-ac03-a2df127d73b0",
+            "offset": "-3",
+        }
+        assert request["json"] == {
+            "uuid": "local-uuid",
+            "pushRegId": "dummy-push-123456",
+            "pushType": "GCM",
+        }
+
+    def test_reuses_registered_device_in_same_instance(self, br_api):
+        br_api.session = MagicMock()
+        br_api.session.post.return_value = _resp(
+            200,
+            {
+                "retCode": "S",
+                "resCode": "0000",
+                "resMsg": {"deviceId": "registered-device"},
+            },
+        )
+
+        assert br_api._get_device_id() == "registered-device"
+        assert br_api._get_device_id() == "registered-device"
+        assert br_api.session.post.call_count == 1
+
+    @pytest.mark.parametrize(
+        ("status_code", "data", "message"),
+        [
+            (500, {"retCode": "F", "resCode": "5000"}, "HTTP 500"),
+            (200, {"retCode": "F", "resCode": "4002"}, "was rejected"),
+            (200, {"retCode": "S", "resCode": "0000", "resMsg": {}}, "deviceId"),
+            (200, None, "invalid JSON"),
+            (200, [], "unexpected JSON"),
+        ],
+    )
+    def test_rejects_invalid_registration_responses(
+        self, br_api, status_code, data, message
+    ):
+        br_api.session = MagicMock()
+        br_api.session.post.return_value = _resp(status_code, data)
+
+        with pytest.raises(APIError, match=message):
+            br_api._get_device_id()
+        assert br_api.ccsp_device_id is None
+
+    def test_login_uses_registered_device_id_in_token(self, br_api):
+        br_api._get_device_id = MagicMock(return_value="registered-device")
+        br_api._get_cookies = MagicMock(return_value={})
+        br_api._get_authorization_code = MagicMock(return_value="authorization-code")
+        br_api._get_auth_response = MagicMock(
+            return_value={
+                "access_token": "access-token",
+                "refresh_token": "refresh-token",
+                "expires_in": 3600,
+            }
+        )
+
+        token = br_api.login("user@example.com", "password", pin="1234")
+
+        assert token.device_id == "registered-device"
+        br_api._get_device_id.assert_called_once_with()


### PR DESCRIPTION
## Summary
- replace the shared Brazilian device ID with per-client registration through the notification endpoint
- update the Brazilian application ID to the current Android app value
- persist the returned device ID in the existing Token field for subsequent reads and commands

## Validation
- add BR registration tests covering the Android request contract, instance reuse, invalid responses, and token assignment
- 539 tests passed locally
- verified login, vehicle listing, and cached-state read against a Brazilian account without issuing a vehicle command

## Notes
- this intentionally does not add automatic recovery for a later 4002 invalid-device response; that behavior is kept for a follow-up PR
- no credentials, vehicle identifiers, tokens, or captured traffic are included