### PR TITLE
chore: run pytest in CI + packaging housekeeping

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,9 +1,12 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# This workflow runs the pytest suite across the supported Python versions.
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Test Builds
 
 on:
+    push:
+        branches:
+            - master
     pull_request:
         branches:
             - master
@@ -11,7 +14,7 @@ on:
 jobs:
     build:
         runs-on: ubuntu-latest
-        name: "test py${{matrix.python-version}}"
+        name: "test py${{ matrix.python-version }}"
         strategy:
             fail-fast: false
             matrix:
@@ -19,21 +22,14 @@ jobs:
 
         steps:
             - uses: actions/checkout@v7
-              with:
-                  ref: ${{github.event.pull_request.head.ref}}
-                  repository: ${{github.event.pull_request.head.repo.full_name}}
             - name: Set up Python ${{ matrix.python-version }}
               uses: actions/setup-python@v7
               with:
                   python-version: ${{ matrix.python-version }}
+                  cache: pip
             - name: Install dependencies
               run: |
                   python -m pip install --upgrade pip
-                  python -m pip install flake8 pytest syrupy
-                  if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-            - name: Lint with flake8
-              run: |
-                  # stop the build if there are Python syntax errors or undefined names
-                  flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-                  # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-                  flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+                  python -m pip install -e . pytest syrupy
+            - name: Run tests
+              run: pytest

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ This package is designed to simplify the complexity of using multiple regions.  
 
 Europe Hyundai and Kia login logic is based on the `bluelink-refresh-token <https://github.com/TMA84/bluelink-refresh-token>`_ project.  Username/password login is supported directly for Kia, Hyundai, and Genesis (EU) — no browser or manual token extraction needed. The ``pycryptodome`` package (included as a dependency) is used for RSA password encryption during the EU login flow.
 
-Python 3.10 or newer is required to use this package. Vehicle manager is the key class that is called to manage the vehicle lists.  One vehicle manager should be used per login. Key data points required to instantiate vehicle manager are::
+Python 3.12 or newer is required to use this package. Vehicle manager is the key class that is called to manage the vehicle lists.  One vehicle manager should be used per login. Key data points required to instantiate vehicle manager are::
 
     region: int
     brand: int,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,22 +1,3 @@
-[bumpversion]
-current_version = 0.1.0
-commit = True
-tag = True
-
-[bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
-
-[bumpversion:file:hyundai_kia_connect_api/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
-
-[bdist_wheel]
-universal = 1
-
-[flake8]
-exclude = docs
-max-line-length = 88
 [tool:pytest]
 addopts = --ignore=setup.py
 env_files = .env

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,10 @@ with open("HISTORY.rst") as history_file:
 with open("requirements.txt") as f:
     requirements = f.read().splitlines()
 
-long_description = readme + "\n\n" + history
 long_description = readme
 
 test_requirements = [
-    "pytest>=3",
+    "pytest>=8",
     "syrupy>=4.0.0",
 ]
 
@@ -24,7 +23,7 @@ setup(
     author_email="fuatakgun@gmail.com",
     python_requires=">=3.12",
     classifiers=[
-        "Development Status :: 4 - Beta",
+        "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",


### PR DESCRIPTION
Supersets #1286.

**`.github/workflows/python-tests.yml`** — the existing "Test Builds" workflow only ran `flake8`, never `pytest`. This runs the suite:
- install `syrupy` (snapshot tests need it; missing in #1286) via `pip install -e . pytest syrupy` (also resolves runtime deps + package)
- keep the `3.12/3.13/3.14` matrix, `fail-fast: false`
- scope triggers to `push`/`pull_request` on `master` (not every fork branch push)
- drop the `flake8` step (ruff runs via pre-commit.ci); add `cache: pip`

**`setup.py`** — `Development Status :: 4 - Beta` → `5 - Production/Stable` (no longer beta); `pytest>=3` → `pytest>=8` (current major; 8.1+ adds core `env_files` used by `setup.cfg`); drop the dead `long_description = readme + "\n\n" + history` line (immediately overwritten).

**`setup.cfg`** — remove `[bumpversion]` (release.yml bumps via semantic-release + `sed` on `setup.py`; `current_version = 0.1.0` with single-quote `search` never matched the double-quoted `4.27.0`, and the `__version__` file target does not exist), `[bdist_wheel] universal = 1` (package is `python_requires>=3.12`, not py2-compatible), `[flake8]` (ruff in pre-commit, flake8 no longer used). `[tool:pytest]` kept.

**`README.rst`** — `Python 3.10` → `Python 3.12` (matches `python_requires>=3.12`; 3.10/3.11 dropped in #1216).

Closes #1286 as a superset. 531 tests + 15 snapshots green locally.