### PR TITLE
fix(EU): convert forced refresh location time from UTC

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -672,8 +672,13 @@ class KiaUvoApiEU(ApiImplType1):
             self._force_refresh_vehicle_state_ccs2(token, vehicle)
         else:
             state = self._get_forced_vehicle_state(token, vehicle)
-            state["vehicleLocation"] = self._get_location(token, vehicle)
+            location = self._get_location(token, vehicle)
+            state["vehicleLocation"] = location
             self._update_vehicle_properties(vehicle, state)
+            # Must run after _update_vehicle_properties: that method labels
+            # vehicleLocation.time with data_timezone, which is correct for the
+            # cached feed but wrong for the GET /location payload attached above.
+            self._set_location_from_gps_detail(vehicle, location)
         # Only call for driving info on cars we know have a chance of supporting it.
         # Could be expanded if other types do support it.
         if (
@@ -1293,6 +1298,35 @@ class KiaUvoApiEU(ApiImplType1):
         except Exception as e:
             _LOGGER.exception(f"{DOMAIN} - _get_location failed: {e}")  # noqa: TRY401
             return None
+
+    def _set_location_from_gps_detail(
+        self, vehicle: Vehicle, gps_detail: dict | None
+    ) -> None:
+        """Apply the gpsDetail of GET /location, whose time is UTC.
+
+        Two feeds fill vehicle.location from the same compact YYYYMMDDHHMMSS
+        shape but on different clocks: this one is UTC, while the
+        vehicleLocation embedded in the cached status response and
+        GET /location/park are region local. parse_datetime only labels a
+        compact value, so _update_vehicle_properties leaves this feed one UTC
+        offset early. Convert here, as the CCS2 'Date' field does (#1147).
+        """
+        if not gps_detail or not get_child_value(gps_detail, "coord.lat"):
+            return
+        # A missing timestamp must stay None, which HA shows as "unknown".
+        # See kia_uvo #1771.
+        location_last_updated_at = parse_datetime(
+            get_child_value(gps_detail, "time"), dt.UTC
+        )
+        if location_last_updated_at is not None:
+            location_last_updated_at = location_last_updated_at.astimezone(
+                self.data_timezone
+            )
+        vehicle.location = (
+            get_child_value(gps_detail, "coord.lat"),
+            get_child_value(gps_detail, "coord.lon"),
+            location_last_updated_at,
+        )
 
     def _get_forced_vehicle_state(self, token: Token, vehicle: Vehicle) -> dict:
         url = self.SPA_API_URL + "vehicles/" + vehicle.id + "/status"

--- a/hyundai_kia_connect_api/utils.py
+++ b/hyundai_kia_connect_api/utils.py
@@ -180,6 +180,15 @@ def get_index_into_hex_temp(value):
 
 
 def parse_datetime(value, timezone) -> datetime.datetime | None:
+    """Parse an API timestamp into an aware datetime.
+
+    The two accepted formats are not equivalent. "Tue, 24 Jun 2025 16:18:10
+    GMT" states its own zone, so it is read as UTC and converted into
+    ``timezone``. The compact "20250624161810" states no zone, so it is only
+    labelled with ``timezone``; no conversion happens. A caller whose compact
+    value is UTC must therefore pass ``datetime.UTC`` and convert itself
+    (see the CCS2 'Date' field, #1147).
+    """
     # Missing timestamp must surface as None (HA renders "unknown") rather than
     # a 2000-01-01 sentinel that renders as "27 years ago". See kia_uvo #1771.
     if value is None:

--- a/tests/test_eu_forced_location_timezone.py
+++ b/tests/test_eu_forced_location_timezone.py
@@ -1,0 +1,156 @@
+"""EU forced refresh: GET /location returns gpsDetail.time in UTC. See kia_uvo #931.
+
+The cached feeds (the vehicleLocation embedded in the status response, and
+GET /location/park) return region local time, so only the forced value needs
+a conversion. The last test guards that difference.
+"""
+
+import datetime as dt
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hyundai_kia_connect_api.KiaUvoApiEU import KiaUvoApiEU
+from hyundai_kia_connect_api.Vehicle import Vehicle
+
+# One instant, two clocks: the forced /status payload reports local wall clock
+# (18:18:10 CEST), GET /location reports UTC (16:18:10Z).
+FORCED_STATUS = {
+    "retCode": "S",
+    "resCode": "0000",
+    "resMsg": {"time": "20260624181810", "doorLock": True},
+}
+LOCATION = {
+    "retCode": "S",
+    "resCode": "0000",
+    "resMsg": {
+        "gpsDetail": {
+            "coord": {"lat": 52.52, "lon": 13.405, "alt": 10, "type": 0},
+            "head": 180,
+            "speed": {"value": 0, "unit": 0},
+            "time": "20260624161810",
+        }
+    },
+}
+
+
+@pytest.fixture
+def eu_api() -> KiaUvoApiEU:
+    api = KiaUvoApiEU.__new__(KiaUvoApiEU)
+    api.SPA_API_URL = "https://test.invalid/api/v1/spa/"
+    api.data_timezone = KiaUvoApiEU.data_timezone
+    api.temperature_range = KiaUvoApiEU.temperature_range
+    api.session = MagicMock()
+    api._get_authenticated_headers = MagicMock(
+        return_value={"Authorization": "Bearer x"}
+    )
+    return api
+
+
+@pytest.fixture
+def vehicle() -> Vehicle:
+    v = Vehicle()
+    v.id = "vid-123"
+    # ccu_ccs2_protocol_support defaults to None, and None != 0 is True, so it
+    # must be set to take the legacy branch that calls _get_location.
+    v.ccu_ccs2_protocol_support = 0
+    return v
+
+
+def _mock_get(status, location):
+    def get(url, headers=None):
+        resp = MagicMock()
+        resp.json.return_value = location if url.endswith("/location") else status
+        return resp
+
+    return get
+
+
+def test_forced_location_time_is_parsed_as_utc(eu_api, vehicle):
+    token = SimpleNamespace(access_token="t", device_id="d")
+    with patch.object(
+        eu_api.session, "get", side_effect=_mock_get(FORCED_STATUS, LOCATION)
+    ):
+        eu_api.force_refresh_vehicle_state(token, vehicle)
+
+    # Aware datetimes compare by instant, thus this is independent of the
+    # timezone of the machine that runs the test.
+    assert vehicle.location_last_updated_at == dt.datetime(
+        2026, 6, 24, 16, 18, 10, tzinfo=dt.UTC
+    )
+    # It is the same moment that the status payload gives as local time.
+    assert vehicle.location_last_updated_at == vehicle.last_updated_at
+
+
+def test_forced_location_time_is_utc_in_winter(eu_api, vehicle):
+    """CET, not CEST: a constant two hour shift must not pass this."""
+    location = {
+        "retCode": "S",
+        "resCode": "0000",
+        "resMsg": {
+            "gpsDetail": {
+                "coord": {"lat": 52.52, "lon": 13.405},
+                "time": "20260115104500",
+            }
+        },
+    }
+    status = {"retCode": "S", "resCode": "0000", "resMsg": {"time": "20260115114500"}}
+    token = SimpleNamespace(access_token="t", device_id="d")
+    with patch.object(eu_api.session, "get", side_effect=_mock_get(status, location)):
+        eu_api.force_refresh_vehicle_state(token, vehicle)
+
+    assert vehicle.location_last_updated_at == dt.datetime(
+        2026, 1, 15, 10, 45, 0, tzinfo=dt.UTC
+    )
+
+
+def test_forced_location_absent_keeps_cached_value(eu_api, vehicle):
+    """An offline vehicle returns no gpsDetail. Do not fail, and do not
+    overwrite the position that is already known."""
+    cached = dt.datetime(2026, 6, 24, 12, 0, 0, tzinfo=KiaUvoApiEU.data_timezone)
+    vehicle.location = (52.52, 13.405, cached)
+    location = {"retCode": "S", "resCode": "0000", "resMsg": {}}
+    token = SimpleNamespace(access_token="t", device_id="d")
+    with patch.object(
+        eu_api.session, "get", side_effect=_mock_get(FORCED_STATUS, location)
+    ):
+        eu_api.force_refresh_vehicle_state(token, vehicle)
+
+    assert vehicle.location_latitude == 52.52
+    assert vehicle.location_last_updated_at == cached
+
+
+def test_forced_location_without_time_has_no_timestamp(eu_api, vehicle):
+    """gpsDetail without a time must leave the timestamp None, which HA shows
+    as "unknown", and not a sentinel. See kia_uvo #1771."""
+    location = {
+        "retCode": "S",
+        "resCode": "0000",
+        "resMsg": {"gpsDetail": {"coord": {"lat": 52.52, "lon": 13.405}}},
+    }
+    token = SimpleNamespace(access_token="t", device_id="d")
+    with patch.object(
+        eu_api.session, "get", side_effect=_mock_get(FORCED_STATUS, location)
+    ):
+        eu_api.force_refresh_vehicle_state(token, vehicle)
+
+    assert vehicle.location_latitude == 52.52
+    assert vehicle.location_last_updated_at is None
+
+
+def test_cached_embedded_location_time_stays_local(eu_api, vehicle):
+    """The other half of the seam: the vehicleLocation embedded in the cached
+    status response is local time, and must not be converted."""
+    state = {
+        "vehicleStatus": {"time": "20260624181810"},
+        "vehicleLocation": {
+            "coord": {"lat": 52.52, "lon": 13.405},
+            "time": "20260624181810",
+        },
+    }
+    eu_api._update_vehicle_properties(vehicle, state)
+
+    assert vehicle.location_last_updated_at == dt.datetime(
+        2026, 6, 24, 18, 18, 10, tzinfo=KiaUvoApiEU.data_timezone
+    )

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -157,3 +157,14 @@ def test_parse_datetime_old_iso_format_with_separators():
 def test_parse_datetime_invalid_raises():
     with pytest.raises(ValueError):
         parse_datetime("garbage", datetime.UTC)
+
+
+def test_parse_datetime_compact_labels_while_gmt_converts():
+    """The compact form is only labelled; the GMT form is converted."""
+    tz = ZoneInfo("Europe/Warsaw")
+    assert parse_datetime("20250624161810", tz) == datetime.datetime(
+        2025, 6, 24, 16, 18, 10, tzinfo=tz
+    )
+    assert parse_datetime("Tue, 24 Jun 2025 16:18:10 GMT", tz) == datetime.datetime(
+        2025, 6, 24, 18, 18, 10, tzinfo=tz
+    )


### PR DESCRIPTION
## Summary

On a non-CCS2 EU vehicle a forced refresh stamps `location_last_updated_at` one UTC offset early:
two hours in CEST, one hour in CET. The cached path gives the correct time for the same fix, so
the sensor moves backwards on every force refresh.

The cause is that the two paths read endpoints with different clocks, and both end in the same
line of `_update_vehicle_properties`:

| path | endpoint | field | clock |
| --- | --- | --- | --- |
| `update_vehicle_with_cached_state` | `/location/park` | `resMsg.time` | region local |
| `force_refresh_vehicle_state` | `/location` | `resMsg.gpsDetail.time` | **UTC** |

`utils.parse_datetime` only labels a compact `YYYYMMDDHHMMSS` value with the zone it receives, it
does not convert it, so a UTC value becomes an `Europe/Berlin` instant.

Full analysis and the user reports are in #1291.

## Changes

- `hyundai_kia_connect_api/KiaUvoApiEU.py` — a new `_set_location_from_gps_detail`, called from
  `force_refresh_vehicle_state` after `_update_vehicle_properties`. It parses `gpsDetail.time`
  as UTC and converts into `data_timezone`, which is the treatment that #1147 already applies to
  the CCS2 `Date` field.
- `hyundai_kia_connect_api/utils.py` — a docstring on `parse_datetime` that states the difference
  between its two formats. Comment only.
- `tests/test_eu_forced_location_timezone.py` — new.
- `tests/utils_test.py` — one test that pins the difference between the two formats.

## Why the change is at the call site, and not in `_update_vehicle_properties`

That branch serves two feeds. Besides the forced `/location` payload, it also receives the
`vehicleLocation` embedded in the cached status response, which really is region local time. A
conversion inside `_update_vehicle_properties` would move the cached feed wrong by the same one
or two hours in the other direction. `test_cached_embedded_location_time_stays_local` fails if
someone later makes that change.

Writing the value and then overriding it is the shape this file already uses: on the cached path
and on the CCS2 forced path, `_set_cached_location_park` also runs after the properties are set.

The raw payload in `vehicle.data` keeps the original string, so a later diagnosis still sees what
the server sent.

## Scope

EU, non-CCS2, forced refresh only.

- `KiaUvoApiEU` has no subclasses, and `_get_location` has exactly one caller.
- A CCS2 vehicle never reaches this code: `force_refresh_vehicle_state` sends it to
  `_force_refresh_vehicle_state_ccs2`, which ends at `_set_cached_location_park`.
- `KiaUvoApiAU._get_location` reads `/location/park` and is untouched.
- `KiaUvoApiCN` reads `/location` but with a different response shape and no DST. I have no
  capture for it and did not change it.

## Tests

Four new tests for the EU path, one for `parse_datetime`.

Without the source change, `test_forced_location_time_is_parsed_as_utc` fails by two hours and
`test_forced_location_time_is_utc_in_winter` fails by one hour, so a constant offset cannot pass
both. The other three pass before and after; they guard the cached feed, the offline vehicle and
the missing timestamp.

`pytest` on the full suite gives `540 passed`.

`pre-commit run --all-files` is clean, and so is
`flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`.

## Related issues

Closes #1291.

Same symptom reported downstream in Hyundai-Kia-Connect/kia_uvo#1639,
Hyundai-Kia-Connect/kia_uvo#931 and Hyundai-Kia-Connect/kia_uvo#1451, and here in #993.
#1147 is the CCS2 `Date` precedent that this follows.
