### PR TITLE
fix(ccs2): map BatteryPreCondition.Status per the official app (0/2/6 off, 3/4 on)

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -588,8 +588,6 @@ class ApiImplType1(ApiImpl):
         winter_mode = get_child_value(
             state, "Green.BatteryManagement.WinterModeOperation"
         )
-        if winter_mode is not None:
-            vehicle.ev_battery_winter_mode = bool(winter_mode)
 
         # EV battery preconditioning toggle.
         # EV (e.g. IONIQ 5) reports Green.BatteryManagement.BatteryPreCondition.Status
@@ -598,17 +596,24 @@ class ApiImplType1(ApiImpl):
         # Fe) reports only WinterModeOperation; "winter mode" is itself the
         # battery preconditioning/winter-heating toggle there, so keep it as the
         # fallback (preserves existing HEV behaviour, no regression).
-        # Status enum confirmed via reporter dumps (kia_uvo #1652, 2026-07-12):
-        #   0 = disabled in vehicle settings, 2 = enabled in vehicle settings.
+        # Status enum mapping matches the official app (kia_uvo #1823, dump:
+        # Status=2 with preconditioning off in vehicle settings):
+        #   0 / 2 / 6 = off, 3 / 4 = on.
         # Pre-#1205 this sensor aliased WinterModeOperation, which is absent on
         # EVs -> the sensor never appeared (see API #1187).
         battery_precondition_status = get_child_value(
             state, "Green.BatteryManagement.BatteryPreCondition.Status"
         )
         if battery_precondition_status is not None:
-            vehicle.ev_battery_precondition_enabled = battery_precondition_status != 0
+            vehicle.ev_battery_precondition_enabled = battery_precondition_status in (
+                3,
+                4,
+            )
+            # WinterModeOperation is not a user-facing "Winter Mode" toggle on
+            # EVs (kia_uvo #1823) — leave ev_battery_winter_mode unset (None).
         elif winter_mode is not None:
             vehicle.ev_battery_precondition_enabled = bool(winter_mode)
+            vehicle.ev_battery_winter_mode = bool(winter_mode)
 
         if get_child_value(state, "Green.Electric.SmartGrid.RealTimePower") is not None:
             vehicle.ev_charging_power = get_child_value(

--- a/tests/test_ccs2_precondition_status.py
+++ b/tests/test_ccs2_precondition_status.py
@@ -1,19 +1,27 @@
 """Tests for CCS2 ev_battery_precondition_enabled read mapping.
 
-EV (IONIQ 5) reports Green.BatteryManagement.BatteryPreCondition.Status —
-a configuration setting (stable across ignition/climate state), not a runtime
+EV (IONIQ 5 / IONIQ 6) reports Green.BatteryManagement.BatteryPreCondition.Status
+— a configuration setting (stable across ignition/climate state), not a runtime
 flag (BatteryConditioning is the runtime flag). HEV (Santa Fe) reports only
 WinterModeOperation; "winter mode" is itself the battery preconditioning /
 winter-heating toggle there, so it is used as a fallback. This preserves
 existing HEV behaviour (no regression) while making the precondition sensor
 appear on EVs that report BatteryPreCondition.
 
-Status enum (confirmed via reporter dumps, kia_uvo #1652, 2026-07-12):
-  Status = 0 -> preconditioning disabled in vehicle settings
-  Status = 2 -> preconditioning enabled in vehicle settings
-Both dumps (disabled and enabled) have no WinterModeOperation key -> the
-#1187 alias (precondition = bool(WinterModeOperation)) never produced a
-sensor on EVs.
+Status enum — mapping matches the official Hyundai app
+(BatteryConditioningModel, option==2 vehicles):
+  Status = 0 / 2 / 6 -> preconditioning OFF
+  Status = 3 / 4     -> preconditioning ON
+This supersedes the earlier reading of the kia_uvo #1652 IONIQ 5 dumps
+(2026-07-12) that Status=2 meant "enabled" — that was an inference from two
+dumps without UI confirmation. kia_uvo #1823 (Ioniq 6 2026, ccNC) captured
+Status=2 with preconditioning OFF in the vehicle settings; the "toggling
+while driving" reported there was Status moving between 2/3/4.
+
+kia_uvo #1823 also established that WinterModeOperation is NOT a user-facing
+"Winter Mode" toggle on EVs (the app never exposes it as one), so when
+BatteryPreCondition.Status is present, ev_battery_winter_mode must stay None
+instead of bool(WinterModeOperation).
 
 The CCS2 states below are inlined (not loaded from tests/fixtures/) because
 they are minimal, target-specific, and derived from live reporter dumps that
@@ -50,29 +58,18 @@ def _state(battery_management: dict) -> dict:
     return state
 
 
-# EV (IONIQ 5): preconditioning ENABLED in vehicle settings (kia_uvo #1652,
-# 2026-07-12). BatteryPreCondition.Status = 2, no WinterModeOperation.
-_IONIQ5_ENABLED = _state(
-    {
-        "SoH": {"Ratio": 100},
-        "BatteryRemain": {"Value": 109843.2, "Ratio": 42, "Unit": "kJ"},
-        "BatteryConditioning": 0,
-        "BatteryPreCondition": {"Status": 2, "TemperatureLevel": 2},
-        "BatteryCapacity": {"Value": 302400, "Unit": "kJ"},
-    }
-)
+def _ev_state(status: int) -> dict:
+    """EV state with BatteryPreCondition.Status set (no WinterModeOperation)."""
+    return _state(
+        {
+            "SoH": {"Ratio": 100},
+            "BatteryRemain": {"Value": 109843.2, "Ratio": 42, "Unit": "kJ"},
+            "BatteryConditioning": 0,
+            "BatteryPreCondition": {"Status": status, "TemperatureLevel": 2},
+            "BatteryCapacity": {"Value": 302400, "Unit": "kJ"},
+        }
+    )
 
-# EV (IONIQ 5): preconditioning DISABLED in vehicle settings (kia_uvo #1652,
-# 2026-07-12). BatteryPreCondition.Status = 0, no WinterModeOperation.
-_IONIQ5_DISABLED = _state(
-    {
-        "SoH": {"Ratio": 100},
-        "BatteryRemain": {"Value": 125107.2, "Ratio": 47.5, "Unit": "kJ"},
-        "BatteryConditioning": 0,
-        "BatteryPreCondition": {"Status": 0, "TemperatureLevel": 2},
-        "BatteryCapacity": {"Value": 302400, "Unit": "kJ"},
-    }
-)
 
 # HEV (Santa Fe): WinterModeOperation = 0, no BatteryPreCondition. This is the
 # no-regression case — the fallback path must reproduce today's behaviour.
@@ -80,6 +77,16 @@ _HEV_WINTER_MODE_OFF = _state(
     {
         "SoH": {"Ratio": 100},
         "WinterModeOperation": 0,
+        "BatteryRemain": {"Value": 0, "Ratio": 49.5, "Unit": "kJ"},
+    }
+)
+
+# HEV (Santa Fe): WinterModeOperation = 1, no BatteryPreCondition — the other
+# side of the no-regression guarantee (fallback maps 1 -> True/True).
+_HEV_WINTER_MODE_ON = _state(
+    {
+        "SoH": {"Ratio": 100},
+        "WinterModeOperation": 1,
         "BatteryRemain": {"Value": 0, "Ratio": 49.5, "Unit": "kJ"},
     }
 )
@@ -97,14 +104,45 @@ class TestCCS2PreconditionSensor:
     """Precondition read from BatteryPreCondition.Status (EV) with
     WinterModeOperation fallback (HEV)."""
 
-    def test_ioniq5_precondition_enabled_from_battery_precondition_status(
-        self, ccs2_api
-    ):
-        """EV (IONIQ 5): BatteryPreCondition.Status=2 -> precondition enabled."""
+    @pytest.mark.parametrize(
+        ("status", "expected_enabled"),
+        [
+            (0, False),
+            (2, False),  # kia_uvo #1823 dump: precondition OFF in settings
+            (3, True),
+            (4, True),
+            (6, False),
+        ],
+    )
+    def test_ioniq5_precondition_status_enum(self, ccs2_api, status, expected_enabled):
+        """EV: BatteryPreCondition.Status maps 0/2/6 -> off, 3/4 -> on."""
         vehicle = Vehicle()
-        ccs2_api._update_vehicle_properties_ccs2(vehicle, _IONIQ5_ENABLED)
-        assert vehicle.ev_battery_precondition_enabled is True
-        # IONIQ 5 does not report WinterModeOperation -> winter_mode stays None.
+        ccs2_api._update_vehicle_properties_ccs2(vehicle, _ev_state(status))
+        assert vehicle.ev_battery_precondition_enabled is expected_enabled
+        # Status present -> WinterModeOperation is not mapped to a boolean.
+        assert vehicle.ev_battery_winter_mode is None
+
+    def test_ioniq6_ccnc_1823_dump_case(self, ccs2_api):
+        """kia_uvo #1823 exact dump (Ioniq 6 2026, ccNC).
+
+        WinterModeOperation=1 alongside BatteryPreCondition.Status=2, with
+        Winter Mode NOT armed and preconditioning OFF in the vehicle settings.
+        Precondition must read OFF (app mapping: 2 -> off) and winter_mode
+        must not become a boolean from WinterModeOperation on an EV.
+        """
+        vehicle = Vehicle()
+        state = _state(
+            {
+                "SoH": {"Ratio": 100},
+                "WinterModeOperation": 1,
+                "BatteryConditioning": 0,
+                "HeatingState": 0,
+                "BatteryPreCondition": {"Status": 2, "TemperatureLevel": 1},
+                "BatteryRemain": {"Value": 109843.2, "Ratio": 42, "Unit": "kJ"},
+            }
+        )
+        ccs2_api._update_vehicle_properties_ccs2(vehicle, state)
+        assert vehicle.ev_battery_precondition_enabled is False
         assert vehicle.ev_battery_winter_mode is None
 
     def test_ioniq5_precondition_disabled_from_battery_precondition_status(
@@ -116,17 +154,25 @@ class TestCCS2PreconditionSensor:
         preconditioning turned OFF in the myHyundai app, Status reads 0.
         """
         vehicle = Vehicle()
-        ccs2_api._update_vehicle_properties_ccs2(vehicle, _IONIQ5_DISABLED)
+        ccs2_api._update_vehicle_properties_ccs2(vehicle, _ev_state(0))
         assert vehicle.ev_battery_precondition_enabled is False
         assert vehicle.ev_battery_winter_mode is None
 
-    def test_hev_precondition_falls_back_to_winter_mode(self, ccs2_api):
+    def test_hev_precondition_falls_back_to_winter_mode_off(self, ccs2_api):
         """HEV: no BatteryPreCondition -> fallback to WinterModeOperation=0 ->
         False. No-regression guarantee: existing HEV behaviour is unchanged."""
         vehicle = Vehicle()
         ccs2_api._update_vehicle_properties_ccs2(vehicle, _HEV_WINTER_MODE_OFF)
         assert vehicle.ev_battery_precondition_enabled is False
         assert vehicle.ev_battery_winter_mode is False
+
+    def test_hev_precondition_falls_back_to_winter_mode_on(self, ccs2_api):
+        """HEV: no BatteryPreCondition -> fallback to WinterModeOperation=1 ->
+        True for both fields. No-regression guarantee for the armed case."""
+        vehicle = Vehicle()
+        ccs2_api._update_vehicle_properties_ccs2(vehicle, _HEV_WINTER_MODE_ON)
+        assert vehicle.ev_battery_precondition_enabled is True
+        assert vehicle.ev_battery_winter_mode is True
 
     def test_precondition_field_exists_in_vehicle(self):
         v = Vehicle()


### PR DESCRIPTION
## Summary

`BatteryPreCondition.Status` is not a 0/1 flag — the official app maps it as `0 / 2 / 6 → Off`, `3 / 4 → On`. The old `!= 0` read produced false positives on EVs:

- reported ON while parked/charging on a Ioniq 6 (ccNC) with preconditioning **disabled** in vehicle settings — reporter dump in Hyundai-Kia-Connect/kia_uvo#1823: `Status = 2`, `WinterModeOperation = 1`, `BatteryConditioning = 0`, `HeatingState = 0`
- the "toggling while driving" reported there is `Status` moving between 2/3/4, which `!= 0` read as constant ON

Additionally, `WinterModeOperation` is not a user-facing "Winter Mode" toggle on EVs (the app never exposes it as one), so `ev_battery_winter_mode` now stays `None` (entity shows Unknown in Home Assistant) whenever `BatteryPreCondition.Status` is present. Vehicles reporting only `WinterModeOperation` (e.g. Santa Fe HEV, where it IS the winter-heating/precondition toggle) keep the existing behavior.

## Changes

- `ApiImplType1._update_vehicle_properties_ccs2`: map `BatteryPreCondition.Status` per the official app enum (`status in (3, 4)` instead of `!= 0`); set `ev_battery_winter_mode = bool(winter_mode)` only on the HEV fallback path
- `tests/test_ccs2_precondition_status.py`: parametrized Status enum cases (0/2/3/4/6), exact reporter-dump case from kia_uvo#1823, HEV ON/OFF no-regression cases; docstring notes that the earlier "Status = 2 means enabled" reading of the kia_uvo #1652 dumps was an inference without UI confirmation and is superseded by the app mapping + the #1823 dump

## Scope

Applies to vehicles reporting `Green.BatteryManagement.BatteryPreCondition.Status`. Vehicles where the status only comes via `WinterModeOperation` are unaffected. Vehicles whose firmware reports `Status = 2` for an enabled setting (if any exist) would now read Off — the app mapping is treated as the source of truth.

Fixes Hyundai-Kia-Connect/kia_uvo#1823
