### PR TITLE
fix(CA): fetch location when none is known after restart/reload

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -476,9 +476,16 @@ class KiaUvoApiCA(ApiImpl):
         # Service Status Call
         service = self._get_next_service(token, vehicle)
 
-        # Get location if the car has moved since last call
+        # Get location if the car has moved since last call, or if no location
+        # is known yet: coordinates live only in the in-memory Vehicle object,
+        # so after a restart/reload a parked car would otherwise never get a
+        # location fetch and the location sensors stay unavailable until the
+        # car physically moves (Hyundai-Kia-Connect/kia_uvo#1844).
         if vehicle.odometer:
-            if vehicle.odometer < get_child_value(service, "currentOdometer"):
+            if (
+                vehicle.odometer < get_child_value(service, "currentOdometer")
+                or vehicle.location_latitude is None
+            ):
                 location = self.get_location(token, vehicle)
                 self._update_vehicle_properties_location(vehicle, location)
         else:
@@ -526,9 +533,14 @@ class KiaUvoApiCA(ApiImpl):
         # Service Status Call
         service = self._get_next_service(token, vehicle)
 
-        # Get location if the car has moved since last call
+        # Get location if the car has moved since last call, or if no location
+        # is known yet (same restart/reload rationale as the cached-state path
+        # above, Hyundai-Kia-Connect/kia_uvo#1844).
         if vehicle.odometer:
-            if vehicle.odometer < get_child_value(service, "currentOdometer"):
+            if (
+                vehicle.odometer < get_child_value(service, "currentOdometer")
+                or vehicle.location_latitude is None
+            ):
                 location = self.get_location(token, vehicle)
                 self._update_vehicle_properties_location(vehicle, location)
         else:

--- a/tests/test_ca_location_unknown_fetch.py
+++ b/tests/test_ca_location_unknown_fetch.py
@@ -1,0 +1,105 @@
+"""Tests for the CA location fetch gate when coordinates are unknown.
+
+KiaUvoApiCA only calls get_location (fndmcr, PIN-protected) when the odometer
+increased since the service reading. Coordinates live only in the in-memory
+Vehicle object, so after a Home Assistant restart/reload a parked car would
+never get a location fetch — the device_tracker and the geocoded-location
+sensor stay unavailable until the car physically moves
+(Hyundai-Kia-Connect/kia_uvo#1844). The gate now also fires while no location
+is known yet; once a location exists, behaviour is unchanged (moved-gate only).
+
+get_location is mocked at the gate boundary: an fndmcr result without a
+"time" field yields coordinates with location_last_set_time None (seen in the
+#1844 reporter dump) — parse_datetime(None) is None by design (kia_uvo #1771).
+"""
+
+import datetime as dt
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from hyundai_kia_connect_api.const import ENGINE_TYPES
+from hyundai_kia_connect_api.KiaUvoApiCA import KiaUvoApiCA
+from hyundai_kia_connect_api.Vehicle import Vehicle
+
+
+@pytest.fixture
+def ca_api() -> KiaUvoApiCA:
+    api = KiaUvoApiCA.__new__(KiaUvoApiCA)
+    api.data_timezone = KiaUvoApiCA.data_timezone
+    api._get_cached_vehicle_state = MagicMock(return_value={"status": {}})
+    api._update_vehicle_properties_base = MagicMock()
+    api._get_next_service = MagicMock(
+        return_value={"currentOdometer": 100, "currentOdometerUnit": 1}
+    )
+    api._update_vehicle_properties_service = MagicMock()
+    api._get_forced_vehicle_state = MagicMock(
+        return_value={
+            "status": {
+                "lastStatusDate": dt.datetime.now(dt.UTC).strftime("%Y%m%d%H%M%S")
+            }
+        }
+    )
+    api.get_location = MagicMock(
+        return_value={"coord": {"lat": 43.5, "lon": -79.4}, "time": None}
+    )
+    return api
+
+
+def _vehicle(odometer: float, with_location: bool) -> Vehicle:
+    v = Vehicle()
+    v.id = "vid-1"
+    v.engine_type = ENGINE_TYPES.PHEV
+    v._odometer = odometer
+    # The real _update_vehicle_properties_base populates vehicle.data; the
+    # test mocks it, so start with an empty dict like post-base state.
+    v.data = {}
+    if with_location:
+        v.location = (43.5, -79.4, None)
+    return v
+
+
+def _token() -> SimpleNamespace:
+    return SimpleNamespace(access_token="t", device_id="d")
+
+
+class TestCachedStateLocationGate:
+    def test_parked_car_without_location_fetches(self, ca_api):
+        """Odometer unchanged + no location yet (post-restart) -> fetch.
+
+        This is the kia_uvo #1844 case: before the fix the moved-gate
+        suppressed the fetch and the location sensors stayed unavailable
+        until the car physically moved.
+        """
+        vehicle = _vehicle(odometer=100, with_location=False)
+        ca_api.update_vehicle_with_cached_state(_token(), vehicle)
+        ca_api.get_location.assert_called_once()
+        assert vehicle.location_latitude == 43.5
+        assert vehicle.location_longitude == -79.4
+        # fndmcr result without "time" -> timestamp stays None (HA: unknown)
+        assert vehicle.location_last_updated_at is None
+
+    def test_parked_car_with_location_keeps_moved_gate(self, ca_api):
+        """Odometer unchanged + location known -> no fetch (no API load)."""
+        vehicle = _vehicle(odometer=100, with_location=True)
+        ca_api.update_vehicle_with_cached_state(_token(), vehicle)
+        ca_api.get_location.assert_not_called()
+        assert vehicle.location_latitude == 43.5
+        assert vehicle.location_longitude == -79.4
+
+    def test_moved_car_fetches(self, ca_api):
+        """Odometer below the service reading -> fetch (existing behaviour)."""
+        vehicle = _vehicle(odometer=99.5, with_location=True)
+        ca_api.update_vehicle_with_cached_state(_token(), vehicle)
+        ca_api.get_location.assert_called_once()
+
+
+class TestForceRefreshLocationGate:
+    def test_parked_car_without_location_fetches_on_force_refresh(self, ca_api):
+        """Same gate on the forced-refresh path (sibling call site)."""
+        vehicle = _vehicle(odometer=100, with_location=False)
+        ca_api.force_refresh_vehicle_state(_token(), vehicle)
+        ca_api.get_location.assert_called_once()
+        assert vehicle.location_latitude == 43.5
+        assert vehicle.location_longitude == -79.4


### PR DESCRIPTION
## Summary

In the CA region the vehicle location comes exclusively from the Find-My-Car call (`fndmcr`, PIN-protected) — the cached status's `vehicleLocation` field is never read. `KiaUvoApiCA` only calls it when the odometer increased since the service reading ("the car has moved").

Coordinates live only in the in-memory `Vehicle` object: after a Home Assistant restart / integration reload they are gone, and for a parked car the moved-gate never fires again. The device_tracker and the geocoded-location sensor then stay unavailable until the car physically moves — which can be weeks (Hyundai-Kia-Connect/kia_uvo#1844: "gone for weeks and then came back", reproduces on reboot / reload / force refresh).

## Changes

- `KiaUvoApiCA.update_vehicle_with_cached_state` / `force_refresh_vehicle_state` (sibling call sites): the location gate now also fires while `vehicle.location_latitude` is None. Once a location exists, behaviour is unchanged (moved-gate only), so the extra API load is bounded to the first successful fetch after a restart or a failed one.
- `tests/test_ca_location_unknown_fetch.py`: parked+unknown (fetch — the #1844 case), parked+known (no fetch — no API-load regression), moved (fetch — existing behaviour), plus the force-refresh sibling site. The no-`time` fndmcr case from the #1844 dump (coordinates set, timestamp unknown) is covered by the mocked result.

## Scope

CA region only. HyundaiBlueLinkApiUSA has a structurally similar moved-gate (`HyundaiBlueLinkApiUSA.py` ~line 894) with its own location fallback path — left untouched. kia_uvo needs no change: the entities already render unavailable-while-unknown and become available once the first fetch succeeds.

Fixes Hyundai-Kia-Connect/kia_uvo#1844