### PR TITLE
fix(CA): bound the unknown-location fetch to one attempt per session

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiCA.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCA.py
@@ -480,12 +480,17 @@ class KiaUvoApiCA(ApiImpl):
         # is known yet: coordinates live only in the in-memory Vehicle object,
         # so after a restart/reload a parked car would otherwise never get a
         # location fetch and the location sensors stay unavailable until the
-        # car physically moves (Hyundai-Kia-Connect/kia_uvo#1844).
+        # car physically moves (Hyundai-Kia-Connect/kia_uvo#1844). The
+        # unknown-location fetch is bounded to one attempt per session (the
+        # flag is in-memory like the coordinates) so a persistently failing
+        # Find-My-Car response cannot re-run on every poll.
         if vehicle.odometer:
-            if (
-                vehicle.odometer < get_child_value(service, "currentOdometer")
-                or vehicle.location_latitude is None
+            if vehicle.odometer < get_child_value(service, "currentOdometer") or (
+                vehicle.location_latitude is None
+                and not vehicle._location_fetch_attempted
             ):
+                if vehicle.location_latitude is None:
+                    vehicle._location_fetch_attempted = True
                 location = self.get_location(token, vehicle)
                 self._update_vehicle_properties_location(vehicle, location)
         else:
@@ -534,13 +539,16 @@ class KiaUvoApiCA(ApiImpl):
         service = self._get_next_service(token, vehicle)
 
         # Get location if the car has moved since last call, or if no location
-        # is known yet (same restart/reload rationale as the cached-state path
-        # above, Hyundai-Kia-Connect/kia_uvo#1844).
+        # is known yet (same restart/reload rationale and same one-attempt
+        # bound as the cached-state path above,
+        # Hyundai-Kia-Connect/kia_uvo#1844).
         if vehicle.odometer:
-            if (
-                vehicle.odometer < get_child_value(service, "currentOdometer")
-                or vehicle.location_latitude is None
+            if vehicle.odometer < get_child_value(service, "currentOdometer") or (
+                vehicle.location_latitude is None
+                and not vehicle._location_fetch_attempted
             ):
+                if vehicle.location_latitude is None:
+                    vehicle._location_fetch_attempted = True
                 location = self.get_location(token, vehicle)
                 self._update_vehicle_properties_location(vehicle, location)
         else:

--- a/hyundai_kia_connect_api/Vehicle.py
+++ b/hyundai_kia_connect_api/Vehicle.py
@@ -189,6 +189,11 @@ class Vehicle:
     _location_latitude: float = None
     _location_longitude: float = None
     _location_last_set_time: datetime.datetime = None
+    # True after an attempt to fetch the (still unknown) location. In-memory
+    # like the coordinates themselves: a restart/reload starts a fresh
+    # attempt. Bounds the unknown-location fetch to one try per session so a
+    # persistently failing Find-My-Car response cannot re-run on every poll.
+    _location_fetch_attempted: bool = False
 
     # EV fields (EV/PHEV)
 

--- a/tests/test_ca_location_unknown_fetch.py
+++ b/tests/test_ca_location_unknown_fetch.py
@@ -94,6 +94,42 @@ class TestCachedStateLocationGate:
         ca_api.update_vehicle_with_cached_state(_token(), vehicle)
         ca_api.get_location.assert_called_once()
 
+    def test_failed_fetch_does_not_retry_next_poll(self, ca_api):
+        """A failed fndmcr attempt must not re-fire on every poll.
+
+        get_location swallows all errors and returns None, so coords stay
+        None and the unknown-branch gate would re-run (vrfypin + fndmcr,
+        two POSTs) on every poll for the whole session — the review
+        concern on Hyundai-Kia-Connect/hyundai_kia_connect_api#1294.
+        Bounded: one attempt per in-memory Vehicle session.
+        """
+        vehicle = _vehicle(odometer=100, with_location=False)
+        ca_api.get_location.return_value = None  # server error path
+        ca_api.update_vehicle_with_cached_state(_token(), vehicle)
+        ca_api.update_vehicle_with_cached_state(_token(), vehicle)
+        ca_api.update_vehicle_with_cached_state(_token(), vehicle)
+        ca_api.get_location.assert_called_once()
+
+    def test_moved_fetch_failure_does_not_retry_when_parked(self, ca_api):
+        """A failed moved-gate fetch must not hand over to the unknown
+        branch for an unbounded retry once the odometer catches up."""
+        vehicle = _vehicle(odometer=99.5, with_location=False)
+        ca_api.get_location.return_value = None
+        ca_api.update_vehicle_with_cached_state(_token(), vehicle)
+        vehicle._odometer = 100  # service reading catches up after the fetch
+        ca_api.update_vehicle_with_cached_state(_token(), vehicle)
+        ca_api.get_location.assert_called_once()
+
+    def test_fresh_vehicle_after_restart_retries_once(self, ca_api):
+        """A new Vehicle object (restart/reload) gets a fresh attempt —
+        the kia_uvo #1844 recovery, not an unbounded retry."""
+        ca_api.get_location.return_value = None
+        vehicle = _vehicle(odometer=100, with_location=False)
+        ca_api.update_vehicle_with_cached_state(_token(), vehicle)
+        fresh = _vehicle(odometer=100, with_location=False)
+        ca_api.update_vehicle_with_cached_state(_token(), fresh)
+        assert ca_api.get_location.call_count == 2
+
 
 class TestForceRefreshLocationGate:
     def test_parked_car_without_location_fetches_on_force_refresh(self, ca_api):
@@ -103,3 +139,11 @@ class TestForceRefreshLocationGate:
         ca_api.get_location.assert_called_once()
         assert vehicle.location_latitude == 43.5
         assert vehicle.location_longitude == -79.4
+
+    def test_failed_fetch_does_not_retry_on_force_refresh(self, ca_api):
+        """Same bound on the forced-refresh path (sibling call site)."""
+        vehicle = _vehicle(odometer=100, with_location=False)
+        ca_api.get_location.return_value = None
+        ca_api.force_refresh_vehicle_state(_token(), vehicle)
+        ca_api.force_refresh_vehicle_state(_token(), vehicle)
+        ca_api.get_location.assert_called_once()


### PR DESCRIPTION
## Summary

Follow-up to #1294 (per the review comment): `get_location` swallows all errors and returns `None`, so a **persistently failing** Find-My-Car response would leave `vehicle.location_latitude` as `None` and re-run the fetch on every poll for the whole session. Each attempt is two POSTs (`vrfypin` for the PIN token + `fndmcr`), so at the default 30-minute scan interval that is ~96 server calls per day, indefinitely, in exactly the failure mode seen in kia_uvo #1844 (`Get vehicle location failed`).

## Changes

- `Vehicle`: new in-memory flag `_location_fetch_attempted` (next to the coordinates themselves — a restart/reload starts a fresh attempt, which is the #1844 recovery).
- `KiaUvoApiCA.update_vehicle_with_cached_state` / `force_refresh_vehicle_state` (both sibling call sites): the unknown-location fetch now fires once per session; the moved-gate keeps working unchanged, and a moved+unknown fetch also counts as the attempt.
- Tests: failed fetch does not retry on subsequent polls (cached and forced paths), a failed moved-gate fetch does not hand over to an unbounded retry once the odometer catches up, and a fresh `Vehicle` (restart/reload) gets a new attempt.

## Scope

- The `odometer`-falsy `else` branch keeps its pre-existing unconditional fetch (that behaviour predates #1294 and is a different, rarer state — no service data); flagging it here for visibility rather than silently widening the change.
- kia_uvo side of #1844 (the geocoded-location sensor staying "no longer provided" after a reload) is Hyundai-Kia-Connect/kia_uvo#1856.

Related: Hyundai-Kia-Connect/hyundai_kia_connect_api#1294, Hyundai-Kia-Connect/kia_uvo#1844
