### PR TITLE
fix: Skip no-op HVAC write on EV5 flat scheduled charging

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -1280,6 +1280,19 @@ class ApiImplType1(ApiImpl):
         _LOGGER.debug(f"{DOMAIN} - EV5 schedule charge response: {charge_response}")
         _check_response_for_errors(charge_response)
 
+        # EV5 climate is a separate endpoint from the charge write. When
+        # nothing climate-related is requested the write is a no-op, and
+        # sending it right after the charge write is rejected by the backend
+        # as a duplicate request (4004), failing the whole action — skip it
+        # instead. Live evidence: KiaUvo discussion #1764 (EV6 debug log
+        # 2026-08-19: charge 0000, then hvac 4004 duplicate).
+        if (
+            not departures[0].enabled
+            and not departures[1].enabled
+            and not options.climate_enabled
+        ):
+            return charge_response["msgId"]
+
         _LOGGER.debug(f"{DOMAIN} - EV5 schedule hvac request: {hvac_payload}")
         hvac_response = self.session.post(
             base_url + "/hvac",

--- a/tests/test_schedule_ev5_flat.py
+++ b/tests/test_schedule_ev5_flat.py
@@ -97,7 +97,10 @@ class TestEV5Dispatch:
     def test_ccs2_ev_uses_flat_endpoints(self, api):
         calls = _mock_post(api)
         v = _make_vehicle(ccs2=1, engine_type=ENGINE_TYPES.EV)
-        api.schedule_charging_and_climate(MagicMock(spec=Token), v, _options())
+        # climate part present (departure enabled) so both endpoints are hit
+        api.schedule_charging_and_climate(
+            MagicMock(spec=Token), v, _options(first_departure_enabled=True)
+        )
         urls = [c["url"] for c in calls]
         assert any(u.endswith("/ccs2/reservation/charge") for u in urls)
         assert any(u.endswith("/ccs2/reservation/hvac") for u in urls)
@@ -258,10 +261,50 @@ class TestEV5FlatHvacPayload:
         calls = _mock_post(api)
         v = _make_vehicle(ccs2=1, engine_type=ENGINE_TYPES.EV)
         api.schedule_charging_and_climate(
-            MagicMock(spec=Token), v, _options(first_departure_enabled=False)
+            MagicMock(spec=Token), v, _options(climate_enabled=True)
         )
         hvac = next(c["json"] for c in calls if c["url"].endswith("/hvac"))
         assert hvac["reservedHVACInfo1"]["reservHVACflag"] == 0
+        assert hvac["reservedHVACInfo1"]["reservHVACSet"]["airCtrl"] == 1
+
+
+class TestEV5HvacSkip:
+    """The no-op HVAC write is skipped instead of POSTed.
+
+    Live evidence (kia_uvo discussion #1764, GasManGeek EV6 log 2026-08-19):
+    the charge write succeeds (0000) and the immediately-following unchanged
+    HVAC write is rejected with 4004 "Duplicate request", failing the whole
+    action. When nothing climate-related is requested the HVAC write is
+    skipped entirely.
+    """
+
+    def test_noop_hvac_skipped(self, api):
+        calls = _mock_post(api)
+        v = _make_vehicle(ccs2=1, engine_type=ENGINE_TYPES.EV)
+        # default options: both departures disabled, climate_enabled False
+        api.schedule_charging_and_climate(MagicMock(spec=Token), v, _options())
+        urls = [c["url"] for c in calls]
+        assert len(urls) == 1
+        assert urls[0].endswith("/ccs2/reservation/charge")
+
+    def test_hvac_sent_when_departure_enabled(self, api):
+        calls = _mock_post(api)
+        v = _make_vehicle(ccs2=1, engine_type=ENGINE_TYPES.EV)
+        api.schedule_charging_and_climate(
+            MagicMock(spec=Token), v, _options(first_departure_enabled=True)
+        )
+        urls = [c["url"] for c in calls]
+        assert any(u.endswith("/ccs2/reservation/charge") for u in urls)
+        assert any(u.endswith("/ccs2/reservation/hvac") for u in urls)
+
+    def test_hvac_sent_when_climate_enabled(self, api):
+        calls = _mock_post(api)
+        v = _make_vehicle(ccs2=1, engine_type=ENGINE_TYPES.EV)
+        api.schedule_charging_and_climate(
+            MagicMock(spec=Token), v, _options(climate_enabled=True)
+        )
+        urls = [c["url"] for c in calls]
+        assert any(u.endswith("/ccs2/reservation/hvac") for u in urls)
 
 
 class TestEV5Return:


### PR DESCRIPTION
## Problem

On ccNC/EV5-appMode EVs (EV6, EV9 — `ccu_ccs2_protocol_support==1` + `engine_type==EV`), scheduled charging writes go to two separate endpoints: `/ccs2/reservation/charge` followed by `/ccs2/reservation/hvac`. When a user only changes charging settings, the HVAC write is a no-op (all-off payload with unchanged departure data), and the backend rejects it with `resCode 4004 "Duplicate request"`:

```
POST /ccs2/reservation/charge  -> {"retCode":"S","resCode":"0000"}
POST /ccs2/reservation/hvac    -> {"retCode":"F","resCode":"4004","resMsg":"Duplicate request"}
```

The second failure raises `DuplicateRequestError` for the whole action, so the HA service call reports an error even though the charge write succeeded. Live debug log from [kia_uvo discussion #1764](https://github.com/Hyundai-Kia-Connect/kia_uvo/discussions/1764) (EV6, 2026-08-19) shows exactly this pattern; the combined `/reservation/chargehvac` path (CCSP / EV2–EV4) sends a single write and is not affected.

## Fix

In `_schedule_ev5_flat`, skip the HVAC write when nothing climate-related is requested — both departures disabled **and** `climate_enabled` false. Any climate-related write (enabled departure or `climate_enabled`) still POSTs `/hvac` unchanged.

**Known limitation:** an explicit all-off service call can no longer clear existing HVAC schedules on the car via the API. This is a rare case (all-off writes previously mostly failed with 4004 anyway); clearing schedules through the OEM app still works.

The duplicate-guard mechanism itself (backend rejecting back-to-back writes on these endpoints) is a hypothesis supported by the log above; a separate live test with genuinely different back-to-back writes is planned to confirm.

## Testing

- New `TestEV5HvacSkip` tests: all-off options → only the charge POST; departure or climate enabled → both POSTs.
- Existing 12 flat-dispatch tests updated for the skip and still green; full suite 551 passed, snapshots unchanged.