### PR TITLE
fix(BR): register a real device id instead of using a hardcoded one

### DIFF
--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
@@ -315,6 +315,61 @@ class HyundaiBlueLinkApiBR(ApiImplType1):
             pin=pin,
         )
 
+    def refresh_access_token(self, token: Token) -> Token:
+        """Refresh the access token with BR's oauth2 refresh_token grant.
+
+        ``ApiImplType1.refresh_access_token`` targets ``USER_API_URL`` /
+        ``BASE_URL`` / ``BASIC_AUTHORIZATION``, none of which BR defines, so it
+        raised ``AttributeError`` on every call, swallowed it in its
+        ``except Exception`` and fell back to a full login on *every* poll. It
+        also prefixes the token type onto ``access_token``, while BR builds its
+        own ``Bearer`` prefix in ``_get_authenticated_headers``, so the
+        inherited implementation could not have worked here even if the
+        attributes existed.
+
+        Falls back to a full login when there is no refresh token or the
+        exchange fails (an expired refresh token is the normal case).
+        """
+        if token.refresh_token:
+            try:
+                url = self._build_api_url("/user/oauth2/token")
+                body = {
+                    "client_id": self.ccsp_service_id,
+                    "grant_type": "refresh_token",
+                    "refresh_token": token.refresh_token,
+                }
+                headers = {
+                    "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+                    "User-Agent": self.api_headers["User-Agent"],
+                    "Authorization": self.basic_authorization_header,
+                }
+
+                response = self.session.post(url, data=body, headers=headers)
+                self._raise_auth_error(response, "token refresh")
+                auth_response = response.json()
+
+                expires_at = dt.datetime.now(dt.UTC) + timedelta(
+                    seconds=auth_response["expires_in"]
+                )
+                _LOGGER.debug(f"{DOMAIN} - Access token refreshed")
+                return Token(
+                    access_token=auth_response["access_token"],
+                    refresh_token=auth_response.get(
+                        "refresh_token", token.refresh_token
+                    ),
+                    valid_until=expires_at,
+                    username=token.username,
+                    password=token.password,
+                    device_id=token.device_id,
+                    pin=token.pin,
+                )
+            except Exception:
+                _LOGGER.warning(
+                    f"{DOMAIN} - Refresh token exchange failed, "
+                    "falling back to full login"
+                )
+        return self.login(token.username, token.password, pin=token.pin)
+
     @_retry_on_device_id_error
     def get_vehicles(self, token: Token) -> list:
         """Get list of vehicles."""

--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py
@@ -4,7 +4,9 @@
 
 import datetime as dt
 import logging
+import random
 import typing as ty
+import uuid
 from datetime import timedelta
 from time import sleep
 from urllib.parse import parse_qs, urljoin, urlparse
@@ -12,7 +14,11 @@ from urllib.parse import parse_qs, urljoin, urlparse
 from requests import Response
 
 from .ApiImpl import ApiImplSession, ClimateRequestOptions, WindowRequestOptions
-from .ApiImplType1 import ApiImplType1, _check_response_for_errors
+from .ApiImplType1 import (
+    ApiImplType1,
+    _check_response_for_errors,
+    _retry_on_device_id_error,
+)
 from .const import (
     BRAND_HYUNDAI,
     BRANDS,
@@ -73,7 +79,6 @@ class HyundaiBlueLinkApiBR(ApiImplType1):
         self.base_url = "br-ccapi.hyundai.com.br"
         self.api_url = f"https://{self.base_url}/api/v1/"
         self.api_v2_url = f"https://{self.base_url}/api/v2/"
-        self.ccsp_device_id = "c6e5815b-3057-4e5e-95d5-e3d5d1d2093e"
         self.ccsp_service_id = "03f7df9b-7626-4853-b7bd-ad1e8d722bd5"
         self.ccsp_application_id = "513a491a-0d7c-4d6a-ac03-a2df127d73b0"
         self.basic_authorization_header = (
@@ -94,6 +99,10 @@ class HyundaiBlueLinkApiBR(ApiImplType1):
 
         self.session = ApiImplSession()
         self.temperature_range = range(62, 82)
+        # Registered with /spa/notifications/register on first use and
+        # reused for the lifetime of this object, so a full login does not
+        # register a new push device every time.
+        self._registered_device_id: str | None = None
 
     def _build_api_url(self, path: str) -> str:
         """Build full API URL from path."""
@@ -103,10 +112,50 @@ class HyundaiBlueLinkApiBR(ApiImplType1):
         """Build API v2 URL from path."""
         return urljoin(self.api_v2_url, path.lstrip("/"))
 
+    def _get_stamp(self) -> None:
+        """BR does not use the Stamp header; required by the shared retry helper."""
+
+    def _get_device_id(self, stamp: str | None = None) -> str:
+        """Register a push device and return the server-issued device id.
+
+        The BR backend validates ``ccsp-device-id`` against its own device
+        registry: it rejects both client-generated UUIDs and ids it has since
+        invalidated, answering ``resCode 4002`` ("Invalid deviceId") on every
+        authenticated SPA call. The id therefore has to be obtained from
+        ``/spa/notifications/register``, the same way EU and IN do it.
+
+        Always registers a fresh id and caches it, so the retry path can
+        recover from a server-side invalidation.
+        """
+        registration_id = f"{random.randrange(10**80):064x}"[:64]
+        url = self._build_api_url("/spa/notifications/register")
+        payload = {
+            "pushRegId": registration_id,
+            "pushType": "APNS",
+            "uuid": str(uuid.uuid4()),
+        }
+        headers = dict(self.api_headers)
+        headers["ccsp-service-id"] = self.ccsp_service_id
+        headers["ccsp-application-id"] = self.ccsp_application_id
+
+        _LOGGER.debug(f"{DOMAIN} - Registering device at {url}")
+        response = self.session.post(url, headers=headers, json=payload)
+        self._raise_auth_error(response, "device registration")
+        response_json = response.json()
+        _check_response_for_errors(response_json)
+
+        device_id = response_json["resMsg"]["deviceId"]
+        self._registered_device_id = device_id
+        return device_id
+
+    def _ensure_device_id(self) -> str:
+        """Return this session's registered device id, registering one if needed."""
+        return self._registered_device_id or self._get_device_id()
+
     def _get_authenticated_headers(self, token: Token) -> dict:
         """Get headers with authentication."""
         headers = dict(self.api_headers)
-        device_id = token.device_id or self.ccsp_device_id
+        device_id = token.device_id or self._ensure_device_id()
         headers["ccsp-device-id"] = device_id
         headers["ccsp-application-id"] = self.ccsp_application_id
         headers["Authorization"] = f"Bearer {token.access_token}"
@@ -262,10 +311,11 @@ class HyundaiBlueLinkApiBR(ApiImplType1):
             valid_until=expires_at,
             username=username,
             password=password,
-            device_id=self.ccsp_device_id,
+            device_id=self._ensure_device_id(),
             pin=pin,
         )
 
+    @_retry_on_device_id_error
     def get_vehicles(self, token: Token) -> list:
         """Get list of vehicles."""
         url = self._build_api_url("/spa/vehicles")
@@ -319,6 +369,7 @@ class HyundaiBlueLinkApiBR(ApiImplType1):
         _check_response_for_errors(response)
         return response["resMsg"]["state"]["Vehicle"]
 
+    @_retry_on_device_id_error
     def update_vehicle_with_cached_state(self, token: Token, vehicle: Vehicle) -> None:
         """Update with the server-cached CCS2 state (does not wake the car)."""
         state = self._get_cached_vehicle_state(token, vehicle)
@@ -374,7 +425,7 @@ class HyundaiBlueLinkApiBR(ApiImplType1):
         if not token.pin:
             raise APIError("PIN is required for remote commands.")
 
-        device_id = token.device_id or self.ccsp_device_id
+        device_id = token.device_id or self._ensure_device_id()
         token.device_id = device_id
 
         url = self._build_api_url("/user/pin")
@@ -401,7 +452,7 @@ class HyundaiBlueLinkApiBR(ApiImplType1):
     ) -> str:
         """Lock or unlock the vehicle."""
         control_token = self._ensure_control_token(token)
-        device_id = token.device_id or self.ccsp_device_id
+        device_id = token.device_id or self._ensure_device_id()
 
         url = self._build_api_v2_url(
             f"spa/vehicles/{vehicle.id}/control/door",
@@ -481,7 +532,7 @@ class HyundaiBlueLinkApiBR(ApiImplType1):
     ) -> str:
         """Open or close all windows (BR API controls all windows together)."""
         control_token = self._ensure_control_token(token)
-        device_id = token.device_id or self.ccsp_device_id
+        device_id = token.device_id or self._ensure_device_id()
 
         url = self._build_api_v2_url(f"spa/vehicles/{vehicle.id}/control/window")
 
@@ -519,7 +570,7 @@ class HyundaiBlueLinkApiBR(ApiImplType1):
     def start_hazard_lights(self, token: Token, vehicle: Vehicle) -> str:
         """Turn on hazard lights (lights only, no horn)."""
         control_token = self._ensure_control_token(token)
-        device_id = token.device_id or self.ccsp_device_id
+        device_id = token.device_id or self._ensure_device_id()
 
         url = self._build_api_v2_url(f"spa/vehicles/{vehicle.id}/control/light")
         headers = self._get_authenticated_headers(token)
@@ -558,7 +609,7 @@ class HyundaiBlueLinkApiBR(ApiImplType1):
     ) -> str:
         """Start climate control with temperature and seat heating settings."""
         control_token = self._ensure_control_token(token)
-        device_id = token.device_id or self.ccsp_device_id
+        device_id = token.device_id or self._ensure_device_id()
 
         url = self._build_api_v2_url(f"spa/vehicles/{vehicle.id}/control/engine")
 
@@ -622,7 +673,7 @@ class HyundaiBlueLinkApiBR(ApiImplType1):
     def stop_climate(self, token: Token, vehicle: Vehicle) -> str:
         """Stop climate control."""
         control_token = self._ensure_control_token(token)
-        device_id = token.device_id or self.ccsp_device_id
+        device_id = token.device_id or self._ensure_device_id()
 
         url = self._build_api_v2_url(f"spa/vehicles/{vehicle.id}/control/engine")
 

--- a/tests/test_br_login.py
+++ b/tests/test_br_login.py
@@ -22,6 +22,7 @@ from hyundai_kia_connect_api.exceptions import (
     InvalidAPIResponseError,
 )
 from hyundai_kia_connect_api.HyundaiBlueLinkApiBR import HyundaiBlueLinkApiBR
+from hyundai_kia_connect_api.Token import Token
 
 _BR_REGION = next(k for k, v in REGIONS.items() if v == REGION_BRAZIL)
 _HYUNDAI_BRAND = next(k for k, v in BRANDS.items() if v == BRAND_HYUNDAI)
@@ -143,10 +144,13 @@ class TestGetVehicles:
     def test_400_spa_envelope_raises_typed_error_not_httperror(self, br_api):
         # SPA envelope (retCode F + resCode 4002) → DeviceIDError via the shared
         # classifier, preserving device-id retry semantics — not a raw HTTPError.
+        # get_vehicles re-registers and retries once; when the retry fails the
+        # same way, the typed error still surfaces.
         br_api.session = MagicMock()
         br_api.session.get.return_value = _resp(
             400, {"retCode": "F", "resCode": "4002", "resMsg": "Invalid deviceId"}
         )
+        br_api._get_device_id = MagicMock(return_value="srv-1")
         with pytest.raises(DeviceIDError):
             br_api.get_vehicles(MagicMock())
 
@@ -181,3 +185,98 @@ class TestGetVehicles:
         vehicles = br_api.get_vehicles(MagicMock())
         assert len(vehicles) == 1
         assert vehicles[0].id == "v1"
+
+
+class TestDeviceIdRegistration:
+    """BR must use a server-issued device id, not a hardcoded/random one.
+
+    Regression for kia_uvo #1861: the device id hardcoded in #962 was
+    eventually invalidated server-side, so every authenticated SPA call
+    answered ``resCode 4002`` ("Invalid deviceId") and the integration was
+    stuck in ``setup_retry`` with all entities unavailable.
+    """
+
+    def test_no_hardcoded_device_id(self, br_api):
+        assert not hasattr(br_api, "ccsp_device_id")
+        assert br_api._registered_device_id is None
+
+    def test_get_device_id_returns_server_issued_id(self, br_api):
+        br_api.session = MagicMock()
+        br_api.session.post.return_value = _resp(
+            200, {"retCode": "S", "resCode": "0000", "resMsg": {"deviceId": "srv-1"}}
+        )
+        assert br_api._get_device_id() == "srv-1"
+
+        url = br_api.session.post.call_args.args[0]
+        assert url.endswith("/spa/notifications/register")
+        payload = br_api.session.post.call_args.kwargs["json"]
+        assert set(payload) == {"pushRegId", "pushType", "uuid"}
+        assert len(payload["pushRegId"]) == 64
+
+    def test_get_device_id_caches_for_reuse(self, br_api):
+        br_api.session = MagicMock()
+        br_api.session.post.return_value = _resp(
+            200, {"retCode": "S", "resCode": "0000", "resMsg": {"deviceId": "srv-1"}}
+        )
+        assert br_api._ensure_device_id() == "srv-1"
+        # Second call must not register another push device.
+        assert br_api._ensure_device_id() == "srv-1"
+        assert br_api.session.post.call_count == 1
+
+    def test_get_device_id_surfaces_registration_failure(self, br_api):
+        br_api.session = MagicMock()
+        br_api.session.post.return_value = _resp(403, None, text="<html>blocked</html>")
+        with pytest.raises(AuthenticationError, match="device registration"):
+            br_api._get_device_id()
+
+    def test_login_uses_registered_device_id(self, br_api):
+        br_api.session = MagicMock()
+        br_api._get_cookies = MagicMock(return_value={})
+        br_api._get_authorization_code = MagicMock(return_value="code")
+        br_api._get_auth_response = MagicMock(
+            return_value={
+                "access_token": "at",
+                "refresh_token": "rt",
+                "expires_in": 3600,
+            }
+        )
+        br_api._get_device_id = MagicMock(return_value="srv-1")
+
+        token = br_api.login("user@example.com", "pass")
+        assert token.device_id == "srv-1"
+
+    def test_get_vehicles_reregisters_and_retries_on_4002(self, br_api):
+        """A device id invalidated mid-session must self-heal, not strand the
+        integration until the next restart."""
+        br_api.session = MagicMock()
+        br_api.session.get.side_effect = [
+            _resp(
+                400, {"retCode": "F", "resCode": "4002", "resMsg": "Invalid deviceId"}
+            ),
+            _resp(
+                200,
+                {
+                    "resMsg": {
+                        "vehicles": [
+                            {
+                                "vehicleId": "v1",
+                                "nickname": "My Car",
+                                "vehicleName": "Creta",
+                                "regDate": "20240101",
+                                "vin": "VIN123",
+                                "type": "GN",
+                                "ccuCCS2ProtocolSupport": 0,
+                            }
+                        ]
+                    }
+                },
+            ),
+        ]
+        br_api._get_device_id = MagicMock(return_value="srv-2")
+
+        token = Token(access_token="at", device_id="stale-id")
+        vehicles = br_api.get_vehicles(token)
+
+        assert [v.id for v in vehicles] == ["v1"]
+        assert token.device_id == "srv-2"
+        br_api._get_device_id.assert_called_once()

--- a/tests/test_br_login.py
+++ b/tests/test_br_login.py
@@ -280,3 +280,60 @@ class TestDeviceIdRegistration:
         assert [v.id for v in vehicles] == ["v1"]
         assert token.device_id == "srv-2"
         br_api._get_device_id.assert_called_once()
+
+
+class TestRefreshAccessToken:
+    """BR must not inherit the Type1 refresh, which cannot work here.
+
+    ``ApiImplType1.refresh_access_token`` reads ``USER_API_URL`` /
+    ``BASE_URL`` / ``BASIC_AUTHORIZATION``; BR defines none of them, so every
+    refresh raised ``AttributeError``, was swallowed by the helper's
+    ``except Exception`` and degraded into a full login on every poll.
+    """
+
+    def test_refresh_uses_br_endpoint_and_preserves_device_id(self, br_api):
+        br_api.session = MagicMock()
+        br_api.session.post.return_value = _resp(
+            200, {"access_token": "at2", "refresh_token": "rt2", "expires_in": 3600}
+        )
+        token = Token(
+            username="user@example.com",
+            password="pass",
+            access_token="at1",
+            refresh_token="rt1",
+            device_id="srv-1",
+            pin="1234",
+        )
+
+        new_token = br_api.refresh_access_token(token)
+
+        url = br_api.session.post.call_args.args[0]
+        assert url == "https://br-ccapi.hyundai.com.br/api/v1/user/oauth2/token"
+        assert br_api.session.post.call_args.kwargs["data"]["grant_type"] == (
+            "refresh_token"
+        )
+        # BR adds its own "Bearer " prefix in _get_authenticated_headers, so the
+        # stored token must stay unprefixed (Type1 prepends token_type).
+        assert new_token.access_token == "at2"
+        assert new_token.refresh_token == "rt2"
+        assert new_token.device_id == "srv-1"
+        assert new_token.pin == "1234"
+
+    def test_refresh_without_refresh_token_falls_back_to_login(self, br_api):
+        br_api.login = MagicMock(return_value="logged-in")
+        token = Token(username="user@example.com", password="pass", refresh_token=None)
+
+        assert br_api.refresh_access_token(token) == "logged-in"
+        # pin must be passed as a keyword; Type1 passed it positionally into
+        # login()'s otp_handler slot.
+        br_api.login.assert_called_once_with("user@example.com", "pass", pin=None)
+
+    def test_refresh_failure_falls_back_to_login(self, br_api):
+        br_api.session = MagicMock()
+        br_api.session.post.return_value = _resp(
+            400, {"errCode": 4001, "errMsg": "Invalid grant"}
+        )
+        br_api.login = MagicMock(return_value="logged-in")
+        token = Token(username="user@example.com", password="pass", refresh_token="rt1")
+
+        assert br_api.refresh_access_token(token) == "logged-in"


### PR DESCRIPTION
## Summary

Fixes Hyundai-Kia-Connect/kia_uvo#1861.

Fixes the Brazilian Hyundai BlueLink integration, which is currently
dead for every BR user: the device id hardcoded in #962 has been
invalidated server-side, so every authenticated SPA call answers
`retCode: F / resCode: 4002` ("Invalid request body - Invalid deviceId").
`get_vehicles` raises `DeviceIDError` immediately after a successful
login, so in Home Assistant the config entry never leaves `setup_retry`
and all entities stay `unavailable`.

```
File ".../hyundai_kia_connect_api/HyundaiBlueLinkApiBR.py", line 276, in get_vehicles
    _check_response_for_errors(response)
hyundai_kia_connect_api.exceptions.DeviceIDError: Invalid request body - Invalid deviceId.
```

### 1. Register a real device id (`fix(BR): register a real device id...`)

The BR backend validates `ccsp-device-id` against its own device
registry — which is why #962 had to replace the random UUID with a
registered one. Replacing one constant with another only moves the
expiry date, so this registers the id the same way EU and IN already
do, via `POST /api/v1/spa/notifications/register`. Verified against the
live BR backend:

```
$ POST https://br-ccapi.hyundai.com.br/api/v1/spa/notifications/register
{"retCode":"S","resCode":"0000","resMsg":{"deviceId":"f24874fa-..."}}
```

The id is registered once per API object and reused, so a full login
does not register a new push device on every poll. `get_vehicles` and
`update_vehicle_with_cached_state` now use the existing
`_retry_on_device_id_error` helper, so a future server-side
invalidation re-registers and recovers instead of stranding the
integration until a restart.

### 2. BR-specific `refresh_access_token` (`fix(BR): implement the region's own...`)

Separate latent bug on the same path, happy to split it out if you
prefer. BR inherited `ApiImplType1.refresh_access_token`, which reads
`USER_API_URL` / `BASE_URL` / `BASIC_AUTHORIZATION` — attributes only
EU/AU/IN/CN set in their `__init__`. On BR every refresh raised
`AttributeError`, was swallowed by the helper's `except Exception` and
degraded into a full login **on every poll**:

```
WARNING [hyundai_kia_connect_api.ApiImplType1] Refresh token exchange failed, falling back to full login
```

It also prepends `token_type` to `access_token`, while BR builds its own
`Bearer` prefix in `_get_authenticated_headers`, so it could not have
worked here even with the attributes present.

## Test plan

- [x] `pytest` — 557 passed (10 new BR tests; one existing BR test
      updated for the new retry semantics)
- [x] `ruff check` / `ruff format`
- [x] Verified live against a real BR account (Creta, ICE) on
      Home Assistant 2026.9.0 + kia_uvo 3.11.0: config entry goes from
      `setup_retry` to `loaded`, and odometer / fuel level / driving
      range / 12V battery / lock state / location all report real values.
      No `DeviceIDError` and no "falling back to full login" warnings
      after the change.
- [ ] `refresh_access_token` exercised only after the access token
      expires; the full-login fallback keeps behaviour no worse than
      today if a BR server rejects the grant.

## Relation to #1287

@jonhnes reached the same diagnosis in #1287 (self-closed before review).
This PR differs in three ways:

- **Keeps `ccsp-application-id` as-is.** #1287 also changed it from
  `513a491a-...` to `213a491a-...`; the existing value registers and
  authenticates fine against the live backend, so this leaves it alone.
- **Registration matches the file's existing iOS client.** The module
  already sends a `BR_BlueLink/1.0.14 ... iOS 18.4.0` user agent, so this
  registers with `pushType: APNS` and a 64-hex `pushRegId`, exactly like
  EU/IN. #1287 registered as an Android/GCM client.
- **Wires up the retry decorator.** #1287 cached inside `_get_device_id`
  itself, which makes it a no-op for `_retry_on_device_id_error` (noted
  there as deferred to a follow-up). Splitting `_get_device_id` (always
  fresh) from `_ensure_device_id` (cached) lets the existing helper work,
  so recovery is included rather than deferred.

No unrelated changes are bundled in — #1287 also carried a `start_climate`
`temp_code` change.
