### PR TITLE
fix: correct inverted offPeakPowerFlag semantics (prioritised vs only)

### DIFF
--- a/hyundai_kia_connect_api/ApiImplType1.py
+++ b/hyundai_kia_connect_api/ApiImplType1.py
@@ -1191,7 +1191,10 @@ class ApiImplType1(ApiImpl):
                         "time": options.off_peak_start_time.strftime("%I%M"),
                     },
                 },
-                "offPeakPowerFlag": 1 if options.off_peak_charge_only_enabled else 2,
+                # Flag semantics match the apps' vehicle data model:
+                # 1 = considering peak time ("off-peak tariffs prioritised"),
+                # 2 = only peak time ("off-peak tariffs only"), 0 = not applied.
+                "offPeakPowerFlag": 2 if options.off_peak_charge_only_enabled else 1,
             },
             "reservFlag": 1 if options.charging_enabled else 0,
         }
@@ -1230,7 +1233,8 @@ class ApiImplType1(ApiImpl):
 
         charge_payload = {
             "reservFlag": 1 if options.charging_enabled else 0,
-            "offpeakPowerFlag": (1 if options.off_peak_charge_only_enabled else 2),
+            # Same enum as the combined path: 2 = only off-peak, 1 = prioritised.
+            "offpeakPowerFlag": (2 if options.off_peak_charge_only_enabled else 1),
             "reservStartTime": {
                 "time": options.off_peak_start_time.strftime("%I%M"),
                 "timeSection": (

--- a/hyundai_kia_connect_api/KiaUvoApiAU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiAU.py
@@ -568,6 +568,9 @@ class KiaUvoApiAU(ApiImplType1):
             ),
         )
 
+        # offPeakPowerFlag semantics match the apps' vehicle data model:
+        # 1 = considering peak time ("off-peak tariffs prioritised"),
+        # 2 = only peak time ("off-peak tariffs only"), 0 = not applied.
         if get_child_value(
             state,
             "status.evStatus.reservChargeInfos.offpeakPowerInfo.offPeakPowerFlag",
@@ -577,7 +580,7 @@ class KiaUvoApiAU(ApiImplType1):
                     state,
                     "status.evStatus.reservChargeInfos.offpeakPowerInfo.offPeakPowerFlag",
                 )
-                == 1
+                == 2
             ):
                 vehicle.ev_off_peak_charge_only_enabled = True
             elif (
@@ -585,7 +588,7 @@ class KiaUvoApiAU(ApiImplType1):
                     state,
                     "status.evStatus.reservChargeInfos.offpeakPowerInfo.offPeakPowerFlag",
                 )
-                == 2
+                == 1
             ):
                 vehicle.ev_off_peak_charge_only_enabled = False
 

--- a/hyundai_kia_connect_api/KiaUvoApiCN.py
+++ b/hyundai_kia_connect_api/KiaUvoApiCN.py
@@ -934,6 +934,9 @@ class KiaUvoApiCN(ApiImplType1):
             ),
         )
 
+        # offPeakPowerFlag semantics match the apps' vehicle data model:
+        # 1 = considering peak time ("off-peak tariffs prioritised"),
+        # 2 = only peak time ("off-peak tariffs only"), 0 = not applied.
         if get_child_value(
             state,
             "status.evStatus.reservChargeInfos.offpeakPowerInfo.offPeakPowerFlag",
@@ -943,7 +946,7 @@ class KiaUvoApiCN(ApiImplType1):
                     state,
                     "status.evStatus.reservChargeInfos.offpeakPowerInfo.offPeakPowerFlag",
                 )
-                == 1
+                == 2
             ):
                 vehicle.ev_off_peak_charge_only_enabled = True
             elif (
@@ -951,7 +954,7 @@ class KiaUvoApiCN(ApiImplType1):
                     state,
                     "status.evStatus.reservChargeInfos.offpeakPowerInfo.offPeakPowerFlag",
                 )
-                == 2
+                == 1
             ):
                 vehicle.ev_off_peak_charge_only_enabled = False
 

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -1161,6 +1161,9 @@ class KiaUvoApiEU(ApiImplType1):
             ),
         )
 
+        # offPeakPowerFlag semantics match the apps' vehicle data model:
+        # 1 = considering peak time ("off-peak tariffs prioritised"),
+        # 2 = only peak time ("off-peak tariffs only"), 0 = not applied.
         if get_child_value(
             state,
             "vehicleStatus.evStatus.reservChargeInfos.offpeakPowerInfo.offPeakPowerFlag",
@@ -1170,7 +1173,7 @@ class KiaUvoApiEU(ApiImplType1):
                     state,
                     "vehicleStatus.evStatus.reservChargeInfos.offpeakPowerInfo.offPeakPowerFlag",
                 )
-                == 1
+                == 2
             ):
                 vehicle.ev_off_peak_charge_only_enabled = True
             elif (
@@ -1178,7 +1181,7 @@ class KiaUvoApiEU(ApiImplType1):
                     state,
                     "vehicleStatus.evStatus.reservChargeInfos.offpeakPowerInfo.offPeakPowerFlag",
                 )
-                == 2
+                == 1
             ):
                 vehicle.ev_off_peak_charge_only_enabled = False
 

--- a/tests/test_ccs2_vehicle_properties.py
+++ b/tests/test_ccs2_vehicle_properties.py
@@ -505,8 +505,8 @@ def test_ccs2_off_peak_sentinel_31_70_is_none_silent(ccs2_api, vehicle, caplog):
     assert "malformed" not in caplog.text
 
 
-def test_schedule_charging_off_peak_flag_not_inverted(ccs2_api, vehicle):
-    """charge_only=True (time-priority) must send offPeakPowerFlag=1, not 2."""
+def test_schedule_charging_off_peak_flag_only(ccs2_api, vehicle):
+    """charge_only=True must send offPeakPowerFlag=2 ("off-peak tariffs only")."""
     from hyundai_kia_connect_api.ApiImpl import ScheduleChargingClimateRequestOptions
 
     options = ScheduleChargingClimateRequestOptions(
@@ -539,11 +539,11 @@ def test_schedule_charging_off_peak_flag_not_inverted(ccs2_api, vehicle):
     vehicle.id = "test-vehicle-id"
 
     ccs2_api.schedule_charging_and_climate(token=None, vehicle=vehicle, options=options)
-    assert captured["payload"]["offPeakPowerInfo"]["offPeakPowerFlag"] == 1
+    assert captured["payload"]["offPeakPowerInfo"]["offPeakPowerFlag"] == 2
 
 
-def test_schedule_charging_off_peak_flag_target_priority(ccs2_api, vehicle):
-    """charge_only=False (target-priority) must send offPeakPowerFlag=2."""
+def test_schedule_charging_off_peak_flag_prioritised(ccs2_api, vehicle):
+    """charge_only=False must send offPeakPowerFlag=1 ("off-peak tariffs prioritised")."""
     from hyundai_kia_connect_api.ApiImpl import ScheduleChargingClimateRequestOptions
 
     options = ScheduleChargingClimateRequestOptions(
@@ -576,4 +576,4 @@ def test_schedule_charging_off_peak_flag_target_priority(ccs2_api, vehicle):
     vehicle.id = "test-vehicle-id"
 
     ccs2_api.schedule_charging_and_climate(token=None, vehicle=vehicle, options=options)
-    assert captured["payload"]["offPeakPowerInfo"]["offPeakPowerFlag"] == 2
+    assert captured["payload"]["offPeakPowerInfo"]["offPeakPowerFlag"] == 1

--- a/tests/test_schedule_ev5_flat.py
+++ b/tests/test_schedule_ev5_flat.py
@@ -131,8 +131,8 @@ class TestEV5Dispatch:
 class TestCCSPCombinedPayload:
     """CCSP / EV2-EV4 combined /reservation/chargehvac payload shape.
 
-    The offPeakPowerFlag enum direction (1 = time, 2 = target) is covered by
-    ``test_ccs2_vehicle_properties::test_schedule_charging_off_peak_flag_*``;
+    The offPeakPowerFlag enum direction (1 = prioritised, 2 = only) is
+    covered by ``test_ccs2_vehicle_properties::test_schedule_charging_off_peak_flag_*``;
     this class locks the surrounding payload structure and the off-peak
     window envelope so a refactor cannot silently drop fields.
     """
@@ -181,24 +181,25 @@ class TestEV5FlatChargePayload:
             "reservEndTime",
         }
 
-    def test_offpeak_power_flag_time_vs_target(self, api):
-        # off_peak_charge_only_enabled=True -> flag 1 (time-priority)
+    def test_offpeak_power_flag_only(self, api):
+        # off_peak_charge_only_enabled=True -> flag 2 ("off-peak tariffs only")
         calls = _mock_post(api)
         v = _make_vehicle(ccs2=1, engine_type=ENGINE_TYPES.EV)
         api.schedule_charging_and_climate(
             MagicMock(spec=Token), v, _options(off_peak_charge_only_enabled=True)
         )
         charge = next(c["json"] for c in calls if c["url"].endswith("/charge"))
-        assert charge["offpeakPowerFlag"] == 1
+        assert charge["offpeakPowerFlag"] == 2
 
-    def test_offpeak_power_flag_target(self, api):
+    def test_offpeak_power_flag_prioritised(self, api):
+        # off_peak_charge_only_enabled=False -> flag 1 ("off-peak tariffs prioritised")
         calls = _mock_post(api)
         v = _make_vehicle(ccs2=1, engine_type=ENGINE_TYPES.EV)
         api.schedule_charging_and_climate(
             MagicMock(spec=Token), v, _options(off_peak_charge_only_enabled=False)
         )
         charge = next(c["json"] for c in calls if c["url"].endswith("/charge"))
-        assert charge["offpeakPowerFlag"] == 2
+        assert charge["offpeakPowerFlag"] == 1
 
     def test_reserv_flag_on_off(self, api):
         calls = _mock_post(api)


### PR DESCRIPTION
## Summary

`offPeakPowerFlag` in the vehicle data model is inverted on both the write and the read side, so `off_peak_charge_only_enabled=True` flips the vehicle to "off-peak tariffs **prioritised**" instead of "off-peak tariffs **only**", and the status parser mirrors the same inversion — the integration disagrees with the vehicle's own UI while looking self-consistent after a refresh.

Reported in Hyundai-Kia-Connect/kia_uvo#1850 (EU, Kia Niro EV).

## Correct semantics

| value | meaning (vehicle data model / app UI) |
|---|---|
| `0` | not applied |
| `1` | considering peak time — "off-peak tariffs prioritised" |
| `2` | only peak time — "off-peak tariffs only" |

## Changes

- **Write, combined path** (`/ccs2/reservation/chargehvac`): send `2` when `off_peak_charge_only_enabled` is true, `1` when false (was inverted).
- **Write, flat EV5 path** (`/ccs2/reservation/charge`, lowercase `offpeakPowerFlag`): same swap.
- **Read parsers** (`KiaUvoApiEU`, `KiaUvoApiAU`, `KiaUvoApiCN`): flag `2` → `ev_off_peak_charge_only_enabled = True`, flag `1` → `False` (was inverted).
- **CCS2 parser** (`Green.Reservation.OffPeakTime.Mode`: 0 = off, 2 = prioritised, 3 = only) is unchanged — it was already correct.
- Flag `0` handling is unchanged on both sides (falsy → no change / `None`).
- Tests: flipped the four write-direction assertions and renamed the affected tests; no fixture or snapshot changes.

## User-visible note

After updating, `ev_off_peak_charge_only_enabled` will reflect what the vehicle actually reports, so existing entities may appear to flip state once compared to 4.27.x — that is the correction, not a regression.