### PR TITLE
fix(EU): accept flat resMsg location shape in _get_location

### DIFF
--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -1291,10 +1291,15 @@ class KiaUvoApiEU(ApiImplType1):
             ).json()
             _LOGGER.debug(f"{DOMAIN} - _get_location response: {response}")
             _check_response_for_errors(response)
-            gps_detail = response["resMsg"].get("gpsDetail")
+            res_msg = response["resMsg"]
+            gps_detail = res_msg.get("gpsDetail")
+            if gps_detail is None and res_msg.get("coord"):
+                # Some accounts return the location fields flat under resMsg
+                # (GET /location/park already uses the same flat shape).
+                gps_detail = res_msg
             if gps_detail is None:
                 _LOGGER.warning(
-                    f"{DOMAIN} - gpsDetail not found in location response, "
+                    f"{DOMAIN} - no location data in location response, "
                     "vehicle may be offline or returning partial status"
                 )
             return gps_detail

--- a/hyundai_kia_connect_api/KiaUvoApiEU.py
+++ b/hyundai_kia_connect_api/KiaUvoApiEU.py
@@ -1292,16 +1292,9 @@ class KiaUvoApiEU(ApiImplType1):
             _LOGGER.debug(f"{DOMAIN} - _get_location response: {response}")
             _check_response_for_errors(response)
             res_msg = response["resMsg"]
-            gps_detail = res_msg.get("gpsDetail")
-            if gps_detail is None and res_msg.get("coord"):
-                # Some accounts return the location fields flat under resMsg
-                # (GET /location/park already uses the same flat shape).
-                gps_detail = res_msg
-            if gps_detail is None:
-                _LOGGER.warning(
-                    f"{DOMAIN} - no location data in location response, "
-                    "vehicle may be offline or returning partial status"
-                )
+            # Some accounts return the location fields flat under resMsg
+            # (GET /location/park already parses the same flat shape, #1301).
+            gps_detail = res_msg.get("gpsDetail") or res_msg
             return gps_detail
         except Exception as e:
             _LOGGER.exception(f"{DOMAIN} - _get_location failed: {e}")  # noqa: TRY401
@@ -1320,6 +1313,10 @@ class KiaUvoApiEU(ApiImplType1):
         offset early. Convert here, as the CCS2 'Date' field does (#1147).
         """
         if not gps_detail or not get_child_value(gps_detail, "coord.lat"):
+            _LOGGER.warning(
+                f"{DOMAIN} - no location data in location response, "
+                "vehicle may be offline or returning partial status"
+            )
             return
         # A missing timestamp must stay None, which HA shows as "unknown".
         # See kia_uvo #1771.

--- a/tests/test_eu_location_flat_resmsg.py
+++ b/tests/test_eu_location_flat_resmsg.py
@@ -1,0 +1,123 @@
+"""EU forced refresh: GET /location may return the location fields flat under
+resMsg, without the gpsDetail wrapper (#1301).
+
+Some EU non-CCS2 accounts (Kia Sorento 2021 reported in #1301) return
+resMsg.{coord, head, speed, accuracy, time} directly, the same flat shape GET
+/location/park already parses. The old code read only resMsg.gpsDetail and
+silently dropped the position.
+"""
+
+import datetime as dt
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hyundai_kia_connect_api.KiaUvoApiEU import KiaUvoApiEU
+from hyundai_kia_connect_api.Vehicle import Vehicle
+
+# Raw response shape from #1301: the fields sit directly in resMsg.
+FLAT_LOCATION = {
+    "retCode": "S",
+    "resCode": "0000",
+    "resMsg": {
+        "coord": {"lat": 52.52, "lon": 13.405, "alt": 0, "type": 0},
+        "head": 127,
+        "speed": {"value": 0, "unit": 0},
+        "accuracy": {"hdop": 0, "pdop": 0},
+        "time": "20260903105844",
+    },
+}
+WRAPPED_LOCATION = {
+    "retCode": "S",
+    "resCode": "0000",
+    "resMsg": {
+        "gpsDetail": {
+            "coord": {"lat": 48.85, "lon": 2.35},
+            "time": "20260903110000",
+        }
+    },
+}
+FORCED_STATUS = {"retCode": "S", "resCode": "0000", "resMsg": {"doorLock": True}}
+
+
+@pytest.fixture
+def eu_api() -> KiaUvoApiEU:
+    api = KiaUvoApiEU.__new__(KiaUvoApiEU)
+    api.SPA_API_URL = "https://test.invalid/api/v1/spa/"
+    api.data_timezone = KiaUvoApiEU.data_timezone
+    api.temperature_range = KiaUvoApiEU.temperature_range
+    api.session = MagicMock()
+    api._get_authenticated_headers = MagicMock(
+        return_value={"Authorization": "Bearer x"}
+    )
+    return api
+
+
+@pytest.fixture
+def vehicle() -> Vehicle:
+    v = Vehicle()
+    v.id = "vid-123"
+    v.ccu_ccs2_protocol_support = 0
+    return v
+
+
+def _mock_get(status, location):
+    def get(url, headers=None):
+        resp = MagicMock()
+        resp.json.return_value = location if url.endswith("/location") else status
+        return resp
+
+    return get
+
+
+def test_flat_resmsg_location_is_applied(eu_api, vehicle):
+    token = SimpleNamespace(access_token="t", device_id="d")
+    with patch.object(
+        eu_api.session, "get", side_effect=_mock_get(FORCED_STATUS, FLAT_LOCATION)
+    ):
+        eu_api.force_refresh_vehicle_state(token, vehicle)
+
+    assert vehicle.location_latitude == 52.52
+    assert vehicle.location_longitude == 13.405
+    # The flat shape feeds the same gpsDetail clock: UTC, converted like
+    # the wrapped shape (#1292).
+    assert vehicle.location_last_updated_at == dt.datetime(
+        2026, 9, 3, 10, 58, 44, tzinfo=dt.UTC
+    )
+
+
+def test_wrapped_gps_detail_takes_precedence(eu_api, vehicle):
+    """Accounts that do return the wrapper must not change behavior."""
+    location = WRAPPED_LOCATION
+    token = SimpleNamespace(access_token="t", device_id="d")
+    with patch.object(
+        eu_api.session, "get", side_effect=_mock_get(FORCED_STATUS, location)
+    ):
+        eu_api.force_refresh_vehicle_state(token, vehicle)
+
+    assert vehicle.location_latitude == 48.85
+    assert vehicle.location_longitude == 2.35
+    assert vehicle.location_last_updated_at == dt.datetime(
+        2026, 9, 3, 11, 0, 0, tzinfo=dt.UTC
+    )
+
+
+def test_resmsg_without_coord_does_not_become_location(eu_api, vehicle):
+    """No gpsDetail and no coord is still the offline/partial case: no
+    fallback, keep the previously known position."""
+    cached = dt.datetime(2026, 9, 3, 8, 0, 0, tzinfo=KiaUvoApiEU.data_timezone)
+    vehicle.location = (52.52, 13.405, cached)
+    location = {
+        "retCode": "S",
+        "resCode": "0000",
+        "resMsg": {"head": 127},
+    }
+    token = SimpleNamespace(access_token="t", device_id="d")
+    with patch.object(
+        eu_api.session, "get", side_effect=_mock_get(FORCED_STATUS, location)
+    ):
+        eu_api.force_refresh_vehicle_state(token, vehicle)
+
+    assert vehicle.location_latitude == 52.52
+    assert vehicle.location_last_updated_at == cached

--- a/tests/test_eu_location_flat_resmsg.py
+++ b/tests/test_eu_location_flat_resmsg.py
@@ -104,8 +104,9 @@ def test_wrapped_gps_detail_takes_precedence(eu_api, vehicle):
 
 
 def test_resmsg_without_coord_does_not_become_location(eu_api, vehicle):
-    """No gpsDetail and no coord is still the offline/partial case: no
-    fallback, keep the previously known position."""
+    """No gpsDetail and no coord is still the offline/partial case: the flat
+    fallback hands resMsg over, but the coord guard in
+    _set_location_from_gps_detail keeps the previously known position."""
     cached = dt.datetime(2026, 9, 3, 8, 0, 0, tzinfo=KiaUvoApiEU.data_timezone)
     vehicle.location = (52.52, 13.405, cached)
     location = {


### PR DESCRIPTION
## Problem

Some EU (non-CCS2) accounts return `GET /location` with the location fields directly under `resMsg`, without the `gpsDetail` wrapper:

```
'resMsg': {'coord': {'lat': …, 'lon': …, 'alt': 0, 'type': 0},
           'head': 0, 'speed': {'value': 0, 'unit': 0},
           'accuracy': {'hdop': 0, 'pdop': 0},
           'time': '20260903105844'}
```

`_get_location()` reads only `resMsg.gpsDetail`, so for these accounts:

- the HTTP call succeeds and the response contains valid, fresh location data, but
- `_get_location()` returns `None` and logs `gpsDetail not found … vehicle may be offline or returning partial status` — misleading, since the vehicle is online and the payload is complete,
- `_update_vehicle_properties()` then skips the `vehicle.location*` fields entirely: a successful `force_refresh_vehicle_state()` does not update the location at all (reported in #1301 with the raw response).

## Fix

Fall back to `resMsg` itself when `gpsDetail` is absent but it carries a `coord`. This mirrors the existing parsing of `GET /location/park` (`_set_cached_location_park`), which already reads the flat `resMsg` shape directly — the same API family, same shape.

The offline/partial warning now only fires when the response truly contains no location data, and its wording no longer references `gpsDetail` (which is not what is missing in the flat case).

Downstream (`_set_location_from_gps_detail`, UTC handling from #1292) is unchanged: the flat `resMsg` carries exactly the keys it reads (`coord`, `time`).

## Tests

New `tests/test_eu_location_flat_resmsg.py` (built from the raw response in #1301):

- flat `resMsg` → location applied, time converted as UTC like the wrapped shape
- wrapped `gpsDetail` (both present) → unchanged behavior, wrapper takes precedence
- neither → no fallback, previously known position kept, warning logged

Closes #1301