### PR TITLE
fix: isolate vehicle-level API errors in aggregate update loops

### DIFF
--- a/hyundai_kia_connect_api/VehicleManager.py
+++ b/hyundai_kia_connect_api/VehicleManager.py
@@ -36,7 +36,7 @@ from .const import (
     VALET_MODE_ACTION,
     VEHICLE_LOCK_ACTION,
 )
-from .exceptions import APIError, AuthenticationOTPRequired
+from .exceptions import APIError, AuthenticationOTPRequired, RateLimitingError
 from .HyundaiBlueLinkApiBR import HyundaiBlueLinkApiBR
 from .HyundaiBlueLinkApiUSA import HyundaiBlueLinkApiUSA
 from .HyundaiCciApiEU import HyundaiCciApiEU
@@ -140,7 +140,14 @@ class VehicleManager:
 
     def update_all_vehicles_with_cached_state(self) -> None:
         for vehicle_id in self.vehicles:
-            self.update_vehicle_with_cached_state(vehicle_id)
+            try:
+                self.update_vehicle_with_cached_state(vehicle_id)
+            except RateLimitingError:
+                raise
+            except APIError as e:
+                _LOGGER.warning(
+                    f"{DOMAIN} - Failed to update vehicle {vehicle_id}: {e}"
+                )
 
     def update_vehicle_with_cached_state(self, vehicle_id: str) -> None:
         vehicle = self.get_vehicle(vehicle_id)
@@ -160,7 +167,14 @@ class VehicleManager:
 
     def check_and_force_update_vehicles(self, force_refresh_interval: int) -> None:
         for vehicle_id in self.vehicles:
-            self.check_and_force_update_vehicle(force_refresh_interval, vehicle_id)
+            try:
+                self.check_and_force_update_vehicle(force_refresh_interval, vehicle_id)
+            except RateLimitingError:
+                raise
+            except APIError as e:
+                _LOGGER.warning(
+                    f"{DOMAIN} - Failed to update vehicle {vehicle_id}: {e}"
+                )
 
     def check_and_force_update_vehicle(
         self, force_refresh_interval: int, vehicle_id: str
@@ -184,7 +198,14 @@ class VehicleManager:
 
     def force_refresh_all_vehicles_states(self) -> None:
         for vehicle_id in self.vehicles:
-            self.force_refresh_vehicle_state(vehicle_id)
+            try:
+                self.force_refresh_vehicle_state(vehicle_id)
+            except RateLimitingError:
+                raise
+            except APIError as e:
+                _LOGGER.warning(
+                    f"{DOMAIN} - Failed to update vehicle {vehicle_id}: {e}"
+                )
 
     def force_refresh_vehicle_state(self, vehicle_id: str) -> None:
         vehicle = self.get_vehicle(vehicle_id)

--- a/tests/test_vehicle_manager_update_isolation.py
+++ b/tests/test_vehicle_manager_update_isolation.py
@@ -1,0 +1,103 @@
+"""Per-vehicle error isolation in the aggregate update loops (#1280).
+
+One unreachable vehicle (resCode 5031) used to abort the whole update, taking
+every other vehicle of the account down with it in Home Assistant. The
+aggregate loops now isolate vehicle-level API errors; authentication and rate
+limiting errors still propagate (they are account-level and must reach the
+caller), as does a direct call on a single vehicle.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from hyundai_kia_connect_api.exceptions import (
+    APIError,
+    AuthenticationError,
+    RateLimitingError,
+)
+from hyundai_kia_connect_api.Token import Token
+from hyundai_kia_connect_api.Vehicle import Vehicle
+from hyundai_kia_connect_api.VehicleManager import VehicleManager
+
+
+def _manager(raise_for, error):
+    """A two-vehicle manager whose api raises `error` for vehicle-1."""
+    manager = VehicleManager.__new__(VehicleManager)
+    manager.api = MagicMock()
+    manager.token = Token(access_token="x", refresh_token="y", device_id="z")
+    manager.geocode_api_enable = False
+    manager.vehicles = {}
+    for vehicle_id in ("vehicle-1", "vehicle-2"):
+        vehicle = Vehicle()
+        vehicle.id = vehicle_id
+        vehicle.enabled = True
+        manager.vehicles[vehicle_id] = vehicle
+    manager.api.update_vehicle_with_cached_state.side_effect = _raise_or_pass(
+        raise_for, error
+    )
+    manager.api.force_refresh_vehicle_state.side_effect = _raise_or_pass(
+        raise_for, error
+    )
+    return manager
+
+
+def _raise_or_pass(raise_for, error):
+    def behavior(token, vehicle, *args, **kwargs):
+        if vehicle.id in raise_for:
+            raise error
+
+    return behavior
+
+
+def test_cached_update_isolates_one_failing_vehicle():
+    manager = _manager(raise_for=("vehicle-1",), error=APIError("5031 unreachable"))
+    manager.update_all_vehicles_with_cached_state()
+
+    manager.api.update_vehicle_with_cached_state.assert_any_call(
+        manager.token, manager.vehicles["vehicle-2"]
+    )
+    assert manager.vehicles["vehicle-2"].last_scanned_at is not None
+
+
+def test_check_and_force_update_isolates_one_failing_vehicle():
+    manager = _manager(raise_for=("vehicle-1",), error=APIError("5031 unreachable"))
+    manager.check_and_force_update_vehicles(3600)
+
+    manager.api.update_vehicle_with_cached_state.assert_any_call(
+        manager.token, manager.vehicles["vehicle-2"]
+    )
+
+
+def test_force_refresh_isolates_one_failing_vehicle():
+    manager = _manager(raise_for=("vehicle-1",), error=APIError("5031 unreachable"))
+    manager.force_refresh_all_vehicles_states()
+
+    manager.api.force_refresh_vehicle_state.assert_any_call(
+        manager.token, manager.vehicles["vehicle-2"]
+    )
+
+
+@pytest.mark.parametrize(
+    "error", [AuthenticationError("token expired"), RateLimitingError("too fast")]
+)
+def test_account_level_errors_propagate(error):
+    manager = _manager(raise_for=("vehicle-1",), error=error)
+    with pytest.raises(type(error)):
+        manager.update_all_vehicles_with_cached_state()
+
+
+def test_single_vehicle_update_still_raises():
+    manager = _manager(raise_for=("vehicle-1",), error=APIError("5031 unreachable"))
+    with pytest.raises(APIError):
+        manager.update_vehicle_with_cached_state("vehicle-1")
+
+
+def test_isolation_logs_a_warning(caplog):
+    manager = _manager(raise_for=("vehicle-1",), error=APIError("5031 unreachable"))
+    manager.update_all_vehicles_with_cached_state()
+
+    assert any(
+        "vehicle-1" in record.message and "5031" in record.message
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Problem

A single unreachable vehicle (resCode `5031`) aborts the whole update. The three aggregate loops in `VehicleManager` have no per-vehicle error handling, so one failing vehicle raises out of the loop and the caller never reaches the remaining vehicles. In Home Assistant, where the account runs on a single coordinator (`DataUpdateCoordinator`), one bad VIN means one `UpdateFailed` for the whole account: **every** entity of **every** vehicle goes unavailable, including the healthy ones (#1280). kia_uvo uses all three loops (`check_and_force_update_vehicles`, `update_all_vehicles_with_cached_state`, `force_refresh_all_vehicles_states`), so the failure path is shared.

## Fix

The three aggregate loops now catch vehicle-level API errors per vehicle, log a warning naming the vehicle, and continue with the next one:

```python
for vehicle_id in self.vehicles:
    try:
        self.update_vehicle_with_cached_state(vehicle_id)
    except RateLimitingError:
        raise
    except APIError as e:
        _LOGGER.warning(f"{DOMAIN} - Failed to update vehicle {vehicle_id}: {e}")
```

### What propagates, and why

- **`AuthenticationError`** propagates: an expired token fails identically for every vehicle; swallowing it would mask the re-auth path behind "success".
- **`RateLimitingError`** propagates (`except RateLimitingError: raise`): rate limiting is account-level — isolating it would let the caller keep polling at the same pace and make the problem worse.
- **Other exceptions** (network, non-library) propagate: they are account-level too.
- **`APIError` and its vehicle-level subclasses** (`InvalidAPIResponseError`, `DeviceIDError`, `DuplicateRequestError`, `ServiceTemporaryUnavailable`, `NoDataFound`, …) are isolated — resCode `5031` is this case.

### Explicit single-vehicle calls are unchanged

`update_vehicle_with_cached_state(vehicle_id)`, `check_and_force_update_vehicle(...)`, `force_refresh_vehicle_state(vehicle_id)` still raise — a direct call on one vehicle is an explicit request and the caller must see the failure.

### Known tradeoff

The failing vehicle keeps its last known data (stale, with a warning in the log) instead of its entities going unavailable. That is the pre-existing behavior for that vehicle; the change is that the healthy vehicles keep updating instead of being dragged down with it.

## Tests

New `tests/test_vehicle_manager_update_isolation.py` (7 tests):

- each of the three loops isolates a failing vehicle and still updates the second
- `AuthenticationError` and `RateLimitingError` propagate out of the loop
- a direct single-vehicle call still raises
- the warning names the vehicle and the error

Closes #1280