### PR TITLE
feat(svm): expose full imageSize array and validAngleofView on SVMDetails

### DIFF
--- a/hyundai_kia_connect_api/GspaApiEU.py
+++ b/hyundai_kia_connect_api/GspaApiEU.py
@@ -37,6 +37,8 @@ from .svm import (
     SVMDetails,
     _parse_bool,
     _parse_door_open,
+    _parse_float_list,
+    _parse_image_sizes,
     _parse_int,
     redact_svm_metadata,
 )
@@ -110,10 +112,10 @@ def parse_svm_detail(detail: dict[str, Any]) -> SVMDetails:
     """Parse a GSPA SVM ``scsDetail`` object into SVMDetails.
 
     The GSPA response shape mirrors the USA SVM response (gpsDetail with
-    coord/head/speed/time, doorOpen, trunkOpen, imageSize). Fields without
-    a typed slot on SVMDetails (installAngle, boundaryArea,
-    validAngleofView, sideMirrorOpen) stay available through raw_metadata
-    with the base64 image redacted.
+    coord/head/speed/time, doorOpen, trunkOpen, imageSize, and
+    validAngleofView). Fields without a typed slot on SVMDetails
+    (installAngle, boundaryArea, sideMirrorOpen) stay available through
+    raw_metadata with the base64 image redacted.
     """
     gps = detail.get("gpsDetail")
     if not isinstance(gps, dict):
@@ -131,13 +133,7 @@ def parse_svm_detail(detail: dict[str, Any]) -> SVMDetails:
     except (ValueError, TypeError):
         image_bytes = b""
 
-    image_size = None
-    image_size_raw = detail.get("imageSize")
-    if isinstance(image_size_raw, list) and len(image_size_raw) >= 2:
-        width = _parse_int(image_size_raw[0])
-        height = _parse_int(image_size_raw[1])
-        if width is not None and height is not None:
-            image_size = (width, height)
+    image_size, image_sizes = _parse_image_sizes(detail.get("imageSize"))
 
     captured_at_raw = gps.get("time")
     return SVMDetails(
@@ -151,6 +147,8 @@ def parse_svm_detail(detail: dict[str, Any]) -> SVMDetails:
         door_open=_parse_door_open(detail.get("doorOpen")),
         trunk_open=_parse_bool(detail.get("trunkOpen")),
         image_size=image_size,
+        image_sizes=image_sizes,
+        valid_angle_of_view=_parse_float_list(detail.get("validAngleofView")),
         # Coordinates are deliberately preserved here (gps=False): the typed
         # fields above already carry them, advanced consumers get the rest.
         raw_metadata=redact_svm_metadata(detail, gps=False),

--- a/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
+++ b/hyundai_kia_connect_api/HyundaiBlueLinkApiUSA.py
@@ -35,6 +35,8 @@ from .svm import (
     SVMDetails,
     _parse_bool,
     _parse_door_open,
+    _parse_float_list,
+    _parse_image_sizes,
     _parse_int,
     redact_svm_metadata,
 )
@@ -146,13 +148,7 @@ def parse_svm_response(response: dict, timezone: dt.timezone) -> SVMDetails:
         except (ValueError, TypeError):
             _LOGGER.debug("Unable to parse SVM capture timestamp: %s", captured_at_raw)
 
-    image_size_raw = detail.get("imageSize")
-    image_size = None
-    if isinstance(image_size_raw, list) and len(image_size_raw) >= 2:
-        width = _parse_int(image_size_raw[0])
-        height = _parse_int(image_size_raw[1])
-        if width is not None and height is not None:
-            image_size = (width, height)
+    image_size, image_sizes = _parse_image_sizes(detail.get("imageSize"))
 
     speed_value = float_or_none(get_child_value(detail, "gpsDetail.speed.value"))
     speed_unit = get_child_value(detail, "gpsDetail.speed.unit")
@@ -172,6 +168,8 @@ def parse_svm_response(response: dict, timezone: dt.timezone) -> SVMDetails:
         door_open=_parse_door_open(detail.get("doorOpen")),
         trunk_open=_parse_bool(detail.get("trunkOpen")),
         image_size=image_size,
+        image_sizes=image_sizes,
+        valid_angle_of_view=_parse_float_list(detail.get("validAngleofView")),
         raw_metadata=raw_metadata,
     )
 

--- a/hyundai_kia_connect_api/svm.py
+++ b/hyundai_kia_connect_api/svm.py
@@ -35,6 +35,53 @@ def _parse_int(value: str | int | None) -> int | None:
         return None
 
 
+def _parse_float(value: str | float | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        return None
+
+
+def _parse_image_sizes(
+    raw: Any,
+) -> tuple[tuple[int, int] | None, tuple[int, ...] | None]:
+    """Parse an SVM ``imageSize`` array.
+
+    Returns ``(image_size, image_sizes)``: ``image_size`` is the first two
+    elements as the ``(width, height)`` panorama size; ``image_sizes`` is
+    the full array — panorama followed by the individual camera segments —
+    and is only returned when every element parses as an integer, since
+    consumers use it to compute segment crop offsets.
+    """
+    if not isinstance(raw, list) or len(raw) < 2:
+        return None, None
+    width = _parse_int(raw[0])
+    height = _parse_int(raw[1])
+    image_size = (width, height) if width is not None and height is not None else None
+    parsed: list[int] = []
+    for value in raw:
+        item = _parse_int(value)
+        if item is None:
+            return image_size, None
+        parsed.append(item)
+    return image_size, tuple(parsed)
+
+
+def _parse_float_list(raw: Any) -> tuple[float, ...] | None:
+    """Parse a float array (e.g. ``validAngleofView``); None if malformed."""
+    if not isinstance(raw, list):
+        return None
+    parsed: list[float] = []
+    for value in raw:
+        item = _parse_float(value)
+        if item is None:
+            return None
+        parsed.append(item)
+    return tuple(parsed)
+
+
 def _parse_door_open(door_open: dict | None) -> dict[str, bool | None] | None:
     """Map an SVM doorOpen object onto the shared door keys.
 
@@ -62,6 +109,12 @@ class SVMDetails:
     door_open: dict[str, bool] | None = None
     trunk_open: bool | None = None
     image_size: tuple[int, int] | None = None
+    # Full imageSize array: panorama size followed by the width of each
+    # camera segment. Consumers use it to crop individual views.
+    image_sizes: tuple[int, ...] | None = None
+    # GSPA responses carry a per-camera field-of-view array; present only
+    # on some regions, None when absent or malformed.
+    valid_angle_of_view: tuple[float, ...] | None = None
     raw_metadata: dict | None = None
 
 

--- a/tests/eu_svm_test.py
+++ b/tests/eu_svm_test.py
@@ -91,6 +91,8 @@ def test_parse_svm_detail_full():
     }
     assert detail.trunk_open is False
     assert detail.image_size == (4472, 720)
+    assert detail.image_sizes == (4472, 720)
+    assert detail.valid_angle_of_view == (1.5, 2.5)
 
 
 def test_parse_svm_detail_raw_metadata_keeps_coords_redacts_image():
@@ -104,7 +106,6 @@ def test_parse_svm_detail_raw_metadata_keeps_coords_redacts_image():
     # Fields without a typed slot on SVMDetails stay reachable here.
     assert raw["installAngle"] == [1.0, 2.0]
     assert raw["boundaryArea"] == [10, 20, 30, 40]
-    assert raw["validAngleofView"] == [1.5, 2.5]
     assert raw["sidemirrorOpen"] is True
 
 
@@ -120,6 +121,8 @@ def test_parse_svm_detail_missing_fields_graceful():
     assert detail.door_open is None
     assert detail.trunk_open is None
     assert detail.image_size is None
+    assert detail.image_sizes is None
+    assert detail.valid_angle_of_view is None
 
 
 def test_parse_svm_detail_malformed_gps_no_crash():

--- a/tests/us_svm_test.py
+++ b/tests/us_svm_test.py
@@ -83,6 +83,8 @@ def test_parse_svm_response_decodes_image_and_metadata():
     }
     assert details.trunk_open is False
     assert details.image_size == (4472, 720)
+    assert details.image_sizes == (4472, 720, 960, 720, 632, 720)
+    assert details.valid_angle_of_view is None
 
 
 def test_parse_svm_response_unknown_timestamp_does_not_crash():
@@ -95,6 +97,38 @@ def test_parse_svm_response_unknown_timestamp_does_not_crash():
     assert details.image_bytes == image
     assert details.captured_at is None
     assert details.captured_at_raw == "not-a-date"
+
+
+def test_parse_svm_response_malformed_image_size_segment():
+    from hyundai_kia_connect_api.HyundaiBlueLinkApiUSA import parse_svm_response
+
+    image = b"\xff\xd8\xff\xe0fakejpg"
+    response = _make_svm_response(image, "2026-06-23T12:34:56Z")
+    response["svmDetails"][0]["svmDetail"]["imageSize"] = [
+        "4472",
+        "720",
+        "960",
+        "bogus",
+    ]
+    details = parse_svm_response(response, dt.UTC)
+
+    assert details.image_size == (4472, 720)
+    assert details.image_sizes is None
+
+
+def test_parse_svm_response_valid_angle_of_view_when_present():
+    from hyundai_kia_connect_api.HyundaiBlueLinkApiUSA import parse_svm_response
+
+    image = b"\xff\xd8\xff\xe0fakejpg"
+    response = _make_svm_response(image, "2026-06-23T12:34:56Z")
+    response["svmDetails"][0]["svmDetail"]["validAngleofView"] = [
+        76.0,
+        59.28,
+        78.0,
+    ]
+    details = parse_svm_response(response, dt.UTC)
+
+    assert details.valid_angle_of_view == (76.0, 59.28, 78.0)
 
 
 def test_redact_svm_response_for_log_strips_image_and_gps():


### PR DESCRIPTION
## Summary

Expose the full SVM `imageSize` array and `validAngleofView` on `SVMDetails`, alongside the existing `image_size` field.

Requires Hyundai-Kia-Connect/kia_uvo#1745 (the consumers that crop individual camera views out of the panorama).

## What's new

- `SVMDetails.image_sizes: tuple[int, ...] | None` — the full `imageSize` array (panorama width/height followed by each camera segment's width); `None` when any element fails to parse, since consumers compute segment crop offsets from it. `image_size` keeps its exact first-two-elements contract for backward compatibility.
- `SVMDetails.valid_angle_of_view: tuple[float, ...] | None` — per-camera field-of-view array from GSPA responses; `None` when absent or malformed.
- New shared helpers `_parse_image_sizes` / `_parse_float_list` in `svm.py`; both the USA (`parse_svm_response`) and EU GSPA (`parse_svm_detail`) parsers populate the new fields.

## Tests

- USA fixture asserts `image_sizes == (4472, 720, 960, 720, 632, 720)`.
- New malformed-segment test: `image_size` stays `(4472, 720)` while `image_sizes` is `None`.
- EU GSPA fixture asserts `image_sizes == (4472, 720)` and `valid_angle_of_view == (1.5, 2.5)`; missing-fields test asserts both `None`.